### PR TITLE
docs/components/radio-groups/ vertical example #1089

### DIFF
--- a/src/routes/(inner)/components/radio-groups/+page.svelte
+++ b/src/routes/(inner)/components/radio-groups/+page.svelte
@@ -32,7 +32,8 @@
 
 	// Local
 	let justify: number = 0;
-	let time: string = 'Months';
+	let timeHorz: string = 'months';
+	let timeVert: string = 'Millennia';
 	let timeNames = ['Millennia', 'Epochs', 'Eras', 'Eons'];
 </script>
 
@@ -86,8 +87,8 @@
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<RadioGroup active="variant-filled-primary" hover="hover:variant-soft-primary">
-						<RadioItem bind:group={time} name="time" value="months">Months</RadioItem>
-						<RadioItem bind:group={time} name="time" value="years">Years</RadioItem>
+						<RadioItem bind:group={timeHorz} name="time" value="months">Months</RadioItem>
+						<RadioItem bind:group={timeHorz} name="time" value="years">Years</RadioItem>
 					</RadioGroup>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
@@ -105,7 +106,7 @@
 				<svelte:fragment slot="preview">
 					<RadioGroup rounded="rounded-container-token" display="flex-col">
 						{#each timeNames as name, i}
-							<RadioItem bind:group={time} label={name} {name} value={name}>{name}</RadioItem>
+							<RadioItem bind:group={timeVert} label={name} {name} value={name}>{name}</RadioItem>
 						{/each}
 					</RadioGroup>
 				</svelte:fragment>

--- a/src/routes/(inner)/components/radio-groups/+page.svelte
+++ b/src/routes/(inner)/components/radio-groups/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
+	import DocsPreview from '$docs/components/DocsPreview/DocsPreview.svelte';
 	import DocsShell from '$docs/layouts/DocsShell/DocsShell.svelte';
 	import { DocsFeature, type DocsShellSettings } from '$docs/layouts/DocsShell/types';
-	import DocsPreview from '$docs/components/DocsPreview/DocsPreview.svelte';
-	// Components
+// Components
 	import RadioGroup from '$lib/components/Radio/RadioGroup.svelte';
 	import RadioItem from '$lib/components/Radio/RadioItem.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
-	// Sveld
+// Sveld
 	import sveldRadioGroup from '$lib/components/Radio/RadioGroup.svelte?raw&sveld';
 	import sveldRadioItem from '$lib/components/Radio/RadioItem.svelte?raw&sveld';
 
@@ -32,7 +32,8 @@
 
 	// Local
 	let justify: number = 0;
-	let time: string = 'months';
+	let time: string = 'Months';
+	let timeNames = ['Months', 'Years', 'Decades', 'Centuries', 'Millennia', 'Epochs', 'Periods', 'Eras', 'Eons'];
 </script>
 
 <DocsShell {settings}>
@@ -93,6 +94,54 @@
 					<CodeBlock
 						language="html"
 						code={`<RadioGroup active="variant-filled-primary" hover="hover:variant-soft-primary">...</RadioGroup>`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
+		<section class="space-y-4">
+			<h2>Vertical</h2>
+			<p>Set <em>display</em> to <code>flex-col</code> for a vertical layout.</p>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<RadioGroup rounded="rounded-2xl" display="flex-col" active="variant-filled-primary" hover="hover:variant-soft-primary">
+						{#each timeNames.slice(5, -2) as name, i}
+							<RadioItem bind:group={time} label={name} {name} value={name}>{name}</RadioItem>
+						{/each}
+						<RadioItem bind:group={time} name={timeNames[7]} value={timeNames[7]}
+							>{timeNames[7]}
+							<button class="btn h-0 px-0">⚙️</button>
+						</RadioItem>
+						<RadioItem bind:group={time} name={timeNames[8]} value={timeNames[8]}
+							>{timeNames[8]}
+							<button class="btn h-0 px-0">⚙️</button>
+						</RadioItem>
+					</RadioGroup>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let time: string = 'Months';
+let timeNames = ['Months', 'Years', 'Decades', 'Centuries', 'Millennia', 'Epochs', 'Periods', 'Eras', 'Eons']; // Code Words, Custom Words
+					`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<RadioGroup rounded="rounded-2xl" display="flex-col" active="variant-filled-primary" hover="hover:variant-soft-primary">
+	{#each timeNames.slice(2, -2) as name, i}
+		<RadioItem bind:group={time} label={name} {name} value={i}>{name}</RadioItem>
+	{/each}
+	<RadioItem bind:group={time} name={timeNames[7]} value={timeNames[7]}
+		>{timeNames[7]}
+		<button class="btn h-0 px-0">⚙️</button>
+	</RadioItem>
+	<RadioItem bind:group={time} name={timeNames[8]} value={timeNames[8]}
+		>{timeNames[8]}
+		<button class="btn h-0 px-0">⚙️</button>
+	</RadioItem>
+</RadioGroup>
+						`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>

--- a/src/routes/(inner)/components/radio-groups/+page.svelte
+++ b/src/routes/(inner)/components/radio-groups/+page.svelte
@@ -33,7 +33,7 @@
 	// Local
 	let justify: number = 0;
 	let time: string = 'Months';
-	let timeNames = ['Months', 'Years', 'Decades', 'Centuries', 'Millennia', 'Epochs', 'Periods', 'Eras', 'Eons'];
+	let timeNames = ['Millennia', 'Epochs', 'Eras', 'Eons'];
 </script>
 
 <DocsShell {settings}>
@@ -103,44 +103,17 @@
 			<p>Set <em>display</em> to <code>flex-col</code> for a vertical layout.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<RadioGroup rounded="rounded-2xl" display="flex-col" active="variant-filled-primary" hover="hover:variant-soft-primary">
-						{#each timeNames.slice(5, -2) as name, i}
+					<RadioGroup rounded="rounded-container-token" display="flex-col">
+						{#each timeNames as name, i}
 							<RadioItem bind:group={time} label={name} {name} value={name}>{name}</RadioItem>
 						{/each}
-						<RadioItem bind:group={time} name={timeNames[7]} value={timeNames[7]}
-							>{timeNames[7]}
-							<button class="btn h-0 px-0">⚙️</button>
-						</RadioItem>
-						<RadioItem bind:group={time} name={timeNames[8]} value={timeNames[8]}
-							>{timeNames[8]}
-							<button class="btn h-0 px-0">⚙️</button>
-						</RadioItem>
 					</RadioGroup>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock
-						language="ts"
-						code={`
-let time: string = 'Months';
-let timeNames = ['Months', 'Years', 'Decades', 'Centuries', 'Millennia', 'Epochs', 'Periods', 'Eras', 'Eons']; // Code Words, Custom Words
-`}
-					/>
-					<CodeBlock
 						language="html"
 						code={`
-<RadioGroup rounded="rounded-2xl" display="flex-col" active="variant-filled-primary" hover="hover:variant-soft-primary">
-	{#each timeNames.slice(2, -2) as name, i}
-		<RadioItem bind:group={time} label={name} {name} value={i}>{name}</RadioItem>
-	{/each}
-	<RadioItem bind:group={time} name={timeNames[7]} value={timeNames[7]}
-		>{timeNames[7]}
-		<button class="btn h-0 px-0">⚙️</button>
-	</RadioItem>
-	<RadioItem bind:group={time} name={timeNames[8]} value={timeNames[8]}
-		>{timeNames[8]}
-		<button class="btn h-0 px-0">⚙️</button>
-	</RadioItem>
-</RadioGroup>
+<RadioGroup rounded="rounded-container-token" display="flex-col">...</RadioGroup>
 `}
 					/>
 				</svelte:fragment>

--- a/src/routes/(inner)/components/radio-groups/+page.svelte
+++ b/src/routes/(inner)/components/radio-groups/+page.svelte
@@ -2,11 +2,11 @@
 	import DocsPreview from '$docs/components/DocsPreview/DocsPreview.svelte';
 	import DocsShell from '$docs/layouts/DocsShell/DocsShell.svelte';
 	import { DocsFeature, type DocsShellSettings } from '$docs/layouts/DocsShell/types';
-// Components
+	// Components
 	import RadioGroup from '$lib/components/Radio/RadioGroup.svelte';
 	import RadioItem from '$lib/components/Radio/RadioItem.svelte';
 	import CodeBlock from '$lib/utilities/CodeBlock/CodeBlock.svelte';
-// Sveld
+	// Sveld
 	import sveldRadioGroup from '$lib/components/Radio/RadioGroup.svelte?raw&sveld';
 	import sveldRadioItem from '$lib/components/Radio/RadioItem.svelte?raw&sveld';
 
@@ -66,7 +66,7 @@
 	<RadioItem bind:group={value} name="justify" value={1}>(label)</RadioItem>
 	<RadioItem bind:group={value} name="justify" value={2}>(label)</RadioItem>
 </RadioGroup>
-				`}
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -123,7 +123,7 @@
 						code={`
 let time: string = 'Months';
 let timeNames = ['Months', 'Years', 'Decades', 'Centuries', 'Millennia', 'Epochs', 'Periods', 'Eras', 'Eons']; // Code Words, Custom Words
-					`}
+`}
 					/>
 					<CodeBlock
 						language="html"
@@ -141,7 +141,7 @@ let timeNames = ['Months', 'Years', 'Decades', 'Centuries', 'Millennia', 'Epochs
 		<button class="btn h-0 px-0">⚙️</button>
 	</RadioItem>
 </RadioGroup>
-						`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>


### PR DESCRIPTION
Example of vertical layout of RadioGroup

## Before submitting the PR:
- [X] Does your PR reference an issue?
- [X] Did you update and run tests before submission using `npm run test`? Ran them, no updates.
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)?
- [X] Did you update documentation related to your new feature or changes? It is documentation

## What does your PR address?
An example of vertical orientation for RadioGroup

Please briefly describe your changes here.
Used flex-col to flow vertically and a for each of a time period variable to populate it.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.

I assume I don't want to link and auto close?