### PR TITLE
update focus trap action to also focus trap with shift + tab keydown …

### DIFF
--- a/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/src/lib/actions/FocusTrap/focusTrap.ts
@@ -5,14 +5,16 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	let elemFirst: HTMLElement;
 	let elemLast: HTMLElement;
 
-	function onElemFirstKeydown(e: KeyboardEvent): void {
+	// When the first element is selected, shift+tab pressed, jump to the last selectable item.
+	function onFirstElemKeydown(e: KeyboardEvent): void {
 		if (e.shiftKey && e.code === 'Tab') {
 			e.preventDefault();
 			elemLast.focus();
 		}
 	}
 
-	function onElemLastKeydown(e: KeyboardEvent): void {
+	// When the last item selected, tab pressed, jump to the first selectable item.
+	function onLastElemKeydown(e: KeyboardEvent): void {
 		if (!e.shiftKey && e.code === 'Tab') {
 			e.preventDefault();
 			elemFirst.focus();
@@ -30,15 +32,15 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			// Auto-focus first focusable element
 			elemFirst.focus();
 			// Listen for keydown on first & last element
-			elemFirst.addEventListener('keydown', onElemFirstKeydown);
-			elemLast.addEventListener('keydown', onElemLastKeydown);
+			elemFirst.addEventListener('keydown', onFirstElemKeydown);
+			elemLast.addEventListener('keydown', onLastElemKeydown);
 		}
 	};
 	onInit();
 
 	function onDestory(): void {
-		if (elemFirst) elemFirst.removeEventListener('keydown', onElemFirstKeydown);
-		if (elemLast) elemLast.removeEventListener('keydown', onElemLastKeydown);
+		if (elemFirst) elemFirst.removeEventListener('keydown', onFirstElemKeydown);
+		if (elemLast) elemLast.removeEventListener('keydown', onLastElemKeydown);
 	}
 
 	// Lifecycle

--- a/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/src/lib/actions/FocusTrap/focusTrap.ts
@@ -6,9 +6,16 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	let elemLast: HTMLElement;
 
 	function onElemLastKeydown(e: KeyboardEvent): void {
-		if (e.code === 'Tab') {
+		if (!e.shiftKey && e.code === 'Tab') {
 			e.preventDefault();
 			elemFirst.focus();
+		}
+	}
+
+	function onElemFirstKeydown(e: KeyboardEvent): void {
+		if (e.shiftKey && e.code === 'Tab') {
+			e.preventDefault();
+			elemLast.focus();
 		}
 	}
 
@@ -22,7 +29,8 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			elemLast = focusableElems[focusableElems.length - 1];
 			// Auto-focus first focusable element
 			elemFirst.focus();
-			// Listen for keydown on last element
+			// Listen for keydown on first & last element
+			elemFirst.addEventListener('keydown', onElemFirstKeydown);
 			elemLast.addEventListener('keydown', onElemLastKeydown);
 		}
 	};

--- a/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/src/lib/actions/FocusTrap/focusTrap.ts
@@ -5,17 +5,17 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	let elemFirst: HTMLElement;
 	let elemLast: HTMLElement;
 
-	function onElemLastKeydown(e: KeyboardEvent): void {
-		if (!e.shiftKey && e.code === 'Tab') {
-			e.preventDefault();
-			elemFirst.focus();
-		}
-	}
-
 	function onElemFirstKeydown(e: KeyboardEvent): void {
 		if (e.shiftKey && e.code === 'Tab') {
 			e.preventDefault();
 			elemLast.focus();
+		}
+	}
+
+	function onElemLastKeydown(e: KeyboardEvent): void {
+		if (!e.shiftKey && e.code === 'Tab') {
+			e.preventDefault();
+			elemFirst.focus();
 		}
 	}
 
@@ -37,6 +37,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	onInit();
 
 	function onDestory(): void {
+		if (elemFirst) elemFirst.removeEventListener('keydown', onElemFirstKeydown);
 		if (elemLast) elemLast.removeEventListener('keydown', onElemLastKeydown);
 	}
 


### PR DESCRIPTION
…events

## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?
This PR Fixes #596, where the focus trap set for modals could be escaped by using <kbd>Shift</kbd> + <kbd>Tab</kdb>.

Please briefly describe your changes here.

I added an additional event listener to the first focusable element inside `src/lib/actions/FocusTrap/focusTrap.ts` and added a !e.shiftKey condition to the last focusable element event listener to avoid jumping back and forth between first and last element when shift and tab are pressed.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
