### PR TITLE
Feat: Modular Tailwind plugin

### DIFF
--- a/scripts/compile-css-to-js.cjs
+++ b/scripts/compile-css-to-js.cjs
@@ -11,7 +11,7 @@ async function transpileCssToJs() {
 	const twConfig = {
 		darkMode: 'class',
 		content: ['./src/**/*.{html,js,svelte,ts}'],
-		plugins: [require('../src/lib/tailwind/skeleton.cjs')]
+		plugins: [require('../src/lib/tailwind/core.cjs')]
 	};
 
 	const css = fs.readFileSync(cssEntryPath, 'utf8');

--- a/src/lib/tailwind/core.cjs
+++ b/src/lib/tailwind/core.cjs
@@ -1,0 +1,37 @@
+// The Skeleton Tailwind Plugin
+// Tailwind Docs: https://tailwindcss.com/docs/plugins
+// Skeleton Docs: https://www.skeleton.dev/guides/tailwind
+
+const plugin = require('tailwindcss/plugin');
+
+// Skeleton Theme Modules
+const themeColors = require('./theme/colors.cjs');
+// Skeleton Design Token Modules
+const tokensBackgrounds = require('./tokens/backgrounds.cjs');
+const tokensBorders = require('./tokens/borders.cjs');
+const tokensBorderRadius = require('./tokens/border-radius.cjs');
+const tokensFills = require('./tokens/fills.cjs');
+const tokensText = require('./tokens/text.cjs');
+const tokensRings = require('./tokens/rings.cjs');
+
+module.exports = plugin(
+	({ addUtilities }) => {
+		addUtilities({
+			// Implement Skeleton design token classes
+			...tokensBackgrounds(),
+			...tokensBorders(),
+			...tokensBorderRadius(),
+			...tokensFills(),
+			...tokensText(),
+			...tokensRings()
+		});
+	},
+	{
+		theme: {
+			extend: {
+				// Implement Skeleton theme colors
+				colors: themeColors()
+			}
+		}
+	}
+);

--- a/src/lib/tailwind/skeleton.cjs
+++ b/src/lib/tailwind/skeleton.cjs
@@ -2,36 +2,18 @@
 // Tailwind Docs: https://tailwindcss.com/docs/plugins
 // Skeleton Docs: https://www.skeleton.dev/guides/tailwind
 
-const plugin = require('tailwindcss/plugin');
+const intellisensePlugin = require('./intellisense.cjs');
+const corePlugin = require('./core.cjs');
 
-// Skeleton Theme Modules
-const themeColors = require('./theme/colors.cjs');
-// Skeleton Design Token Modules
-const tokensBackgrounds = require('./tokens/backgrounds.cjs');
-const tokensBorders = require('./tokens/borders.cjs');
-const tokensBorderRadius = require('./tokens/border-radius.cjs');
-const tokensFills = require('./tokens/fills.cjs');
-const tokensText = require('./tokens/text.cjs');
-const tokensRings = require('./tokens/rings.cjs');
+// The default export is a function that returns an array of plugins
+// and accepts an optional config that determines which plugins are included.
+// By default, all plugins are included.
+module.exports = function (config = { intellisense: true }) {
+	const { intellisense } = config;
+	const plugins = [corePlugin];
 
-module.exports = plugin(
-	({ addUtilities }) => {
-		addUtilities({
-			// Implement Skeleton design token classes
-			...tokensBackgrounds(),
-			...tokensBorders(),
-			...tokensBorderRadius(),
-			...tokensFills(),
-			...tokensText(),
-			...tokensRings()
-		});
-	},
-	{
-		theme: {
-			extend: {
-				// Implement Skeleton theme colors
-				colors: themeColors()
-			}
-		}
-	}
-);
+	// Add the plugin if the option is not explicitly set to false
+	if (intellisense !== false) plugins.push(intellisensePlugin);
+
+	return plugins;
+};

--- a/src/routes/(inner)/guides/tailwind/+page.svelte
+++ b/src/routes/(inner)/guides/tailwind/+page.svelte
@@ -95,8 +95,7 @@ const config = {
 	// ...
 	plugins: [
 		// Keep any existing plugins present and append the following:
-		require('@skeletonlabs/skeleton/tailwind/skeleton.cjs'),
-		require('@skeletonlabs/skeleton/tailwind/intellisense.cjs')
+		...require('@skeletonlabs/skeleton/tailwind/skeleton.cjs')()
 	]
 }
 `}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -10,5 +10,5 @@ module.exports = {
 			}
 		}
 	},
-	plugins: [require('@tailwindcss/forms'), require('./src/lib/tailwind/skeleton.cjs')]
+	plugins: [require('@tailwindcss/forms'), ...require('./src/lib/tailwind/skeleton.cjs')({ intellisense: false })]
 };


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

This is a rework on how we export our plugin. We'll now export a function that returns an array of plugins. The function will accept an optional config that will allow users to opt out of certain plugins. Users will not be able to opt out of the `core` plugin.

By default (when no config is passed), both the `core` and `intellisense` plugins will be returned. 

Users will be able to import the config as follows:
```ts
// tailwind.config.cjs

// ... other TW options
plugins: [
  // other existing plugins above...
  ...require('@skeletonlabs/skeleton/tailwind/skeleton.cjs')(),
]
```

If users want to opt out of having intellisense, it will be done as such:
```ts
// tailwind.config.cjs

// ... other TW options
plugins: [
  // other existing plugins above...
  ...require('@skeletonlabs/skeleton/tailwind/skeleton.cjs')({ intellisense: false }),
]
```