### PR TITLE
Logistical Fix in Avatars

### DIFF
--- a/src/routes/(inner)/components/avatars/+page.svelte
+++ b/src/routes/(inner)/components/avatars/+page.svelte
@@ -113,8 +113,8 @@
 						<span>Rounded</span>
 						<RadioGroup selected={storeRounded} display="flex">
 							<RadioItem value="rounded-full">Full</RadioItem>
-							<RadioItem value="rounded-xl">XL</RadioItem>
 							<RadioItem value="rounded-3xl">3XL</RadioItem>
+							<RadioItem value="rounded-xl">XL</RadioItem>
 							<RadioItem value="rounded-none">None</RadioItem>
 						</RadioGroup>
 					</label>


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

On the Avatar documentation page (https://www.skeleton.dev/components/avatars), the rounded sizes were in this order: full, xl, 3xl, none. I found this counterintuitive, as it would make more sense to place them in descending order as follows: full, 3xl, xl, none. That is essentially all this pull request addresses. 


