### PR TITLE
Removed TS-ignores and fixed SveldJson type

### DIFF
--- a/src/docs/DocsShell/types.ts
+++ b/src/docs/DocsShell/types.ts
@@ -22,12 +22,12 @@ export interface Component {
 	/** Provide a list of props that children can override. */
 	overrideProps?: string[];
 	/** Provide the raw component Sveld doc source. */
-	sveld: Record<string, SveldObj[]>;
+	sveld:SveldJson;
 }
 
-export interface SveldObj {
-	name: string;
-	type: string;
+export interface SveldJson {
+	name?: string;
+	type?: string;
 	description?: string;
 	value?: string;
 	detail?: string;
@@ -36,7 +36,7 @@ export interface SveldObj {
 		tag: string;
 		value?: string;
 	}[];
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export interface DocsShellSettings {

--- a/src/routes/(inner)/components/accordions/+page.svelte
+++ b/src/routes/(inner)/components/accordions/+page.svelte
@@ -9,9 +9,7 @@
 	// Utilities
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldAccordionGroup from '$lib/components/Accordion/AccordionGroup.svelte?raw&sveld';
-	// @ts-expect-error sveld import
 	import sveldAccordionItem from '$lib/components/Accordion/AccordionItem.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/app-bar/+page.svelte
+++ b/src/routes/(inner)/components/app-bar/+page.svelte
@@ -5,7 +5,6 @@
 	import AppBar from '$lib/components/AppBar/AppBar.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldAppBar from '$lib/components/AppBar/AppBar.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/app-rail/+page.svelte
+++ b/src/routes/(inner)/components/app-rail/+page.svelte
@@ -10,9 +10,7 @@
 	// Utilities
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldAppRail from '$lib/components/AppRail/AppRail.svelte?raw&sveld';
-	// @ts-expect-error sveld import
 	import sveldAppRailTile from '$lib/components/AppRail/AppRailTile.svelte?raw&sveld';
 
 	// Stores

--- a/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/src/routes/(inner)/components/app-shell/+page.svelte
@@ -6,7 +6,6 @@
 	import SlideToggle from '$lib/components/SlideToggle/SlideToggle.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldAppShell from '$lib/components/AppShell/AppShell.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/avatars/+page.svelte
+++ b/src/routes/(inner)/components/avatars/+page.svelte
@@ -23,7 +23,6 @@
 	import Summer84 from '$lib/actions/Filters/svg-filters/Summer84.svelte';
 	import XPro from '$lib/actions/Filters/svg-filters/XPro.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldAvatar from '$lib/components/Avatar/Avatar.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/conic-gradients/+page.svelte
+++ b/src/routes/(inner)/components/conic-gradients/+page.svelte
@@ -7,7 +7,6 @@
 
 	import type { ConicStop } from '$lib/components/ConicGradient/types';
 
-	// @ts-expect-error sveld import
 	import sveldConicGradient from '$lib/components/ConicGradient/ConicGradient.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -5,7 +5,6 @@
 	import FileButton from '$lib/components/FileButton/FileButton.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldFileButton from '$lib/components/FileButton/FileButton.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/file-dropzone/+page.svelte
+++ b/src/routes/(inner)/components/file-dropzone/+page.svelte
@@ -5,7 +5,6 @@
 	import FileDropzone from '$lib/components/FileDropzone/FileDropzone.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldFileDropzone from '$lib/components/FileDropzone/FileDropzone.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/input-chips/+page.svelte
+++ b/src/routes/(inner)/components/input-chips/+page.svelte
@@ -8,7 +8,6 @@
 	// Components
 	import InputChip from '$lib/components/InputChip/InputChip.svelte';
 
-	// @ts-expect-error
 	import sveldInputChip from '$lib/components/InputChip/InputChip.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/listboxes/+page.svelte
+++ b/src/routes/(inner)/components/listboxes/+page.svelte
@@ -8,9 +8,7 @@
 	import ListBox from '$lib/components/ListBox/ListBox.svelte';
 	import ListBoxItem from '$lib/components/ListBox/ListBoxItem.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldListBox from '$lib/components/ListBox/ListBox.svelte?raw&sveld';
-	// @ts-expect-error sveld import
 	import sveldListBoxItem from '$lib/components/ListBox/ListBoxItem.svelte?raw&sveld';
 
 	// Stores

--- a/src/routes/(inner)/components/paginators/+page.svelte
+++ b/src/routes/(inner)/components/paginators/+page.svelte
@@ -8,7 +8,6 @@
 
 	import type { PaginationSettings } from '$lib/components/Paginator/types';
 
-	// @ts-expect-error sveld import
 	import sveldPaginator from '$lib/components/Paginator/Paginator.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/progress-bars/+page.svelte
+++ b/src/routes/(inner)/components/progress-bars/+page.svelte
@@ -9,7 +9,6 @@
 	import RadioItem from '$lib/components/Radio/RadioItem.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldProgressBar from '$lib/components/ProgressBar/ProgressBar.svelte?raw&sveld';
 
 	// Stores

--- a/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -5,7 +5,6 @@
 	import ProgressRadial from '$lib/components/ProgressRadial/ProgressRadial.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldProgressRadial from '$lib/components/ProgressRadial/ProgressRadial.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/radio-groups/+page.svelte
+++ b/src/routes/(inner)/components/radio-groups/+page.svelte
@@ -8,9 +8,7 @@
 	import RadioItem from '$lib/components/Radio/RadioItem.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldRadioGroup from '$lib/components/Radio/RadioGroup.svelte?raw&sveld';
-	// @ts-expect-error sveld import
 	import sveldRadioItem from '$lib/components/Radio/RadioItem.svelte?raw&sveld';
 
 	// Stores

--- a/src/routes/(inner)/components/range-sliders/+page.svelte
+++ b/src/routes/(inner)/components/range-sliders/+page.svelte
@@ -9,7 +9,6 @@
 	import RangeSlider from '$lib/components/RangeSlider/RangeSlider.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldRangeSlider from '$lib/components/RangeSlider/RangeSlider.svelte?raw&sveld';
 
 	// Stores

--- a/src/routes/(inner)/components/slide-toggles/+page.svelte
+++ b/src/routes/(inner)/components/slide-toggles/+page.svelte
@@ -5,7 +5,6 @@
 	import SlideToggle from '$lib/components/SlideToggle/SlideToggle.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldSlideToggle from '$lib/components/SlideToggle/SlideToggle.svelte?raw&sveld';
 
 	// Docs Shell

--- a/src/routes/(inner)/components/steppers/+page.svelte
+++ b/src/routes/(inner)/components/steppers/+page.svelte
@@ -11,9 +11,7 @@
 	import RadioGroup from '$lib/components/Radio/RadioGroup.svelte';
 	import RadioItem from '$lib/components/Radio/RadioItem.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldStepper from '$lib/components/Stepper/Stepper.svelte?raw&sveld';
-	// @ts-expect-error sveld import
 	import sveldStep from '$lib/components/Stepper/Step.svelte?raw&sveld';
 
 	// Stores

--- a/src/routes/(inner)/components/svg-icons/+page.svelte
+++ b/src/routes/(inner)/components/svg-icons/+page.svelte
@@ -7,7 +7,6 @@
 	import SvgIcon from '$lib/components/SvgIcon/SvgIcon.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldSvgIcon from '$lib/components/SvgIcon/SvgIcon.svelte?raw&sveld';
 
 	// Local

--- a/src/routes/(inner)/components/table-of-contents/+page.svelte
+++ b/src/routes/(inner)/components/table-of-contents/+page.svelte
@@ -5,7 +5,6 @@
 	// Utilities
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error
 	import sveldTableOfContents from '$lib/components/TableOfContents/TableOfContents.svelte?raw&sveld';
 
 	// Docs Shell
@@ -40,7 +39,7 @@
 		<p>Lorem, ipsum dolor sit amet consectetur adipisicing elit.</p>
 	</div>
 </main>
-			`}
+`}
 			/>
 		</section>
 		<section class="space-y-4">

--- a/src/routes/(inner)/components/tables/+page.svelte
+++ b/src/routes/(inner)/components/tables/+page.svelte
@@ -17,7 +17,6 @@
 	// Utilities
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldTable from '$lib/components/Table/Table.svelte?raw&sveld';
 
 	// Stores

--- a/src/routes/(inner)/components/tabs/+page.svelte
+++ b/src/routes/(inner)/components/tabs/+page.svelte
@@ -9,9 +9,7 @@
 	import SvgIcon from '$lib/components/SvgIcon/SvgIcon.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
 
-	// @ts-expect-error sveld import
 	import sveldTabGroup from '$lib/components/Tab/TabGroup.svelte?raw&sveld';
-	// @ts-expect-error sveld import
 	import sveldTab from '$lib/components/Tab/Tab.svelte?raw&sveld';
 
 	let storeOne = writable('a');


### PR DESCRIPTION
As part of the sync'ing of tsconfig.json with the latest SK lib project template - it introduced a warning on the //@ts-ignore's on the Sveld import lines, this turned out to be also hiding a type mismatch error on SveldObj - this fixes up both and still retains the new settings of tsconfig.json.