### PR TITLE
feat: Extends the ProgressBar to potentially be also used as a meter.

### DIFF
--- a/src/lib/components/ProgressBar/ProgressBar.svelte
+++ b/src/lib/components/ProgressBar/ProgressBar.svelte
@@ -7,6 +7,8 @@
 	 * @type {number}
 	 */
 	export let value: number | undefined = undefined;
+	/** Minimum amount the bar represents. */
+	export let min = 0;
 	/** Maximum amount the bar represents. */
 	export let max = 100;
 	/** Provide classes to set track height. */
@@ -28,7 +30,7 @@
 	const cBaseMeterIndeterminate = 'h-full w-full';
 
 	// Fill Percent
-	$: fillPercent = value ? (100 * value) / max : 0;
+	$: fillPercent = value ? (100 * (value - min)) / (max - min) : 0;
 
 	// Reactive Classes
 	$: classesTrack = `${cBaseTrack} ${height} ${rounded} ${track} ${$$props.class ?? ''}`;
@@ -41,8 +43,8 @@
 	role="progressbar"
 	aria-label={label}
 	aria-valuenow={value}
-	aria-valuemin={0}
-	aria-valuemax={max}
+	aria-valuemin={min}
+	aria-valuemax={max - min}
 >
 	<!-- Label -->
 	{#if label}<label for="progress" class="progress-bar-label {cBaseLabel}">{label}</label>{/if}

--- a/src/lib/components/ProgressBar/ProgressBar.test.ts
+++ b/src/lib/components/ProgressBar/ProgressBar.test.ts
@@ -13,6 +13,7 @@ describe('ProgressBar.svelte', () => {
 		const { getByTestId } = render(ProgressBar, {
 			props: {
 				label: 'Test',
+				min: 10,
 				value: 50,
 				max: 100,
 				height: 'h-1',


### PR DESCRIPTION
The ProgressBar can now have a minimum and maximum value - not necessarily starting at 0. The value can be set to a value between the minimum and maximum value. The progress bar will then be filled up to the percentage of the value between the minimum and maximum value.

## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ X] Did you update and run tests before submission using `npm run test`?
- [ X ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ X ] Did you update documentation related to your new feature or changes? <<< Happened automatically 🤯

## What does your PR address?

This extends the progress bar with a new property `min` so that it does not have to start at 0 necessarily. 