### PR TITLE
Fix: Lazy load vercel analytics

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,5 @@
 <!-- Layout: (root) -->
 <script lang="ts">
-	import { inject } from '@vercel/analytics';
-
 	// Highlight JS
 	import hljs from 'highlight.js';
 	import '$lib/styles/highlight-js.css'; // was: 'highlight.js/styles/github-dark.css';
@@ -54,7 +52,7 @@
 	export let data: LayoutServerData;
 
 	// Vercel Analytics
-	if (data.vercelEnv == 'production') inject();
+	if (data.vercelEnv === 'production') import('@vercel/analytics').then((mod) => mod.inject());
 
 	// Registered list of Components for Modals
 	const modalComponentRegistry: Record<string, ModalComponent> = {


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributions)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

We need to lazy load the analytics to prevent the errors we've seen in dev due to ad blockers:
```
GET http://localhost:5173/node_modules/.vite/deps/@vercel_analytics.js?v=73c2f3ed net::ERR_BLOCKED_BY_CLIENT
manifest.js:145 TypeError: Failed to fetch dynamically imported module: http://localhost:5173/.svelte-kit/generated/client/nodes/0.js
handleError @ manifest.js:145
handle_error @ client.js?v=73c2f3ed:1812
_hydrate @ client.js?v=73c2f3ed:1749
await in _hydrate (async)
start @ start.js:33
(anonymous) @ (index):7441
localhost/:1 Uncaught (in promise) TypeError: Failed to fetch dynamically imported module: http://localhost:5173/.svelte-kit/generated/client/nodes/0.js
start.js:39 Uncaught (in promise) TypeError: Failed to fetch dynamically imported module: http://localhost:5173/.svelte-kit/generated/client/nodes/0.js
```