### PR TITLE
A prop to disable Tooltip + fixed a rare no trigger Tooltip bug

### DIFF
--- a/src/lib/utilities/Tooltip/tooltip.ts
+++ b/src/lib/utilities/Tooltip/tooltip.ts
@@ -7,6 +7,8 @@ export interface ArgsTooltip {
 	position?: string;
 	/** Sets the wrapping element to be either inline or block */
 	inline?: boolean;
+	/** Conditionally prevent the tooltip from appearing. */
+	disabled?: boolean;
 	/** Provide an optional callback function to handle open/close state changes. */
 	state?: (e: { trigger: HTMLElement; state: boolean }) => void;
 
@@ -62,7 +64,7 @@ export function tooltip(node: HTMLElement, args: ArgsTooltip) {
 	// prettier-ignore
 	const createElemTooltip = (): void => {
 		elemTooltip = document.createElement('div');
-		elemTooltip.classList.add('tooltip', `tooltip-${position}`, 'hidden', regionTooltip);
+		elemTooltip.classList.add('tooltip', `tooltip-${position}`, 'hidden', regionTooltip, 'pointer-events-none');
 		if (args.background) { elemTooltip.classList.add(args.background); }
 		if (args.color) elemTooltip.classList.add(args.color);
 		if (args.width) elemTooltip.classList.add(args.width);
@@ -90,6 +92,7 @@ export function tooltip(node: HTMLElement, args: ArgsTooltip) {
 
 	// On mouse over - show the tooltip
 	const onMouseEnter = (): void => {
+		if (args.disabled) return;
 		elemTooltip.classList.remove('hidden');
 		setTimeout(() => {
 			elemTooltip.classList.add('!opacity-100');
@@ -126,6 +129,7 @@ export function tooltip(node: HTMLElement, args: ArgsTooltip) {
 	// Lifecycle
 	return {
 		update(newArgs: ArgsTooltip) {
+			if (newArgs.disabled) onMouseLeave();
 			args = newArgs;
 		},
 		destroy() {

--- a/src/routes/(inner)/utilities/tooltips/+page.svelte
+++ b/src/routes/(inner)/utilities/tooltips/+page.svelte
@@ -20,6 +20,7 @@
 			['<code>position</code>', 'string', 'top', 'top | bottom | left | right', 'Designates where the tooltip will appear.'],
 			['<code>inline</code>', 'boolean', 'false', 'true | false', 'Sets the wrapping element to inline or block.'],
 			['<code>state</code>', 'function', '-', 'function', 'Provide a callback function for detecting tooltip open/closed state.'],
+			['<code>disabled</code>', 'boolean', 'false', 'true | false', 'Conditionally prevent the tooltip from appearing.'],
 			['<code>background</code>', 'string', '-', 'class', 'Provide a class to set the background color.'],
 			['<code>color</code>', 'string', '-', 'class', 'Provide a class to set the text color.'],
 			['<code>width</code>', 'string', '-', 'class', 'Provide a class to set the width.'],
@@ -147,6 +148,14 @@ function stateHandler(response: { trigger: HTMLElement; state: boolean }): void 
 					the <code>data-tooltip</code> attribute via dataset, while state will be a boolean value representing <em>TRUE</em> for open and
 					<em>FALSE</em> for closed.
 				</p>
+			</div>
+			<div class="space-y-4">
+				<h2>Disable Tooltip</h2>
+				<p>
+					Set <code>disabled: true</code> to prevent the tooltip from showing. This is useful for conditionally enabling the tooltip action on
+					elements.
+				</p>
+				<CodeBlock language="html" code={`<button use:tooltip={{ content: 'Skeleton', disabled: true }}>Disabled Trigger</button>`} />
 			</div>
 		</section>
 	</svelte:fragment>


### PR DESCRIPTION
## Before submitting the PR:
- [x] **(Confirmed on discord)** Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?
- It used to be clunky to remove the whole Tooltip action from an element to conditionally disable the Tooltip, so it's a prop now.
- There was a bug where a hidden Tooltip may overlap the trigger element and prevent onMouseEnter from firing. 

If "disabled", the Tooltip hides immediately and doesn't reappear until "disabled" is false.  

- Added a "disabled: bool" prop to conveniently control disabling the onMouseEnter event handling to prevent showing the Tooltip.
- Added "pointer-events-none" as a base class to the Tooltip element.

## The patched bug
Here's a picture of what this edge case looks like. The Tooltip would intercept onMouseEnter when entering the trigger from above, so pointer events were disabled for the Tooltip.
<img width="220" alt="Screenshot 2023-01-06 at 12 53 50 AM" src="https://user-images.githubusercontent.com/74473253/210940666-cbbf25b0-9c40-4009-ac64-4ebe2d42d41c.png">

