### PR TITLE
Feat/redirector for jsdoc links to hyphenated url's

### DIFF
--- a/src/lib/components/AppShell/AppShell.svelte
+++ b/src/lib/components/AppShell/AppShell.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Slots
-	/** @slot header - Insert fixed header content, such as the <a href='https://www.skeleton.dev/components/app-bar'>AppBar</a> component.
+	/** @slot header - Insert fixed header content, such as the <a href="/redirect/appbar">AppBar</a> component.
 	 * @slot sidebarLeft - Hidden when empty. Allows you to set fixed left sidebar content.
 	 * @slot sidebarRight - Hidden when empty. Allows you to set fixed right sidebar content.
 	 * @slot pageHeader - Insert content that resides above your page content. Great for global alerts.

--- a/src/routes/(inner)/redirect/[destination]/+page.ts
+++ b/src/routes/(inner)/redirect/[destination]/+page.ts
@@ -4,8 +4,6 @@ import { redirect } from '@sveltejs/kit';
 
 // This exists because JSDoc doesn't like multiple '-' characters in a line and a lot of our url's have hyphen's, so we do redirects to the natural destination
 export const load = (({ params }) => {
-	console.log(params.destination);
-	
 	switch (params.destination) {
 		case "appbar":
 			throw redirect(302, "/components/app-bar")

--- a/src/routes/(inner)/redirect/[destination]/+page.ts
+++ b/src/routes/(inner)/redirect/[destination]/+page.ts
@@ -1,0 +1,13 @@
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+
+// This exists because JSDoc doesn't like multiple '-' characters in a line and a lot of our url's have hyphen's, so we do redirects to the natural destination
+export const load = (({ params }) => {
+	console.log(params.destination);
+	
+	switch (params.destination) {
+		case "appbar":
+			throw redirect(302, "/components/app-bar")
+	}
+}) satisfies PageLoad;

--- a/src/routes/(inner)/redirect/[destination]/+page.ts
+++ b/src/routes/(inner)/redirect/[destination]/+page.ts
@@ -6,6 +6,6 @@ import { redirect } from '@sveltejs/kit';
 export const load = (({ params }) => {
 	switch (params.destination) {
 		case "appbar":
-			throw redirect(302, "/components/app-bar")
+			throw redirect(301, "/components/app-bar")
 	}
 }) satisfies PageLoad;


### PR DESCRIPTION
Workaround for hyphenated links in JSDocs