### PR TITLE
Toast store implementation change

### DIFF
--- a/src/lib/utilities/Toast/Toast.svelte
+++ b/src/lib/utilities/Toast/Toast.svelte
@@ -13,7 +13,8 @@
 	export let max: number = 3;
 	/** The duration of the fly in/out animation. */
 	export let duration: number = 150;
-
+	/** Toast store used for the component, by default the const toastStore is used. */
+	export let store: any = toastStore; // the store is still a global variable, but there is the option to override it. If its overriden it *should* no longer pose a problem, although I'm not sure what the best way to test global server-side variable lifecycle is in sveltekit 
 	// Props (styles)
 	/** Provide classes to set the background color. */
 	export let background: string = 'bg-accent-500';
@@ -62,8 +63,8 @@
 	}
 
 	function onAction(): void {
-		$toastStore[0].action.response();
-		toastStore.close();
+		$store[0].action.response();
+		store.close();
 	}
 
 	// Reactive
@@ -72,12 +73,12 @@
 	$: classesBase = `${cToast} ${background} ${width} ${color} ${padding} ${spacing} ${rounded} ${shadow}`;
 </script>
 
-{#if $toastStore.length}
+{#if $store.length}
 	<!-- Wrapper -->
 	<div class="snackbar-wrapper {classesWrapper}" data-testid="snackbar-wrapper">
 		<!-- List -->
 		<div class="snackbar {classesSnackbar}" transition:fly={{ x: animAxis.x, y: animAxis.y, duration }}>
-			{#each $toastStore as t, i}
+			{#each $store as t, i}
 				{#if i < max + 1}
 					<!-- Toast -->
 					<div class="toast {classesBase} {t.classes}" role="alert" aria-live="polite" data-testid="toast">
@@ -85,7 +86,7 @@
 						<!-- prettier-ignore -->
 						<div class="flex items-center space-x-2">
 							{#if t.action}<button class="btn {buttonAction}" on:click={onAction}>{@html t.action.label}</button>{/if}
-							<button class="btn-icon {buttonDismiss}" on:click={() => { toastStore.close(t.id) }}>✕</button>
+							<button class="btn-icon {buttonDismiss}" on:click={() => { store.close(t.id) }}>✕</button>
 						</div>
 					</div>
 				{/if}


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/Brain-Bones/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Potential "fix" for the problem described in [Fixes #522 ](https://github.com/Brain-Bones/skeleton/issues/522) this shouldn't change the default component behaviour at all. It also allows SvelteKit user to set and manage their own stores, essentially mitigating any shared state concerns. To manage global stores in SvelteKit the best solution is to put them inside component [context](https://svelte.dev/tutorial/context-api) . This PR has a halfway solution, the best one would be to not have const global stores, but that would change how the components work (you'll always have to bind a store), I assume this is not desired behaviour. One caveat with this solution is that there is still a global variable, but by overriding it all should be fine (I'm not exactly sure how to test variable lifecycles in SvelteKit).


### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #522 ](https://github.com/Brain-Bones/skeleton/issues/522)
- Linked issues will auto-close when the PR is merged.
