### PR TITLE
Docs: Add `option` class to Menus docs #648

### DIFF
--- a/src/routes/(inner)/utilities/menus/+page.svelte
+++ b/src/routes/(inner)/utilities/menus/+page.svelte
@@ -119,6 +119,11 @@
 				<p>Pair this with Tailwind utility classes to customize the look and feel.</p>
 				<CodeBlock language="html" code={`<div class="card p-2 w-64 shadow-xl" data-menu="example">(menu)</div>`} />
 				<p>Combine <code>.list-nav</code>, and <code>.card</code> Tailwind Element classes to create a navigation menu.</p>
+
+				<p>
+					When <code>.list-nav</code> is applied, links will be styled automatically. To apply the same styles to other elements, such as
+					buttons, use the <code>.option</code> Tailwind Elements class, along with any other desired Tailwind utility classes.
+				</p>
 				<CodeBlock
 					language="html"
 					code={`
@@ -127,6 +132,7 @@
 		<li><a href="/">Home</a></li>
 		<li><a href="/">About</a></li>
 		<li><a href="/">Blog</a></li>
+        <li><button class="option w-full">Logout</button></li>
 	</ul>
 </nav>
 				`}


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
	A test unrelated to a change I made is currently failing. Specifically related to the Drawer utility.
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

Fixes: #648 
Update documentation for *Menus* to include an example of how to mirror styles of `<a>` tags within a menu to a `<button>`.
