### PR TITLE
ListBox value during Form submission

### DIFF
--- a/src/lib/components/ListBox/ListBox.svelte
+++ b/src/lib/components/ListBox/ListBox.svelte
@@ -11,6 +11,8 @@
 	export let space = 'space-y-1';
 	/** Provide to set scrollable listbox region height. */
 	export let height = '';
+	/** Should the ListBox value be included in Form submissions*/
+	export let includeInFormSubmission = false;
 
 	// Props (Item)
 	/** Provide classes to set the item selected background. '!' recommended. */
@@ -63,3 +65,6 @@
 		<slot />
 	</ul>
 </div>
+{#if  includeInFormSubmission}
+<input type="hidden" name={label} value={$selected}/>
+{/if}


### PR DESCRIPTION
Added prop to optionally render a hidden input that contains the selected values to ListBox so that the values automatically get submitted during Form submission.

It has the same issues that the SubmitFunction -> FormData.append() solution that I proposed initially has: It's still FormData and can therefore only take strings or blobs.

That means that strings work perfectly well, numbers and arrays will have to be coerced because they are strings like this:
```json
{
    "selectedString": "stringvalue",
    "selectedNumber": "10",
    "multiSelection": "selectionOne,selectionTwo,selectionThree"
}
```

It's still a better solution than having to include a custom SubmitFunction.

On the other hand, with a custom SubmitFunction we could reset the ListBox to an unselected state like you'd expect it from a Form, that's currently not possible with the hidden input solution proposed here
