### PR TITLE
Fixed Table of Contents crashing on small screens where the Table of Contents isn't visible and therefore can't select the activeHeader

### DIFF
--- a/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -95,7 +95,7 @@
 			if (offsetTop >= 0) visibleHeadings.push(header);
 		});
 		// Set the top-most header as the active ID
-		activeHeaderId = visibleHeadings[0].id;
+		activeHeaderId = visibleHeadings[0]?.id;
 	}
 
 	// Lifecycle


### PR DESCRIPTION
- [ X ] Did you update and run tests before submission using `npm run test`?
- [ X ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
## What does your PR address?

Please briefly describe your changes here.

Fixed Skeleton Page crashing on smaller screens without table of contents
