### PR TITLE
Update keydown function that opens the search field

### DIFF
--- a/src/docs/DocsAppBar/DocsAppBar.svelte
+++ b/src/docs/DocsAppBar/DocsAppBar.svelte
@@ -49,29 +49,19 @@
 		modalStore.trigger(d);
 	}
 
-	// Keyboard Shortcut (⌘+K) to Focus Search
-	let pressedKeys: string[] = [];
-	function onWindowKeydown(e: any): void {
-		const commandKeys = ['MetaLeft', 'MetaRight', 'ControlLeft', 'ControlRight'];
-		if (commandKeys.includes(e.code) || e.code === 'KeyK') {
+	// Keyboard Shortcut (CTRL/⌘+K) to Focus Search
+	function onWindowKeydown(e: KeyboardEvent): void {
+		if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
 			// Prevent default browser behavior of focusing URL bar
 			e.preventDefault();
-			// Set pressed keys
-			pressedKeys = [...pressedKeys, e.code];
-			// If both keys pressed, focus input
-			if (pressedKeys.some((key) => commandKeys.includes(key)) && pressedKeys.includes('KeyK')) {
-				// If modal currently open, close modal (allows to open/close search with CTRL/⌘+K)
-				$modalStore.length ? modalStore.close() : triggerSearch();
-			}
+			// If modal currently open, close modal (allows to open/close search with CTRL/⌘+K)
+			$modalStore.length ? modalStore.close() : triggerSearch();
 		}
-	}
-	function onWindowKeyup(): void {
-		pressedKeys = [];
 	}
 </script>
 
 <!-- NOTE: using stopPropagation to override Chrome for Windows search shortcut -->
-<svelte:window on:keydown|stopPropagation={onWindowKeydown} on:keyup={onWindowKeyup} />
+<svelte:window on:keydown|stopPropagation={onWindowKeydown} />
 
 <AppBar>
 	<!-- Branding -->


### PR DESCRIPTION
…Default is only applied when command keys are also pressed at the same time

## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [X] Did you update and run tests before submission using `npm run test`?
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

This issue was mentioned in Discord. When opening the search bar, it wasn't possible to type "k" into the search field since the keydown function was preventing defaults of it.

I updated the keydown function to use `&&` instead of `||` and also changed `e.code === 'KeyK` to `e.key === 'k'`, since <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>k</kbd> is a shortcut in Firefox to open the web console, but this was prevented here. On the SvelteKit site <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>k</kbd> also doesn't open the search field: https://kit.svelte.dev/, so perhaps they are doing it this way as well?

I don't have Mac so I can't check if these changes also work on there, so I'll create it as a draft PR for now.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
