### PR TITLE
Fix bug where menu wouldn't open on the first click after a page reload

### DIFF
--- a/src/lib/utilities/Menu/menu.ts
+++ b/src/lib/utilities/Menu/menu.ts
@@ -57,9 +57,9 @@ export function menu(node: HTMLElement, args: ArgsMenu) {
 	
 	// Click Handlers ---
 
-	const onTriggerClick = (): void => {
+	const toggleMenu = (): void => {
 		// When the node is clicked, open the menu if it is closed, otherwise close it
-		if (elemMenu.style.display === 'none') {
+		if (elemMenu.style.display != 'block') {
 			autoUpdateOrigin();
 			menuOpen();
 		} else {
@@ -73,16 +73,18 @@ export function menu(node: HTMLElement, args: ArgsMenu) {
 	
 	// Interactive FALSE - any click closes the menu
 	const standardClickHandler = (event: any): void => {
-		// Any click closes the menu, except for when the node is clicked, since onTriggerClick() will take care of closing it in this case. If we don't include this check this function would close the menu when the node is clicked and onTriggerClick reopens it again because display will be 'none' again.
+		// Any click outside the node closes the menu, but a click inside the node toggles the menu.
 		const outsideNode = node && !node.contains(event.target);
 		if (outsideNode) { menuClose(); }
+		else { toggleMenu(); }
 	}
 	
 	// Interactive TRUE - clicks outside close menu
 	const interactiveClickHandler = (event: any): void => {
 		const outsideNode = node && !node.contains(event.target);
 		const outsideMenu = elemMenu && !elemMenu.contains(event.target);
-		if (outsideNode && outsideMenu) { menuClose(); }
+		if (!outsideNode) { toggleMenu(); }
+		else if (outsideNode && outsideMenu) { menuClose(); }
 	}
 
 	// Menu - Set auto origin ---
@@ -109,7 +111,7 @@ export function menu(node: HTMLElement, args: ArgsMenu) {
 			event.preventDefault();
 
 			// Toggle menu
-			onTriggerClick();
+			toggleMenu();
 		}
 	}
 
@@ -152,7 +154,6 @@ export function menu(node: HTMLElement, args: ArgsMenu) {
 	window.addEventListener('click', onWindowClick, true);
 	window.addEventListener('keydown', onWindowKeyDown, true);
 	// Trigger Node Events
-	node.addEventListener('click', onTriggerClick);
 	node.addEventListener('keydown', onTriggerKeyDown);
 	node.addEventListener('change', (e: any) => {
 		console.log(e);
@@ -165,7 +166,6 @@ export function menu(node: HTMLElement, args: ArgsMenu) {
             window.removeEventListener('resize', onWindowClick, true);
 			window.removeEventListener('click', onWindowClick, true);
 			window.removeEventListener('keydown', onWindowKeyDown, true);
-			node.removeEventListener('click', onTriggerClick);
 			node.removeEventListener('keydown', onTriggerKeyDown);
 		}
 	}


### PR DESCRIPTION
…ad and remove node click event listener so that window click event listener takes care of click events

## Before submitting the PR:
- [X] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [X] Did you update and run tests before submission using `npm run test`?
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

This would Close #685, where the menu wouldn't open on the first click after a page reload.

Please briefly describe your changes here.

The problem was because `onToggleClick` was checking if the `elemMenu.style.display === 'none'` but this only gets set when the menu is closed, so when a click is made anywhere on the page but the menu button. I changed the if statement to fix this.

I also made another update and removed the node click event listener, since we already have a window click event listener, and having both of them was a bit confusing.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
