### PR TITLE
fix: FileButton `files` property binding

### DIFF
--- a/src/lib/components/FileButton/FileButton.svelte
+++ b/src/lib/components/FileButton/FileButton.svelte
@@ -25,7 +25,7 @@
 <div class="file-button {$$props.class ?? ''}" data-testid="file-button">
 	<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
 	<div class="h-0 overflow-hidden">
-		<input type="file" bind:this={elemFileInput} files={$$restProps.files} {name} {...prunedRestProps()} on:change />
+		<input type="file" bind:this={elemFileInput} {name} {...prunedRestProps()} on:change />
 	</div>
 	<!-- Button -->
 	<button


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [X] Did you update and run tests before submission using `npm run test`?
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?
If you bind a variable to a FileButton component's `files` property, it won't actually update when a file is selected. This PR removes the explicit property from the file input and just passes `files` to the input like any other property through the `prunedRestProps`.
