### PR TITLE
Add 'ctrl+k' to focus docs search

### DIFF
--- a/src/docs/DocsAppBar/DocsAppBar.svelte
+++ b/src/docs/DocsAppBar/DocsAppBar.svelte
@@ -41,12 +41,20 @@
 	// Keyboard Shortcut (⌘+K) to Focus Search
 	let pressedKeys: string[] = [];
 	function onWindowKeydown(e: any): void {
-		if ($modalStore.length) return;
-		if (e.code === 'MetaLeft' || e.code === 'KeyK') {
+		if (e.code === 'MetaLeft' || e.code === 'ControlLeft' || e.code === 'KeyK') {
+			// Prevent default browser behavior of focusing URL bar
+			e.preventDefault();
 			// Set pressed keys
 			pressedKeys = [...pressedKeys, e.code];
 			// If both keys pressed, focus input
-			if (pressedKeys.includes('MetaLeft') && pressedKeys.includes('KeyK')) search();
+			if ((pressedKeys.includes('MetaLeft') || pressedKeys.includes('ControlLeft')) && pressedKeys.includes('KeyK')) {
+				// If modal currently open, close modal (allows to open/close search with CTRL/⌘+K)
+				if ($modalStore.length) {
+					modalStore.close();
+				} else {
+					search();
+				}
+			}
 		}
 	}
 	function onWindowKeyup(): void {


### PR DESCRIPTION
## Before submitting the PR:
- [X] Does your PR reference an issue?
- [X] Did you update and run tests before submission using `npm run test`?
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? 
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?
Allows users to use CTRL+K to search the docs.

Prevents default browser behavior of focusing the Address bar in certain browsers. CTRL/CMD+K can also be used to close the modal (something else common across other doc sites).

Fixes: #668 
