### PR TITLE
Escapes back in. Fixed ts-expect in comments

### DIFF
--- a/src/routes/(inner)/elements/tables/+page.svelte
+++ b/src/routes/(inner)/elements/tables/+page.svelte
@@ -5,7 +5,7 @@
 	// Utilities
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
+	// @ts-expect- error sveld import NOTE: remove the space between hyphen and error - this is to keep svelte-check happy
 	// import sveldComp from '$lib/.../Component.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/guides/frameworks/sveltekit/+page.svelte
+++ b/src/routes/(inner)/guides/frameworks/sveltekit/+page.svelte
@@ -67,13 +67,13 @@
 		<CodeBlock
 			language="html"
 			code={`
-<script>
+\<script\>
 	import '@skeletonlabs/skeleton/themes/theme-skeleton.css';
 	import '@skeletonlabs/skeleton/styles/all.css';
 	import '../app.postcss';
 
 	import { AppShell, AppBar } from '@skeletonlabs/skeleton';
-</script>
+\</script\>
 
 <AppShell>
 	<!-- Header -->
@@ -170,9 +170,9 @@
 		<CodeBlock
 			language="html"
 			code={`
-<script>
+\<script\>
 	import { GradientHeading } from '@skeletonlabs/skeleton';
-</script>
+\</script\>
 
 <GradientHeading tag="h1" direction="bg-gradient-to-br" from="from-primary-500" to="to-accent-500">
 	Homepage

--- a/src/routes/(inner)/guides/frameworks/vite/+page.svelte
+++ b/src/routes/(inner)/guides/frameworks/vite/+page.svelte
@@ -56,9 +56,9 @@
 		<CodeBlock
 			language="html"
 			code={`
-<script>
+\<script\>
 	import { AppShell, AppBar } from '@skeletonlabs/skeleton';
-</script>
+\</script\>
 
 <AppShell>
 	<!-- Header -->
@@ -158,9 +158,9 @@
 		<CodeBlock
 			language="html"
 			code={`
-<script>
+\<script\>
 	import { GradientHeading } from '@skeletonlabs/skeleton';
-</script>
+\</script\>
 
 <GradientHeading tag="h1" direction="bg-gradient-to-br" from="from-primary-500" to="to-accent-500">
 	Homepage

--- a/src/routes/(inner)/template/+page.svelte
+++ b/src/routes/(inner)/template/+page.svelte
@@ -5,7 +5,7 @@
 	// Utilities
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
+	// @ts-expect- error sveld import NOTE remove space between hyphen and error, this is to keep svelte check happy
 	// import sveldComp from '$lib/.../Component.svelte?raw&sveld';
 
 	// Docs Shell


### PR DESCRIPTION
## Before submitting the PR:
Fixes to make svelte-check happy again.
Escaped <script> tag again
Fixed up complaints about @ts-exepect-error in commented out sections of the templates

NOTE: this increases our lint error count