### PR TITLE
Add styling to active / visible elements in the Table of Contents

### DIFF
--- a/src/docs/DocsShell/DocsShell.svelte
+++ b/src/docs/DocsShell/DocsShell.svelte
@@ -254,12 +254,7 @@
 					</div>
 					<!-- Table of Contents -->
 					<div>
-						<TableOfContents
-							target="#toc-target"
-							minimumHeadings={1}
-							class="sticky top-10 hidden 2xl:inline-block ml-4"
-							activeText="bg-primary-active-token"
-						/>
+						<TableOfContents target="#toc-target" minimumHeadings={1} class="sticky top-10 hidden 2xl:inline-block ml-4" />
 					</div>
 				</div>
 			</div>

--- a/src/docs/DocsShell/DocsShell.svelte
+++ b/src/docs/DocsShell/DocsShell.svelte
@@ -254,7 +254,12 @@
 					</div>
 					<!-- Table of Contents -->
 					<div>
-						<TableOfContents target="#toc-target" minimumHeadings={1} class="sticky top-10 hidden 2xl:inline-block ml-4" />
+						<TableOfContents
+							target="#toc-target"
+							minimumHeadings={1}
+							class="sticky top-10 hidden 2xl:inline-block ml-4"
+							activeText="font-bold bg-tertiary-backdrop-token border-l-2 border-tertiary-400-500-token !rounded-none"
+						/>
 					</div>
 				</div>
 			</div>

--- a/src/docs/DocsShell/DocsShell.svelte
+++ b/src/docs/DocsShell/DocsShell.svelte
@@ -258,7 +258,7 @@
 							target="#toc-target"
 							minimumHeadings={1}
 							class="sticky top-10 hidden 2xl:inline-block ml-4"
-							activeText="font-bold bg-tertiary-backdrop-token border-l-2 border-tertiary-400-500-token !rounded-none"
+							activeText="bg-primary-active-token"
 						/>
 					</div>
 				</div>

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -16,12 +16,16 @@
 	export let spacing: string = 'space-y-4';
 	/** Set the row text color styles. */
 	export let text: string = 'text-surface-600-300-token';
-	/** Set the active text styles. */
-	export let activeText: string = 'font-bold';
 	/** Set the row hover styles. */
 	export let hover: string = 'hover:bg-primary-hover-token';
 	/** Set the row border radius styles. */
 	export let rounded: string = 'rounded-token';
+	/** Set the active text styles. */
+	export let activeText: string = 'font-bold';
+	/** Highlight all headings with content visible in the viewport instead of just the top active heading. */
+	export let highlightAllActive: boolean = false;
+	/** Highlight parent headings along with the current active heading(s). */
+	export let highlightParentHeadings: boolean = true;
 
 	// Props Regions
 	/** Provide arbitrary styles for the label element. */
@@ -119,16 +123,16 @@
 					// Only add the observed element to the activeIndexes list if it isn't added yet.
 					if (activeIndexes.findIndex((item) => item.elementIndex === obsIndex.elementIndex) === -1) {
 						activeIndexes = [...activeIndexes, obsIndex];
-						activeParents = [...activeParents, ...headingsParents[obsIndex.tocIndex]];
+						// activeParents = [...activeParents, ...headingsParents[obsIndex.tocIndex]];
 					}
 				} else {
 					// Remove the observed element from the activeIndexes list if the intersection ratio is below the threshold.
 					activeIndexes = activeIndexes.filter((item) => item.elementIndex !== obsIndex.elementIndex);
 					// Remove all parents of obsIndex from the activeParents list.
-					headingsParents[obsIndex.tocIndex].forEach((parent: number) => {
-						const index = activeParents.indexOf(parent);
-						activeParents.splice(index, 1);
-					});
+					// headingsParents[obsIndex.tocIndex].forEach((parent: number) => {
+					// 	const index = activeParents.indexOf(parent);
+					// 	activeParents.splice(index, 1);
+					// });
 				}
 			},
 			{ root: null, threshold: observerThreshold }
@@ -170,12 +174,25 @@
 	$: classesLabel = `${cLabel} ${regionLabel}`;
 	$: classesList = `${regionList}`;
 	$: classesListItem = `${cListItem} ${text} ${hover} ${rounded}`;
+	$: activeHeading = Math.min(...activeIndexes.map((item) => item.tocIndex));
 	$: setActiveClasses = (index: number): string => {
-		if (activeParents.includes(index) || activeIndexes.some((item) => item.tocIndex === index)) {
+		// if (highlightParents && activeParents.includes(index)) {
+		if (highlightParentHeadings && headingsParents[activeHeading]?.includes(index)) {
 			return activeText;
-		} else {
-			return '';
 		}
+		if (highlightAllActive && activeIndexes.some((item) => item.tocIndex === index)) {
+			return activeText;
+		}
+		if (index === activeHeading) {
+			return activeText;
+		}
+
+		return '';
+		// if (activeParents.includes(index) || activeIndexes.some((item) => item.tocIndex === index)) {
+		// 	return activeText;
+		// } else {
+		// 	return '';
+		// }
 	};
 </script>
 

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -116,39 +116,38 @@
 		});
 	}
 
