### PR TITLE
Fix: Remove dark variants from type selectors in Intellisense

### DIFF
--- a/scripts/generate-jss.js
+++ b/scripts/generate-jss.js
@@ -63,6 +63,8 @@ async function removeDuplicateClasses(cssInJs) {
 
 		// if it's not a class selector, delete it (only want classes in the intellisense)
 		if (key[0] !== '.') delete cssInJs[key];
+		// deletes the dark variant of type selectors (ex: .dark body {...})
+		if (key.startsWith('.dark') && key[6] !== '.') delete cssInJs[key];
 
 		// if it's a default tailwind class, delete it
 		if (twClasses[key]) delete cssInJs[key];


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

Fixes #888

Type selectors were being removed from the generated CSS-in-JS, but their dark variants were not. This fixes that.
