### PR TITLE
Fixes required for monorepo to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
-		"package": "svelte-kit sync && svelte-package",
+		"package": "node ./scripts/pre-build.js && svelte-kit sync && svelte-package && node ./scripts/post-build.js",
 		"patch-package": "npm version patch && svelte-kit package",
 		"publish": "npm publish ./package",
 		"preview": "vite preview",
@@ -18,9 +18,9 @@
 		"coverage": "vitest run --coverage"
 	},
 	"devDependencies": {
-		"@bobthered/tailwindcss-palette-generator": "^3.1.1",
+		"@bobthered/tailwindcss-palette-generator": "^3.1.0",
 		"@sveltejs/adapter-auto": "^1.0.0-next.89",
-		"@sveltejs/kit": "^1.0.0-next.561",
+		"@sveltejs/kit": "^1.0.0-next.560",
 		"@sveltejs/package": "1.0.0-next.5",
 		"@tailwindcss/forms": "^0.5.3",
 		"@testing-library/dom": "^8.19.0",
@@ -29,6 +29,7 @@
 		"@typescript-eslint/parser": "^5.44.0",
 		"autoprefixer": "^10.4.13",
 		"c8": "^7.12.0",
+		"edit-package-json": "^0.7.12",
 		"eslint": "^8.28.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-svelte3": "^4.0.0",
@@ -51,5 +52,11 @@
 		"vitest": "^0.24.5"
 	},
 	"type": "module",
-	"types": "index.d.ts"
+	"types": "index.d.ts",
+	"exports": {
+		".": "./src/lib/index.ts",
+		"./themes/*": "./src/lib/themes/*",
+		"./styles/*": "./src/lib/styles/*",
+		"./tailwind/*": "./src/lib/tailwind/*"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 		"coverage": "vitest run --coverage"
 	},
 	"devDependencies": {
-		"@bobthered/tailwindcss-palette-generator": "^3.1.0",
+		"@bobthered/tailwindcss-palette-generator": "^3.1.1",
 		"@sveltejs/adapter-auto": "^1.0.0-next.89",
-		"@sveltejs/kit": "^1.0.0-next.560",
+		"@sveltejs/kit": "^1.0.0-next.561",
 		"@sveltejs/package": "1.0.0-next.5",
 		"@tailwindcss/forms": "^0.5.3",
 		"@testing-library/dom": "^8.19.0",

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'fs'
+
+//Put the exports field back into package.json so that monorepos can work again
+let packageJson = readFileSync('package.json').toString()
+packageJson = packageJson.slice(0, packageJson.lastIndexOf('}')-1) //strip closing }
+packageJson +=
+`,
+	"exports": {
+		".": "./src/lib/index.ts",
+		"./themes/*": "./src/lib/themes/*",
+		"./styles/*": "./src/lib/styles/*",
+		"./tailwind/*": "./src/lib/tailwind/*"
+	}
+}`
+
+writeFileSync('package.json', packageJson);
+

--- a/scripts/pre-build.js
+++ b/scripts/pre-build.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { del } from "edit-package-json";
+import { readFileSync, writeFileSync } from 'fs'
+
+//We chop out the exports field of ../package.json rather than manipulate the one in ../package/package.json in case there
+//are changes to the behaviour of 'vite build'.  post-build.js will patch it back in so that monorepos work again.
+writeFileSync('package.json', del(readFileSync('package.json').toString(), 'exports'))

--- a/src/lib/components/Accordion/AccordionItem.svelte
+++ b/src/lib/components/Accordion/AccordionItem.svelte
@@ -10,7 +10,7 @@
 	// DISPATCHED: document directly above the definition, like props (ex: paginator)
 
 	import { getContext } from 'svelte';
-	import SvgIcon from '$lib/components/SvgIcon/SvgIcon.svelte';
+	import SvgIcon from '../SvgIcon/SvgIcon.svelte';
 
 	// Props
 	/** Defines the default open state on page load .*/

--- a/src/lib/components/ConicGradient/ConicGradient.svelte
+++ b/src/lib/components/ConicGradient/ConicGradient.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tailwindDefaultColors } from '$lib/tailwind/colors';
+	import { tailwindDefaultColors } from '../../tailwind/colors';
 	import type { ConicStop } from './types';
 
 	// Props

--- a/src/lib/components/Table/Table.svelte
+++ b/src/lib/components/Table/Table.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
-	import type { TableSource } from '$lib/components/Table/types';
-	import { tableA11y } from '$lib/utilities/DataTable/DataTable';
+	import type { TableSource } from './types';
+	import { tableA11y } from '../../utilities/DataTable/DataTable';
 
 	const dispatch = createEventDispatcher();
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -27,7 +27,7 @@ export {
 	// Svelte Actions
 	tableInteraction,
 	tableA11y
-} from '$lib/utilities/DataTable/DataTable';
+} from './utilities/DataTable/DataTable';
 export { localStorageStore } from './utilities/LocalStorageStore/LocalStorageStore';
 // Component Utilities
 export { tableSourceMapper, tableSourceValues, tableMapperValues } from './components/Table/utils';

--- a/src/lib/utilities/CodeBlock/CodeBlock.svelte
+++ b/src/lib/utilities/CodeBlock/CodeBlock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { storeHighlightJs } from './stores';
-	import { clipboard } from '$lib/actions/Clipboard/clipboard';
+	import { clipboard } from '../../actions/Clipboard/clipboard';
 
 	// Props
 	/** Sets a language alias for Highlight.js syntax highlighting. */

--- a/src/lib/utilities/Drawer/Drawer.svelte
+++ b/src/lib/utilities/Drawer/Drawer.svelte
@@ -2,7 +2,7 @@
 	import { fade, fly } from 'svelte/transition';
 	import { writable, type Writable } from 'svelte/store';
 