+	function observerCallback(entries: IntersectionObserverEntry[]) {
+		for (let i = 0; i < entries.length; i++) {
+			const elementIndex = elementsList.indexOf(<HTMLElement>entries[i].target);
+			const tocIndex = elementToHeading[elementIndex];
+
+			if (entries[i].intersectionRatio >= observerThreshold) {
+				// Only add the observed element to the activeIndexes list if it isn't added yet.
+				if (activeIndexes.indexOf(elementIndex) === -1) {
+					activeIndexes = [...activeIndexes, elementIndex];
+					if (headingsParents[tocIndex]) {
+						activeParents = [...activeParents, ...headingsParents[tocIndex]];
+					}
+				}
+			} else {
+				// Remove the observed element from the activeIndexes list if the intersection ratio is below the threshold.
+				activeIndexes = activeIndexes.filter((item) => item !== elementIndex);
+
+				// Remove all parents of obsIndex from the activeParents list.
+				if (headingsParents[tocIndex]) {
+					headingsParents[tocIndex]?.forEach((parent: number) => {
+						const index = activeParents.indexOf(parent);
+						activeParents.splice(index, 1);
+					});
+				}
+			}
+		}
+	}
+
 	function observeElement(e: HTMLElement) {
 		if (!observer) {
 			// Create one observer, that observes all elements.
-			observer = new IntersectionObserver(
-				(entries) => {
-					for (let i = 0; i < entries.length; i++) {
-						const elementIndex = elementsList.indexOf(<HTMLElement>entries[i].target);
-						const tocIndex = elementToHeading[elementIndex];
-
-						if (entries[i].intersectionRatio >= observerThreshold) {
-							// Only add the observed element to the activeIndexes list if it isn't added yet.
-							if (activeIndexes.indexOf(elementIndex) === -1) {
-								activeIndexes = [...activeIndexes, elementIndex];
-								if (headingsParents[tocIndex]) {
-									activeParents = [...activeParents, ...headingsParents[tocIndex]];
-								}
-							}
-						} else {
-							// Remove the observed element from the activeIndexes list if the intersection ratio is below the threshold.
-							activeIndexes = activeIndexes.filter((item) => item !== elementIndex);
-
-							// Remove all parents of obsIndex from the activeParents list.
-							if (headingsParents[tocIndex]) {
-								headingsParents[tocIndex]?.forEach((parent: number) => {
-									const index = activeParents.indexOf(parent);
-									activeParents.splice(index, 1);
-								});
-							}
-						}
-					}
-				},
-				{ root: null, threshold: observerThreshold }
-			);
+			observer = new IntersectionObserver(observerCallback, { root: null, threshold: observerThreshold });
 		}
 
 		observer.observe(e);

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -119,6 +119,8 @@
 	function observeElement(e: HTMLElement, obsIndex: ObserverIndex) {
 		observer = new IntersectionObserver(
 			(entries) => {
+				// console.log(entries);
+				// console.log(allElements.indexOf(entries[0].target));
 				if (entries[0].intersectionRatio >= observerThreshold) {
 					// Only add the observed element to the activeIndexes list if it isn't added yet.
 					if (activeIndexes.findIndex((item) => item.elementIndex === obsIndex.elementIndex) === -1) {

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -17,7 +17,7 @@
 	/** Set the row text color styles. */
 	export let text: string = 'text-surface-600-300-token';
 	/** Set the active text styles. */
-	export let activeText: string = 'font-bold bg-tertiary-backdrop-token border-l-2 !rounded-none';
+	export let activeText: string = 'font-bold';
 	/** Set the row hover styles. */
 	export let hover: string = 'hover:bg-primary-hover-token';
 	/** Set the row border radius styles. */
@@ -46,7 +46,7 @@
 	let activeParents: number[] = [];
 	let observer: IntersectionObserver;
 	let activeIndexes: ObserverIndex[] = [];
-	let observerThreshold: number = 0.1;
+	let observerThreshold: number = 0.25;
 
 	function generateHeadingList(): void {
 		const elemTarget = document.querySelector(target);

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -193,7 +193,7 @@
 
 	// Find active heading by looking at the lowest active index.
 	$: activeHeading = Math.min(...activeIndexes.map((item) => elementToHeading[item]));
-	$: setActiveClasses = (index: number): string => {
+	$: setTextClasses = (index: number): string => {
 		if (
 			highlightParentHeadings &&
 			(headingsParents[activeHeading]?.includes(index) || (highlightAllActive && activeParents.includes(index)))
@@ -219,7 +219,7 @@
 		{#each headingsList as headingElem, i}
 			<!-- prettier-ignore -->
 			<li
-				class="toc-list-item {classesListItem} {setHeadingClasses(headingElem)} {setActiveClasses(i)}"
+				class="toc-list-item {classesListItem} {setHeadingClasses(headingElem)} {setTextClasses(i)}"
 				on:click={() => { scrollToHeading(headingElem, i); }}
 				on:click
 				on:keypress

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -25,7 +25,7 @@
 	/** Highlight all headings with content visible in the viewport instead of just the top active heading. */
 	export let highlightAllActive: boolean = false;
 	/** Highlight parent headings along with the current active heading(s). */
-	export let highlightParentHeadings: boolean = true;
+	export let highlightParentHeadings: boolean = false;
 
 	// Props Regions
 	/** Provide arbitrary styles for the label element. */

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -47,7 +47,6 @@
 	let allElements: HTMLElement[] = [];
 	let headingsList: HTMLElement[] = [];
 	let headingsParents: any = {};
-	let activeParents: number[] = [];
 	let observer: IntersectionObserver;
 	let activeIndexes: ObserverIndex[] = [];
 	let observerThreshold: number = 0.25;
@@ -123,16 +122,10 @@
 					// Only add the observed element to the activeIndexes list if it isn't added yet.
 					if (activeIndexes.findIndex((item) => item.elementIndex === obsIndex.elementIndex) === -1) {
 						activeIndexes = [...activeIndexes, obsIndex];
-						// activeParents = [...activeParents, ...headingsParents[obsIndex.tocIndex]];
 					}
 				} else {
 					// Remove the observed element from the activeIndexes list if the intersection ratio is below the threshold.
 					activeIndexes = activeIndexes.filter((item) => item.elementIndex !== obsIndex.elementIndex);
-					// Remove all parents of obsIndex from the activeParents list.
-					// headingsParents[obsIndex.tocIndex].forEach((parent: number) => {
-					// 	const index = activeParents.indexOf(parent);
-					// 	activeParents.splice(index, 1);
-					// });
 				}
 			},
 			{ root: null, threshold: observerThreshold }
@@ -174,9 +167,10 @@
 	$: classesLabel = `${cLabel} ${regionLabel}`;
 	$: classesList = `${regionList}`;
 	$: classesListItem = `${cListItem} ${text} ${hover} ${rounded}`;
+
+	// Find active heading by looking at the lowest active index.
 	$: activeHeading = Math.min(...activeIndexes.map((item) => item.tocIndex));
 	$: setActiveClasses = (index: number): string => {
-		// if (highlightParents && activeParents.includes(index)) {
 		if (highlightParentHeadings && headingsParents[activeHeading]?.includes(index)) {
 			return activeText;
 		}
@@ -188,11 +182,6 @@
 		}
 
 		return '';
-		// if (activeParents.includes(index) || activeIndexes.some((item) => item.tocIndex === index)) {
-		// 	return activeText;
-		// } else {
-		// 	return '';
-		// }
 	};
 </script>
 

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -78,18 +78,13 @@
 
 	function observeElement(e: HTMLElement, headingIndex: number) {
 		observer = new IntersectionObserver((entries) => {
-			// if (entries[0].isIntersecting) {
-			if (entries[0].intersectionRatio > 0) {
+			if (entries[0].isIntersecting) {
+				// if (entries[0].intersectionRatio > 0) {
 				if (activeIndexes.indexOf(headingIndex) === -1) {
 					activeIndexes = [...activeIndexes, headingIndex];
 				}
-			} else if (entries[0].intersectionRatio <= 0) {
-				console.log('activeIndexes:', activeIndexes, 'smaller', headingIndex);
+			} else {
 				activeIndexes = activeIndexes.filter((v) => v != headingIndex);
-				// const index = activeIndexes.indexOf(headingIndex);
-				// if (index !== -1) {
-				// 	activeIndexes = activeIndexes.slice(index);
-				// }
 			}
 		});
 

--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -43,7 +43,7 @@
 	let elementToHeading: any = {};
 	let headingsParents: any = {};
 	let activeParents: number[] = [];
-	let observer: IntersectionObserver;
+	let observer: IntersectionObserver | null = null;
 	let activeIndexes: number[] = [];
 	let observerThreshold: number = 0.25;
 
@@ -189,7 +189,7 @@
 	$: classesBase = `${width} ${spacing} ${$$props.class ?? ''}`;
 	$: classesLabel = `${cLabel} ${regionLabel}`;
 	$: classesList = `${regionList}`;
-	$: classesListItem = `${cListItem} ${text} ${hover} ${rounded}`;
+	$: classesListItem = `${cListItem} ${hover} ${rounded}`;
 
 	// Find active heading by looking at the lowest active index.
 	$: activeHeading = Math.min(...activeIndexes.map((item) => elementToHeading[item]));
@@ -207,7 +207,7 @@
 			return activeText;
 		}
 
-		return '';
+		return text;
 	};
 </script>
 


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [X] Did you update documentation related to your new feature or changes?

## What does your PR address?

Please briefly describe your changes here.

Related to #357.

- Table of contents now can highlight active headings, so headings which have content visible in the viewport.
- Parent headings of a heading are also highlighted.
- Updated the Table of Contents active styling in the documentation (the default is just `font-bold` for the component).
