### PR TITLE
Fix `DataTable` sorting with BigInts

### DIFF
--- a/src/lib/utilities/DataTable/DataTable.ts
+++ b/src/lib/utilities/DataTable/DataTable.ts
@@ -118,7 +118,9 @@ function sortOrder<T extends Record<PropertyKey, unknown>>(order: string, store:
 		if (typeof x[key] === 'string' && typeof y[key] === 'string') {
 			return String(x[key]).localeCompare(String(y[key]));
 		} else {
-			return (x[key] as number) - (y[key] as number);
+			const a = x[key] as number;
+			const b = y[key] as number;
+			return (a < b) ? -1 : ((a > b) ? 1 : 0)
 		}
 	});
 }


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

The `DataTable` sorting is broken when the data contains `BigInt` values. This is because `Array.sort` doesn't support returning `BigInt`'s, and errors with:
> Cannot convert a BigInt value to a number

A simple fix for this is to return -1, 0, or 1 from the sort function, which is what this PR implements.

<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#comparisons>

Note I didn't run any tests for this and simply made the change in Github.
