### PR TITLE
Feat: Separate intellisense into it's own plugin

### DIFF
--- a/scripts/generate-jss.js
+++ b/scripts/generate-jss.js
@@ -2,12 +2,14 @@
 import { generateAllTWClasses, transpileCssToJs } from './compile-css-to-js.cjs';
 import { mkdir, writeFile, rename, unlink } from 'fs/promises';
 
+const ALL_COMPONENTS_FILE_NAME = 'all-components.cjs';
+
 exec();
 
 async function exec() {
 	// Deletes the previously generated CSS-in-JS file. If we don't, our plugin will
 	// add duplicate classes to our newly generated CSS-in-JS file.
-	await unlink('src/lib/tailwind/generated/allComponents.cjs').catch(() => {
+	await unlink(`src/lib/tailwind/generated/${ALL_COMPONENTS_FILE_NAME}`).catch(() => {
 		// file doesn't exist, don't worry about it
 	});
 
@@ -25,7 +27,7 @@ async function exec() {
 	const purgedJSS = await removeDuplicateClasses(generatedJSS);
 
 	// Creates the generated CSS-in-JS file
-	await writeFile('src/lib/tailwind/generated/allComponents.cjs', `module.exports = ${JSON.stringify(purgedJSS)}`).catch((e) =>
+	await writeFile(`src/lib/tailwind/generated/${ALL_COMPONENTS_FILE_NAME}`, `module.exports = ${JSON.stringify(purgedJSS)}`).catch((e) =>
 		console.error(e)
 	);
 

--- a/scripts/generate-jss.js
+++ b/scripts/generate-jss.js
@@ -2,7 +2,7 @@
 import { generateAllTWClasses, transpileCssToJs } from './compile-css-to-js.cjs';
 import { mkdir, writeFile, rename, unlink } from 'fs/promises';
 
-const ALL_COMPONENTS_FILE_NAME = 'all-components.cjs';
+const ALL_COMPONENTS_FILE_NAME = 'intellisense-classes.cjs';
 
 exec();
 

--- a/scripts/generate-jss.js
+++ b/scripts/generate-jss.js
@@ -2,14 +2,14 @@
 import { generateAllTWClasses, transpileCssToJs } from './compile-css-to-js.cjs';
 import { mkdir, writeFile, rename, unlink } from 'fs/promises';
 
-const ALL_COMPONENTS_FILE_NAME = 'intellisense-classes.cjs';
+const INTELLISENSE_FILE_NAME = 'intellisense-classes.cjs';
 
 exec();
 
 async function exec() {
 	// Deletes the previously generated CSS-in-JS file. If we don't, our plugin will
 	// add duplicate classes to our newly generated CSS-in-JS file.
-	await unlink(`src/lib/tailwind/generated/${ALL_COMPONENTS_FILE_NAME}`).catch(() => {
+	await unlink(`src/lib/tailwind/generated/${INTELLISENSE_FILE_NAME}`).catch(() => {
 		// file doesn't exist, don't worry about it
 	});
 
@@ -27,7 +27,7 @@ async function exec() {
 	const purgedJSS = await removeDuplicateClasses(generatedJSS);
 
 	// Creates the generated CSS-in-JS file
-	await writeFile(`src/lib/tailwind/generated/${ALL_COMPONENTS_FILE_NAME}`, `module.exports = ${JSON.stringify(purgedJSS)}`).catch((e) =>
+	await writeFile(`src/lib/tailwind/generated/${INTELLISENSE_FILE_NAME}`, `module.exports = ${JSON.stringify(purgedJSS)}`).catch((e) =>
 		console.error(e)
 	);
 

--- a/src/lib/tailwind/intellisense.cjs
+++ b/src/lib/tailwind/intellisense.cjs
@@ -11,7 +11,7 @@ module.exports = plugin(({ addComponents }) => {
 	if (process.env.NODE_ENV !== 'production') {
 		// try/catch because it will throw when allComponents.cjs isn't generated yet
 		try {
-			const all = require('./generated/all-components.cjs');
+			const all = require('./generated/intellisense-classes.cjs');
 			addComponents(all, {
 				respectImportant: true,
 				respectPrefix: true

--- a/src/lib/tailwind/intellisense.cjs
+++ b/src/lib/tailwind/intellisense.cjs
@@ -1,0 +1,21 @@
+// The Skeleton Intellisense Tailwind Plugin
+// Tailwind Docs: https://tailwindcss.com/docs/plugins
+// Skeleton Docs: https://www.skeleton.dev/guides/tailwind
+
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(({ addComponents }) => {
+	// The following will generate the non-token classes PURELY for Intellisense.
+	// These are excluded from production, which means we still need to lean into
+	// using the `all.css` stylesheet to import non-token styles.
+	if (process.env.NODE_ENV !== 'production') {
+		// try/catch because it will throw when allComponents.cjs isn't generated yet
+		try {
+			const all = require('./generated/all-components.cjs');
+			addComponents(all, {
+				respectImportant: true,
+				respectPrefix: true
+			});
+		} catch {}
+	}
+});

--- a/src/lib/tailwind/skeleton.cjs
+++ b/src/lib/tailwind/skeleton.cjs
@@ -35,5 +35,3 @@ module.exports = plugin(
 		}
 	}
 );
-
-function ploog() {}

--- a/src/lib/tailwind/skeleton.cjs
+++ b/src/lib/tailwind/skeleton.cjs
@@ -15,7 +15,7 @@ const tokensText = require('./tokens/text.cjs');
 const tokensRings = require('./tokens/rings.cjs');
 
 module.exports = plugin(
-	({ addUtilities, addComponents }) => {
+	({ addUtilities }) => {
 		addUtilities({
 			// Implement Skeleton design token classes
 			...tokensBackgrounds(),
@@ -25,19 +25,6 @@ module.exports = plugin(
 			...tokensText(),
 			...tokensRings()
 		});
-		// The following will generate the non-token classes PURELY for Intellisense.
-		// These are excluded from production, which means we still need to lean into
-		// using the `all.css` stylesheet to import non-token styles.
-		if (process.env.NODE_ENV !== 'production') {
-			// try/catch because it will throw when allComponents.cjs isn't generated yet
-			try {
-				const all = require('./generated/allComponents.cjs');
-				addComponents(all, {
-					respectImportant: true,
-					respectPrefix: true
-				});
-			} catch {}
-		}
 	},
 	{
 		theme: {
@@ -48,3 +35,5 @@ module.exports = plugin(
 		}
 	}
 );
+
+function ploog() {}

--- a/src/routes/(inner)/guides/tailwind/+page.svelte
+++ b/src/routes/(inner)/guides/tailwind/+page.svelte
@@ -95,7 +95,8 @@ const config = {
 	// ...
 	plugins: [
 		// Keep any existing plugins present and append the following:
-		require('@skeletonlabs/skeleton/tailwind/skeleton.cjs')
+		require('@skeletonlabs/skeleton/tailwind/skeleton.cjs'),
+		require('@skeletonlabs/skeleton/tailwind/intellisense.cjs')
 	]
 }
 `}


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?
Decouples the intellisense plugin from the base skeleton plugin. Users will now have to import the intellisense by adding `require('@skeletonlabs/skeleton/tailwind/intellisense.cjs')` to the plugin array in `tailwind.config.cjs`.

Additionally, we've renamed the generated CSS-in-JS file to `intellisense-classes.cjs` to fix the annoying committing issue.

