### PR TITLE
Fix: Added better types for Toast and fixed issue with actions

### DIFF
--- a/src/lib/utilities/Toast/Toast.svelte
+++ b/src/lib/utilities/Toast/Toast.svelte
@@ -61,9 +61,9 @@
 		case ('br'): cPosition = 'justify-end items-end'; cAlign = 'items-end'; animAxis = { x: 100, y: 0 }; break;
 	}
 
-	function onAction(): void {
-		$toastStore[0].action.response();
-		toastStore.close();
+	function onAction(index: number): void {
+		$toastStore[index]?.action?.response();
+		toastStore.close($toastStore[index].id);
 	}
 
 	// Reactive
@@ -84,7 +84,7 @@
 						<div class="text-base">{@html t.message}</div>
 						<!-- prettier-ignore -->
 						<div class="flex items-center space-x-2">
-							{#if t.action}<button class="btn {buttonAction}" on:click={onAction}>{@html t.action.label}</button>{/if}
+							{#if t.action}<button class="btn {buttonAction}" on:click={() => onAction(i)}>{@html t.action.label}</button>{/if}
 							<button class="btn-icon {buttonDismiss}" on:click={() => { toastStore.close(t.id) }}>✕</button>
 						</div>
 					</div>

--- a/src/lib/utilities/Toast/stores.ts
+++ b/src/lib/utilities/Toast/stores.ts
@@ -13,7 +13,6 @@ function randomUUID(): string {
 
 // If toast should auto-hide, wait X time, then close by ID
 function handleAutoHide(toast: ToastSettings): void {
-	console.log(toast);
 	if (toast.autohide === true) {
 		setTimeout(() => {
 			toastStore.close(toast.id);

--- a/src/lib/utilities/Toast/stores.ts
+++ b/src/lib/utilities/Toast/stores.ts
@@ -1,7 +1,7 @@
 // Toast Store Queue
 
 import { writable } from 'svelte/store';
-import type { ToastSettings } from './types';
+import type { ToastSettings, Toast } from './types';
 
 const toastDefaults: ToastSettings = { message: 'Missing Toast Message', autohide: true, timeout: 5000 };
 
@@ -12,7 +12,7 @@ function randomUUID(): string {
 }
 
 // If toast should auto-hide, wait X time, then close by ID
-function handleAutoHide(toast: ToastSettings): void {
+function handleAutoHide(toast: Toast): void {
 	if (toast.autohide === true) {
 		setTimeout(() => {
 			toastStore.close(toast.id);
@@ -20,16 +20,16 @@ function handleAutoHide(toast: ToastSettings): void {
 	}
 }
 
-function toastService(): any {
-	const { subscribe, set, update } = writable([]);
+function toastService() {
+	const { subscribe, set, update } = writable<Toast[]>([]);
 	return {
 		subscribe,
 		/** Add a new toast to the queue. */
 		trigger: (toast: ToastSettings) =>
-			update((tStore: any) => {
+			update((tStore) => {
 				const id: string = randomUUID();
 				// Merge into store
-				let tMerged: ToastSettings = { ...toastDefaults, ...toast, id };
+				const tMerged = { ...toastDefaults, ...toast, id };
 				tStore.push(tMerged);
 				// Handle auto-hide, if needed
 				handleAutoHide(tMerged);
@@ -40,7 +40,7 @@ function toastService(): any {
 		close: (id: string) =>
 			update((tStore) => {
 				if (tStore.length > 0) {
-					var index = tStore.findIndex((t: ToastSettings) => t.id === id);
+					const index = tStore.findIndex((t) => t.id === id);
 					tStore.splice(index, 1);
 				}
 				return tStore;

--- a/src/lib/utilities/Toast/types.ts
+++ b/src/lib/utilities/Toast/types.ts
@@ -16,6 +16,9 @@ export interface ToastSettings {
 	};
 	/** Provide arbitrary CSS classes to style the toast. */
 	classes?: string;
+}
+
+export interface Toast extends ToastSettings {
 	/** A UUID will be auto-assigned on `.trigger()`. */
-	id?: string;
+	id: string;
 }


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/Brain-Bones/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?
- Adds types for the `toastStore`
- Fixes a bug with Toast actions
- Removed a lost `console.log` in the store as well

**Toast actions bug:** if you navigate [here](https://www.skeleton.dev/utilities/toasts) and press on the following buttons in this order, `Paragraph` then `Action`, you will notice that if you try to press the `Greeting` action, the alert won't fire. 
Additionally, if you close all the toasts and press `Action`, then `Paragraph`, followed by pressing the `Greeting` action, you'll see that the alert fires this time. But! When the alert closes, the `Paragraph` toasts closes instead of the `Action` toast!

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
