### PR TITLE
fix typo in logo-cloud example doc

### DIFF
--- a/src/routes/(inner)/elements/logo-clouds/+page.svelte
+++ b/src/routes/(inner)/elements/logo-clouds/+page.svelte
@@ -61,7 +61,7 @@
 				language="html"
 				code={`
 <div class="logo-cloud grid-cols-1 lg:grid-cols-4 gap-1">
-	<div class="logo-item">HR Solutions</span></div>
+	<div class="logo-item">HR Solutions</div>
 	<div class="logo-item">Acme Theaters</div>
 	<div class="logo-item">Cruisin' Cuisine</div>
 	<div class="logo-item">Arcane Security</div>


### PR DESCRIPTION
Small type fix in logo-clouds doc.
There's an extra </span> in the code sample causing a syntax error.