-	import { focusTrap } from '$lib/actions/FocusTrap/focusTrap';
+	import { focusTrap } from '../../actions/FocusTrap/focusTrap';
 
 	// Props
 	/** Provide a store to manage visible state.

--- a/src/lib/utilities/LightSwitch/LightSwitch.svelte
+++ b/src/lib/utilities/LightSwitch/LightSwitch.svelte
@@ -3,7 +3,7 @@
 	import { onMount } from 'svelte';
 
 	// Components
-	import SvgIcon from '$lib/components/SvgIcon/SvgIcon.svelte';
+	import SvgIcon from '../../components/SvgIcon/SvgIcon.svelte';
 
 	// Stores
 	import { storePrefersDarkScheme, storeLightSwitch } from './stores';

--- a/src/lib/utilities/LightSwitch/stores.ts
+++ b/src/lib/utilities/LightSwitch/stores.ts
@@ -1,5 +1,5 @@
 import type { Writable } from 'svelte/store';
-import { localStorageStore } from '$lib/utilities/LocalStorageStore/LocalStorageStore';
+import { localStorageStore } from '../LocalStorageStore/LocalStorageStore';
 
 // OS Prefers Dark Scheme - TRUE: dark | FALSE: light
 export const storePrefersDarkScheme: Writable<boolean> = localStorageStore('storePrefersDarkScheme', false);

--- a/src/lib/utilities/LocalStorageStore/LocalStorageStore.test.ts
+++ b/src/lib/utilities/LocalStorageStore/LocalStorageStore.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { get } from 'svelte/store';
 
-import { localStorageStore } from '$lib/utilities/LocalStorageStore/LocalStorageStore';
+import { localStorageStore } from './LocalStorageStore';
 
 describe('LocalStorageStore.ts', () => {
 	it('uses initial value if nothing in local storage', () => {

--- a/src/lib/utilities/Modal/Modal.svelte
+++ b/src/lib/utilities/Modal/Modal.svelte
@@ -2,10 +2,10 @@
 	import { fade, fly } from 'svelte/transition';
 
 	// Actions
-	import { focusTrap } from '$lib/actions/FocusTrap/focusTrap';
+	import { focusTrap } from '../../actions/FocusTrap/focusTrap';
 
 	// Stores
-	import { modalStore } from '$lib/utilities/Modal/stores';
+	import { modalStore } from './stores';
 
 	// Props
 	/** The open/close animation duration. Set '0' (zero) to disable. */


### PR DESCRIPTION
## What does your PR address?

Currently no one can work on both Skeleton and their own project at the same time, unless their current project is the docs site.  This PR finally fixes that.

You can test it by checking out this repo https://github.com/niktek/minimono

For the following steps pnpm is **NOT** optional - pnpm also does **NOT** become a requirement for Skeleton itself, this is a completely separate repo for seeing how it works. Having all 3 package managers installed at the same time causes no problems - the create-skeleton-app testing has confirmed this.  The version of Skeleton in `minimono` is a copy with the changes in this PR already applied.

```
pnpm i
pnpm dev
```

Both Skeleton and Newsite projects are launched on separate ports.

Newsite's package.json shows @skeletonlabs/skeleton as a workspace reference and can therefore import anything as an end dev would from the published package.  NOTE: VSCode will show red squiggles for component imports - it is lying.

Editing anything in Skeleton will now update Newsite's usage of that thing.  e.g. change the default `width` in packages/skeleton/src/lib/components/Avatar/Avatar.svelte and the Avatar on Newsite updates.
Likewise editing the theme css in Skeleton (vintage in this case), flows through to Newsite - this is the main thing that was killing all prior mono repo attempts.

# How does this work?
The missing ingredient is violence. (j/k)

As usual it's a number of things:
## package.json 
During development, SK and Vite shield you from setting up a correct package.json with the appropriate "exports" field.  They "fix" this on build and insert those entries into the package/package.json file.  This is of course useless for other projects that are referring to the dev package.json file.  Unfortunately `svelte-kit package` is respectful of any entries you already have in the dev package.json and copies them over into the package version without adjusting the paths, this results in a broken published package.  To fix this required the addition of two scripts - one to strip the "exports" before `svelte-kit package` and one to re-insert the "exports" after build.

## Aliases
This was the spanner in the works all along.  While it's a great helper for a single project with an internal library, it just totally stuffs things up for multiple projects working together.  The key thing to note here is that each project's Vite server has their own set of aliases, so Newsite's Vite would find a component in Skeleton that used $lib and try to resolve it within it's own filesystem space, where of course it would not find Skeleton's actual components and just fail.  The proper place for package resolution is at the package manager layer, not trying to fake it at Vite's level.

**This requires that everything in Skeleton's src/lib/ folder uses relative path addressing**

Fortunately there were only a few cases where this was in use and this PR fixes the remaining ones.

## Shut up Vite
Vite would often complain about `The request url "blah blah" is outside of Vite serving allow list.`.  Even though it seemed to be working fine, it was annoying to see this spammage on the console.  The additional config in Newsite's `vite.config.ts` turns off those warnings and the onus is on the consuming project to add that.

## What about doc site ?
It remains tightly coupled to Skeleton itself.  On one hand, it's helpful that it remains with Skeleton because any additions to Skeleton need to have documentation created.  On the other hand, it's just going to become harder and harder to separate - mainly due to autocomplete sticking in references to components using the $lib alias, which as outlined above will break docsite when it moves into it's own project.  It also increases the likelihood of affecting the Skeleton package through accidental inclusion of deps/code or a docsite package having a breaking change that prevents publishing.

Once we are happy that this mono repo approach is working how we want, we should break out doc site sooner rather than later.

