### PR TITLE
Improve positioning of sort indicator

### DIFF
--- a/src/lib/styles/elements/tables.css
+++ b/src/lib/styles/elements/tables.css
@@ -32,11 +32,11 @@
 	}
 
 	.table-sort-asc {
-		@apply after:opacity-50 after:ml-2 after:!content-['↓'];
+		@apply after:opacity-50 after:absolute after:ml-2 after:!content-['↓'];
 	}
 
 	.table-sort-dsc {
-		@apply after:opacity-50 after:ml-2 after:!content-['↑'];
+		@apply after:opacity-50 after:absolute after:ml-2 after:!content-['↑'];
 	}
 
 	/* === Table Head === */


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

When the sort header of a Data Table is clicked the columns shift because of the addition/removal of the `table-sort-asc` or `table-sort-dsc` class. Adding position absolute prevents the class change affecting column width.
