### PR TITLE
Fixed spelling of Arbitrary

### DIFF
--- a/src/routes/(inner)/docs/styling/+page.svelte
+++ b/src/routes/(inner)/docs/styling/+page.svelte
@@ -41,7 +41,7 @@
 		<CodeBlock language="html" code={`<ExampleComponent class="text-3xl px-10 py-5">Skeleton</ExampleComponent>`} />
 	</section>
 	<section class="space-y-4">
-		<h2>Tailwind Abitrary Variants</h2>
+		<h2>Tailwind Arbitrary Variants</h2>
 		<p>
 			If you need to target deeper than the parent element, we recommend using <a
 				href="https://tailwindcss.com/blog/tailwindcss-v3-1#arbitrary-values-but-for-variants"


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

Arbitrary was spelling incorrectly on the `docs/styling` page referencing Tailwind arbitrary variants.