### PR TITLE
docs/examples/ all CodeBlock space trim and whole line with return #1089

### DIFF
--- a/src/routes/(inner)/actions/clipboard/+page.svelte
+++ b/src/routes/(inner)/actions/clipboard/+page.svelte
@@ -41,8 +41,8 @@
 				</button>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`const exampleData: string = 'This text was copied by the Skeleton clipboard action.';`} />
-				<CodeBlock language="html" code={`<button use:clipboard={exampleData}>Copy</button>`} />
+				<CodeBlock language="ts" code={`const exampleData: string = 'This text was copied by the Skeleton clipboard action.';\n`} />
+				<CodeBlock language="html" code={`<button use:clipboard={exampleData}>Copy</button>\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -54,8 +54,8 @@
 		<div class="space-y-4">
 			<h2>Copying HTML Contents</h2>
 			<p>
-				To copy the <em>innerHTML</em> for an element, set a <code>data-clipboard</code> on your target, then provide
-				an <code>element</code> reference to the action.
+				To copy the <em>innerHTML</em> for an element, set a <code>data-clipboard</code> on your target, then provide an
+				<code>element</code> reference to the action.
 			</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
@@ -71,7 +71,8 @@
 						language="html"
 						code={`
 <!-- Source -->
-<div data-clipboard="exampleElement">(contents)</div>\n
+<div data-clipboard="exampleElement">(contents)</div>
+
 <!-- Trigger -->
 <button use:clipboard={{ element: 'exampleElement' }}>Copy</button>
 `}
@@ -83,8 +84,8 @@
 		<div class="space-y-4">
 			<h2>Copying Input Values</h2>
 			<p>
-				To copy the target input <em>value</em>, set a <code>data-clipboard</code> data attribute on your target, then provide
-				an <code>input</code> reference to the action.
+				To copy the target input <em>value</em>, set a <code>data-clipboard</code> data attribute on your target, then provide an
+				<code>input</code> reference to the action.
 			</p>
 
 			<DocsPreview background="neutral">
@@ -99,7 +100,8 @@
 						language="html"
 						code={`
 <!-- Source -->
-<input type="text" value="(contents)" data-clipboard="exampleInput"></input>\n
+<input type="text" value="(contents)" data-clipboard="exampleInput"></input>
+
 <!-- Trigger -->
 <button use:clipboard={{ input: 'exampleInput' }}>Copy</button>
 `}

--- a/src/routes/(inner)/actions/filters/+page.svelte
+++ b/src/routes/(inner)/actions/filters/+page.svelte
@@ -111,11 +111,11 @@ only utlize theme on this doc page.
 			</svelte:fragment>
 			<svelte:fragment slot="source">
 				<p>Import the filter and each filter component you wish to use.</p>
-				<CodeBlock language="ts" code={`import { filter, Emerald, BlueNight /* ... */  } from '@skeletonlabs/skeleton';`} />
+				<CodeBlock language="ts" code={`import { filter, Emerald, BlueNight /* ... */  } from '@skeletonlabs/skeleton';\n`} />
 				<p>Implement each filter component. For global scope add these to your root layout.</p>
-				<CodeBlock language="html" code={`<Emerald />\n<BlueNight />`} />
+				<CodeBlock language="html" code={`<Emerald />\n<BlueNight />\n`} />
 				<p>Apply the filter to your desired element.</p>
-				<CodeBlock language="html" code={`<img ... use:filter={'#Emerald'} />`} />
+				<CodeBlock language="html" code={`<img ... use:filter={'#Emerald'} />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -138,14 +138,14 @@ only utlize theme on this doc page.
 				<svelte:fragment slot="panel">
 					{#if method === 0}
 						<p>
-							Use the following <a href="https://svelte.dev/tutorial/actions" target="_blank" rel="noreferrer">Svelte action</a> to filter
-							any element. Pass the filter name as the only parameter.
+							Use the following <a href="https://svelte.dev/tutorial/actions" target="_blank" rel="noreferrer">Svelte action</a> to filter any
+							element. Pass the filter name as the only parameter.
 						</p>
-						<CodeBlock language="ts" code={`import { filter } from '@skeletonlabs/skeleton';`} />
-						<CodeBlock language="html" code={`<img src={myImageSrc} use:filter={'#BlueNight'}>`} />
+						<CodeBlock language="ts" code={`import { filter } from '@skeletonlabs/skeleton';\n`} />
+						<CodeBlock language="html" code={`<img src={myImageSrc} use:filter={'#BlueNight'}>\n`} />
 					{:else if method === 1}
 						<p>Alternatively you may apply filters using inline CSS. This is what the action is doing under the hood.</p>
-						<CodeBlock language="html" code={`<img src={myImageSrc} style="filter: url({'#Emerald'})">`} />
+						<CodeBlock language="html" code={`<img src={myImageSrc} style="filter: url({'#Emerald'})">\n`} />
 					{/if}
 				</svelte:fragment>
 			</TabGroup>

--- a/src/routes/(inner)/actions/focus-trap/+page.svelte
+++ b/src/routes/(inner)/actions/focus-trap/+page.svelte
@@ -46,7 +46,7 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let isFocused: boolean = true;`} />
+				<CodeBlock language="ts" code={`let isFocused: boolean = true;\n`} />
 				<CodeBlock
 					language="html"
 					code={`

--- a/src/routes/(inner)/components/accordions/+page.svelte
+++ b/src/routes/(inner)/components/accordions/+page.svelte
@@ -111,14 +111,14 @@
 		<section class="space-y-4">
 			<h2>Auto-Collapse Mode</h2>
 			<p>Enable the <code>autocollapse</code> setting to limit display to one accordion panel at a time.</p>
-			<CodeBlock language="html" code={`<Accordion autocollapse>...</Accordion>`} />
+			<CodeBlock language="html" code={`<Accordion autocollapse>...</Accordion>\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Open on Load</h2>
 			<p>
 				Set the visible items on load with <code>open</code>. When using <code>autocollapse</code> mode, this is limited to a single item.
 			</p>
-			<CodeBlock language="html" code={`<AccordionItem open>...</AccordionItem>`} />
+			<CodeBlock language="html" code={`<AccordionItem open>...</AccordionItem>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/components/app-bar/+page.svelte
+++ b/src/routes/(inner)/components/app-bar/+page.svelte
@@ -97,7 +97,7 @@
 					<AppBar class="w-full"><h2 data-toc-ignore>Title</h2></AppBar>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<AppBar>(title)</AppBar>`} />
+					<CodeBlock language="html" code={`<AppBar>(title)</AppBar>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/src/routes/(inner)/components/app-rail/+page.svelte
+++ b/src/routes/(inner)/components/app-rail/+page.svelte
@@ -106,7 +106,7 @@ const storeValue: Writable<number> = writable(0);
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<AppRailTile tag="a" href="/my/page/route">(icon)</AppRailTile>`} />
+					<CodeBlock language="html" code={`<AppRailTile tag="a" href="/my/page/route">(icon)</AppRailTile>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -117,7 +117,7 @@ const storeValue: Writable<number> = writable(0);
 				To set an active state for an anchor link, compare the tile <em>href</em> URL to the active page URL using
 				<a href="https://kit.svelte.dev/docs/modules#$app-stores-page" target="_blank" rel="noreferrer">$page.url.pathname</a>. Then set a background color or other visual indicator via the Svelte class syntax.
 			</p>
-			<CodeBlock language="ts" code={`import { page } from '$app/stores';`} />
+			<CodeBlock language="ts" code={`import { page } from '$app/stores';\n`} />
 			<CodeBlock
 				language="html"
 				code={`

--- a/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/src/routes/(inner)/components/app-shell/+page.svelte
@@ -124,7 +124,8 @@
 	<!-- ---- / ---- -->
 	<svelte:fragment slot="pageFooter">Page Footer</svelte:fragment>
 	<svelte:fragment slot="footer">Footer</svelte:fragment>
-</AppShell>`}
+</AppShell>
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -149,13 +150,13 @@
 			</p>
 			<CodeBlock
 				language="html"
-				code={`<body>\n\t<div style="display: contents" class="h-full overflow-hidden">%sveltekit.body%</div>\n</body>`.trim()}
+				code={`<body>\n\t<div style="display: contents" class="h-full overflow-hidden">%sveltekit.body%</div>\n</body>\n`}
 			/>
 			<p>
 				Then update your global stylesheet with the following. This will disable overflow for <em>html</em> and <em>body</em> tags to prevent
 				duplicate scroll bars.
 			</p>
-			<CodeBlock language="css" code={`html, body { @apply h-full overflow-hidden; }`} />
+			<CodeBlock language="css" code={`html, body { @apply h-full overflow-hidden; }\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Using an App Bar</h2>
@@ -171,7 +172,8 @@
 		<AppBar>Skeleton</AppBar>
 	</svelte:fragment>
 	<!-- ... -->
-</AppShell>`}
+</AppShell>
+`}
 			/>
 			<p>If you wish for your App Bar to scroll with the page, insert it into the <code>pageHeader</code> slot.</p>
 			<CodeBlock
@@ -182,10 +184,11 @@
 		<AppBar>Skeleton</AppBar>
 	</svelte:fragment>
 	<!-- ... -->
-</AppShell>`}
+</AppShell>
+`}
 			/>
 			<p>If you wish to have a sticky <code>pageHeader</code>, apply the following App Shell prop styles.</p>
-			<CodeBlock language="html" code={`<AppShell regionPage="relative" slotPageHeader="sticky top-0 z-10">...</AppShell>`} />
+			<CodeBlock language="html" code={`<AppShell regionPage="relative" slotPageHeader="sticky top-0 z-10">...</AppShell>\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Responsive Sidebars</h2>
@@ -204,7 +207,8 @@
 		<!-- Hidden below Tailwind's large breakpoint -->
 		<div id="sidebar-left" class="hidden lg:block">Sidebar</div>
 	</svelte:fragment>
-</AppShell>`}
+</AppShell>
+`}
 			/>
 			<aside class="alert variant-ghost-warning">
 				<i class="fa-solid fa-lightbulb text-2xl" />
@@ -227,7 +231,7 @@ function scrollHandler(event: UIEvent & { currentTarget: EventTarget & HTMLDivEl
 }
 `}
 			/>
-			<CodeBlock language="html" code={`<AppShell ... on:scroll={scrollHandler}>`} />
+			<CodeBlock language="html" code={`<AppShell ... on:scroll={scrollHandler}>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/components/avatars/+page.svelte
+++ b/src/routes/(inner)/components/avatars/+page.svelte
@@ -59,7 +59,7 @@
 				<Avatar src={imgPlaceholder} width="w-32" />
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<Avatar src="${imgPlaceholder}" width="w-32" />`} />
+				<CodeBlock language="html" code={`<Avatar src="${imgPlaceholder}" width="w-32" />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -74,7 +74,7 @@
 					<Avatar initials="JD" background="bg-primary-500" />
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<Avatar initials="JD" background="bg-primary-500" />`} />
+					<CodeBlock language="html" code={`<Avatar initials="JD" background="bg-primary-500" />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -103,16 +103,16 @@
 			<p>
 				See <a href="/actions/filters">Filters</a> to learn how to import and configure the filters action and SVG filter components.
 			</p>
-			<CodeBlock language="ts" code={`import { filter, ${actionParams.replace('#', '')} } from '@skeletonlabs/skeleton';`} />
+			<CodeBlock language="ts" code={`import { filter, ${actionParams.replace('#', '')} } from '@skeletonlabs/skeleton';\n`} />
 			<DocsPreview background="neutral" regionFooter="text-center">
 				<svelte:fragment slot="preview">
 					<Avatar src={imgPlaceholder} action={filter} {actionParams} />
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<p>Via Filter Action</p>
-					<CodeBlock language="html" code={`<Avatar src="https://i.pravatar.cc/" action={filter} actionParams="${actionParams}" />`} />
+					<CodeBlock language="html" code={`<Avatar src="https://i.pravatar.cc/" action={filter} actionParams="${actionParams}" />\n`} />
 					<p>Via Style Attribute</p>
-					<CodeBlock language="html" code={`<Avatar src="https://i.pravatar.cc/" style="filter: url({'${actionParams}'})" />`} />
+					<CodeBlock language="html" code={`<Avatar src="https://i.pravatar.cc/" style="filter: url({'${actionParams}'})" />\n`} />
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
 					<select class="select w-auto" name="filter" id="filter" bind:value={actionParams}>

--- a/src/routes/(inner)/components/conic-gradients/+page.svelte
+++ b/src/routes/(inner)/components/conic-gradients/+page.svelte
@@ -60,7 +60,7 @@ const conicStops: ConicStop[] = [
 ];
 `}
 				/>
-				<CodeBlock language="html" code={`<ConicGradient stops={conicStops}>(caption)</ConicGradient>`} />
+				<CodeBlock language="html" code={`<ConicGradient stops={conicStops}>(caption)</ConicGradient>\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -147,7 +147,7 @@ const conicStops: ConicStop[] = [
 ];
 `}
 					/>
-					<CodeBlock language="html" code={`<ConicGradient stops={conicStops} legend>(caption)</ConicGradient>`} />
+					<CodeBlock language="html" code={`<ConicGradient stops={conicStops} legend>(caption)</ConicGradient>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -185,7 +185,7 @@ const conicStops: ConicStop[] = [
 				Use the <a href="https://tailwindcss.com/docs/rotate" target="_blank" rel="noreferrer">Tailwind rotate</a> utility clases with the
 				<code>regionCone</code> property to change the starting axis position.
 			</p>
-			<CodeBlock language="html" code={`<ConicGradient ... regionCone="rotate-90" />`} />
+			<CodeBlock language="html" code={`<ConicGradient ... regionCone="rotate-90" />\n`} />
 		</div>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -38,7 +38,7 @@
 				<p class="!w-full text-center">Monitor your browser's console when adding files.</p>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<FileButton name="files" />`} />
+				<CodeBlock language="html" code={`<FileButton name="files" />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -59,21 +59,21 @@
 					<FileButton name="files" button="variant-soft-primary">Upload</FileButton>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<FileButton name="files" button="variant-soft-primary">Upload</FileButton>`} />
+					<CodeBlock language="html" code={`<FileButton name="files" button="variant-soft-primary">Upload</FileButton>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
 		<section class="space-y-4">
 			<h2>Binding Method</h2>
 			<p>Use a <code>FileList</code> to bind the file data.</p>
-			<CodeBlock language="ts" code={`let files: FileList;`} />
-			<CodeBlock language="html" code={`<FileButton ... bind:files />`} />
+			<CodeBlock language="ts" code={`let files: FileList;\n`} />
+			<CodeBlock language="html" code={`<FileButton ... bind:files />\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>On Change Event</h2>
 			<p>Use the <code>on:change</code> event to monitor file selection or changes.</p>
-			<CodeBlock language="ts" code={`function onChangeHandler(e: Event): void {\n\tconsole.log('file data:', e);\n}`} />
-			<CodeBlock language="html" code={`<FileButton ... on:change={onChangeHandler}>Upload</FileButton>`} />
+			<CodeBlock language="ts" code={`function onChangeHandler(e: Event): void {\n\tconsole.log('file data:', e);\n}\n`} />
+			<CodeBlock language="html" code={`<FileButton ... on:change={onChangeHandler}>Upload</FileButton>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/components/file-dropzone/+page.svelte
+++ b/src/routes/(inner)/components/file-dropzone/+page.svelte
@@ -40,7 +40,7 @@
 				<p class="!w-full text-center">Monitor your browser's console when adding files.</p>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<FileDropzone name="files" />`} />
+				<CodeBlock language="html" code={`<FileDropzone name="files" />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -80,14 +80,14 @@
 		<div class="space-y-4">
 			<h2>Binding Method</h2>
 			<p>Use a <code>FileList</code> to bind the file data.</p>
-			<CodeBlock language="ts" code={`let files: FileList;`} />
-			<CodeBlock language="html" code={`<FileDropzone ... bind:files />`} />
+			<CodeBlock language="ts" code={`let files: FileList;\n`} />
+			<CodeBlock language="html" code={`<FileDropzone ... bind:files />\n`} />
 		</div>
 		<div class="space-y-4">
 			<h2>On Change Event</h2>
 			<p>Use the <code>on:change</code> event to monitor file selection or changes.</p>
-			<CodeBlock language="ts" code={`function onChangeHandler(e: Event): void {\n\tconsole.log('file data:', e);\n}`} />
-			<CodeBlock language="html" code={`<FileDropzone ... on:change={onChangeHandler}>Upload</FileDropzone>`} />
+			<CodeBlock language="ts" code={`function onChangeHandler(e: Event): void {\n\tconsole.log('file data:', e);\n}\n`} />
+			<CodeBlock language="html" code={`<FileDropzone ... on:change={onChangeHandler}>Upload</FileDropzone>\n`} />
 		</div>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/components/input-chips/+page.svelte
+++ b/src/routes/(inner)/components/input-chips/+page.svelte
@@ -47,8 +47,8 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let list: string[] = ['foo', 'bar', 'fizz', 'buzz'];`} />
-				<CodeBlock language="html" code={`<InputChip bind:value={list} name="chips" placeholder="Enter any value..." />`} />
+				<CodeBlock language="ts" code={`let list: string[] = ['foo', 'bar', 'fizz', 'buzz'];\n`} />
+				<CodeBlock language="html" code={`<InputChip bind:value={list} name="chips" placeholder="Enter any value..." />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -81,8 +81,8 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="ts" code={`let flavorsWhitelist = ['vanilla', 'chocolate', 'strawberry', 'peach', 'rocky road'];`} />
-					<CodeBlock language="html" code={`<InputChip ... whitelist={flavorsWhitelist} />`} />
+					<CodeBlock language="ts" code={`let flavorsWhitelist = ['vanilla', 'chocolate', 'strawberry', 'peach', 'rocky road'];\n`} />
+					<CodeBlock language="html" code={`<InputChip ... whitelist={flavorsWhitelist} />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -108,9 +108,9 @@
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="ts"
-						code={`function isValidEmail(value: string): boolean {\n\treturn value.includes('@') && value.includes('.');\n}`}
+						code={`function isValidEmail(value: string): boolean {\n\treturn value.includes('@') && value.includes('.');\n}\n`}
 					/>
-					<CodeBlock language="html" code={`<InputChip ... validation={isValidEmail} />`} />
+					<CodeBlock language="html" code={`<InputChip ... validation={isValidEmail} />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -118,19 +118,19 @@
 		<section class="space-y-4">
 			<h2>Additional Settings</h2>
 			<p>Use the <code>max</code> property to define a maximum number of chips allowed.</p>
-			<CodeBlock language="html" code={`<InputChip ... max={3} />`} />
+			<CodeBlock language="html" code={`<InputChip ... max={3} />\n`} />
 			<p>
 				Use the <code>minlength</code> and <code>maxlength</code> properties to set the minimum/maximum number of input characters respectively.
 			</p>
-			<CodeBlock language="html" code={`<InputChip ... minlength={2} maxlength={5} />`} />
+			<CodeBlock language="html" code={`<InputChip ... minlength={2} maxlength={5} />\n`} />
 			<p>
 				By default, only a single instance of each value is allowed. If you wish to allow duplicates, set <code>allowDuplicates</code>.
 			</p>
-			<CodeBlock language="html" code={`<InputChip ... allowDuplicates />`} />
+			<CodeBlock language="html" code={`<InputChip ... allowDuplicates />\n`} />
 			<p>
 				By default, all values are trimmed and formatted lowercase. If you wish to allow uppercase, set <code>allowUpperCase</code>.
 			</p>
-			<CodeBlock language="html" code={`<InputChip ... allowUpperCase />`} />
+			<CodeBlock language="html" code={`<InputChip ... allowUpperCase />\n`} />
 		</section>
 		<hr />
 		<!-- See Also -->

--- a/src/routes/(inner)/components/listboxes/+page.svelte
+++ b/src/routes/(inner)/components/listboxes/+page.svelte
@@ -62,7 +62,7 @@
 				<div class="text-center"><code>Selected: {valueSingle}</code></div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let valueSingle: string = 'books';`} />
+				<CodeBlock language="ts" code={`let valueSingle: string = 'books';\n`} />
 				<CodeBlock
 					language="html"
 					code={`
@@ -71,7 +71,7 @@
 	<ListBoxItem bind:group={valueSingle} name="medium" value="movies">Movies</ListBoxItem>
 	<ListBoxItem bind:group={valueSingle} name="medium" value="tv">TV</ListBoxItem>
 </ListBox>
-			`}
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -108,7 +108,7 @@
 					<div class="text-center"><code>Selected: {valueMultiple.length ? valueMultiple : 'None'}</code></div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="ts" code={`let valueMultiple: string[] = ['books', 'movies'];`} />
+					<CodeBlock language="ts" code={`let valueMultiple: string[] = ['books', 'movies'];\n`} />
 					<CodeBlock
 						language="html"
 						code={`
@@ -117,7 +117,7 @@
 	<ListBoxItem bind:group={valueMultiple} name="medium" value="movies">Movies</ListBoxItem>
 	<ListBoxItem bind:group={valueMultiple} name="medium" value="tv">TV</ListBoxItem>
 </ListBox>
-			`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -133,7 +133,7 @@
 	(label)
 	<svelte:fragment slot="trail">(icon)</svelte:fragment>
 </ListBoxItem>
-			`}
+`}
 			/>
 		</section>
 		<section class="space-y-4">
@@ -163,7 +163,7 @@
 	<option value="4">Option 4</option>
 	<option value="5">Option 5</option>
 </select>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>

--- a/src/routes/(inner)/components/paginators/+page.svelte
+++ b/src/routes/(inner)/components/paginators/+page.svelte
@@ -66,7 +66,7 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`const source = [ /* any array of objects */ ];`} />
+				<CodeBlock language="ts" code={`const source = [ /* any array of objects */ ];\n`} />
 				<CodeBlock
 					language="ts"
 					code={`
@@ -77,9 +77,9 @@ let page = {
 	size: source.length,
 	amounts: [1,2,5,10],
 };
-					`}
+`}
 				/>
-				<CodeBlock language="html" code={`<Paginator bind:settings={page}></Paginator>`} />
+				<CodeBlock language="html" code={`<Paginator bind:settings={page}></Paginator>\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -100,7 +100,8 @@ let page = {
 $: paginatedSource = source.slice(
 	page.offset * page.limit,             // start
 	page.offset * page.limit + page.limit // end
-);`}
+);
+`}
 			/>
 			<CodeBlock
 				language="html"
@@ -110,7 +111,7 @@ $: paginatedSource = source.slice(
 		<li>{row}</li>
 	{/each}
 </ul>
-				`}
+`}
 			/>
 			<p>
 				Or combine with the <a href="/components/tables">Table</a> component.
@@ -125,7 +126,7 @@ let tableHeaders: string[] = ['Positions', 'Name', 'Weight', 'Symbol'];
 				language="html"
 				code={`
 <Table source={{ head: tableHeaders, body: paginatedSource }} />
-				`}
+`}
 			/>
 		</div>
 		<div class="space-y-4">
@@ -141,9 +142,9 @@ function onPageChange(e: CustomEvent): void {
 function onAmountChange(e: CustomEvent): void {
 	console.log('event:amount', e.detail);
 }
-			`}
+`}
 			/>
-			<CodeBlock language="html" code={`<Paginator ... on:page={onPageChange} on:amount={onAmountChange}></Paginator>`} />
+			<CodeBlock language="html" code={`<Paginator ... on:page={onPageChange} on:amount={onAmountChange}></Paginator>\n`} />
 		</div>
 		<hr />
 		<!-- See Also -->

--- a/src/routes/(inner)/components/progress-bars/+page.svelte
+++ b/src/routes/(inner)/components/progress-bars/+page.svelte
@@ -48,7 +48,7 @@
 				<div class="w-48 mx-auto"><input type="range" min="0" bind:value={props.value} max={props.max} step={props.step} /></div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<ProgressBar label="Progress Bar" value={${props.value}} max={${props.max}} />`} />
+				<CodeBlock language="html" code={`<ProgressBar label="Progress Bar" value={${props.value}} max={${props.max}} />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -63,8 +63,8 @@
 					<ProgressBar />
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<ProgressBar />`} />
-					<CodeBlock language="html" code={`<ProgressBar value={undefined} />`} />
+					<CodeBlock language="html" code={`<ProgressBar />\n`} />
+					<CodeBlock language="html" code={`<ProgressBar value={undefined} />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -76,7 +76,7 @@
 					<progress value={props.value} max={props.max} />
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<progress value={props.value} max={props.max} />`} />
+					<CodeBlock language="html" code={`<progress value={props.value} max={props.max} />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -35,8 +35,8 @@
 				<div class="w-48 mx-auto"><input type="range" min="0" max={props.max} step={props.step} bind:value={props.value} /></div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let value: number = 50; // %`} />
-				<CodeBlock language="html" code={`<ProgressRadial {value}>{value}%</ProgressRadial>`} />
+				<CodeBlock language="ts" code={`let value: number = 50; // %\n`} />
+				<CodeBlock language="html" code={`<ProgressRadial {value}>{value}%</ProgressRadial>\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -83,7 +83,7 @@
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="html"
-						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" />`}
+						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" />\n`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -96,8 +96,8 @@
 					<ProgressRadial width="w-28" />
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<ProgressRadial />`} />
-					<CodeBlock language="html" code={`<ProgressRadial value={undefined} />`} />
+					<CodeBlock language="html" code={`<ProgressRadial />\n`} />
+					<CodeBlock language="html" code={`<ProgressRadial value={undefined} />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/src/routes/(inner)/components/radio-groups/+page.svelte
+++ b/src/routes/(inner)/components/radio-groups/+page.svelte
@@ -56,7 +56,7 @@
 				<div class="text-center"><code>selected: {justify}</code></div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let value: number = 0;`} />
+				<CodeBlock language="ts" code={`let value: number = 0;\n`} />
 				<CodeBlock
 					language="html"
 					code={`
@@ -65,7 +65,7 @@
 	<RadioItem bind:group={value} name="justify" value={1}>(label)</RadioItem>
 	<RadioItem bind:group={value} name="justify" value={2}>(label)</RadioItem>
 </RadioGroup>
-				`}
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -92,7 +92,7 @@
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="html"
-						code={`<RadioGroup active="variant-filled-primary" hover="hover:variant-soft-primary">...</RadioGroup>`}
+						code={`<RadioGroup active="variant-filled-primary" hover="hover:variant-soft-primary">...</RadioGroup>\n`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -100,7 +100,7 @@
 		<section class="space-y-4">
 			<h2>Full Width</h2>
 			<p>Set <em>display</em> to <code>flex</code> to stretch and fill the full width.</p>
-			<CodeBlock language="html" code={`<RadioGroup display="flex">...</RadioGroup>`} />
+			<CodeBlock language="html" code={`<RadioGroup display="flex">...</RadioGroup>\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Radio Attributes</h2>
@@ -108,7 +108,7 @@
 				The Radio Item component supports Svelte's <code>$$restProps</code>, which allows for <em>required</em>, <em>disabled</em>, and any
 				other valid radio input attributes. Please note these settings are applied per item.
 			</p>
-			<CodeBlock language="html" code={`<RadioItem ... required disabled />`} />
+			<CodeBlock language="html" code={`<RadioItem ... required disabled />\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/components/range-sliders/+page.svelte
+++ b/src/routes/(inner)/components/range-sliders/+page.svelte
@@ -43,10 +43,10 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let value = 15;`} />
+				<CodeBlock language="ts" code={`let value = 15;\n`} />
 				<CodeBlock
 					language="html"
-					code={`<RangeSlider name="range-slider" bind:value={value} max={25} step={1} ticked>Label</RangeSlider>`}
+					code={`<RangeSlider name="range-slider" bind:value={value} max={25} step={1} ticked>Label</RangeSlider>\n`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -72,7 +72,7 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="ts" code={`let value = 15;\nlet max = 25;`} />
+					<CodeBlock language="ts" code={`let value = 15;\nlet max = 25;\n`} />
 					<CodeBlock
 						language="html"
 						code={`
@@ -81,7 +81,8 @@
 		<div class="font-bold">Label</div>
 		<div class="text-xs">{value} / {max}</div>
 	</div>
-</RangeSlider>`}
+</RangeSlider>
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>

--- a/src/routes/(inner)/components/slide-toggles/+page.svelte
+++ b/src/routes/(inner)/components/slide-toggles/+page.svelte
@@ -32,8 +32,8 @@
 				<SlideToggle name="slider" checked />
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let value: boolean = false;`} />
-				<CodeBlock language="html" code={`<SlideToggle name="slide" bind:checked={value} />`} />
+				<CodeBlock language="ts" code={`let value: boolean = false;\n`} />
+				<CodeBlock language="html" code={`<SlideToggle name="slide" bind:checked={value} />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -52,7 +52,7 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<SlideToggle name="slider-label" checked>(label)</SlideToggle>`} />
+					<CodeBlock language="html" code={`<SlideToggle name="slider-label" checked>(label)</SlideToggle>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -68,7 +68,7 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<SlideToggle name="slider-large" checked active="bg-primary-500" size="lg" />`} />
+					<CodeBlock language="html" code={`<SlideToggle name="slider-large" checked active="bg-primary-500" size="lg" />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -78,7 +78,7 @@
 				This component supports Svelte's <code>$$restProps</code>, which allows for <em>required</em>, <em>disabled</em>, and any other
 				valid checkbox input attributes.
 			</p>
-			<CodeBlock language="html" code={`<SlideToggle ... required disabled />`} />
+			<CodeBlock language="html" code={`<SlideToggle ... required disabled />\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/components/steppers/+page.svelte
+++ b/src/routes/(inner)/components/steppers/+page.svelte
@@ -119,7 +119,7 @@
 	</Step>
 	<!-- ... -->
 </Stepper>
-			`}
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -134,11 +134,11 @@
 		<section class="space-y-4">
 			<h2>Event Handlers</h2>
 			<h3>Complete Event</h3>
-			<CodeBlock language="ts" code={`function onCompleteHandler(e: Event): void { console.log('event:complete', e); }`} />
-			<CodeBlock language="html" code={`<Stepper on:complete={onCompleteHandler}>...</Stepper>`} />
+			<CodeBlock language="ts" code={`function onCompleteHandler(e: Event): void { console.log('event:complete', e); }\n`} />
+			<CodeBlock language="html" code={`<Stepper on:complete={onCompleteHandler}>...</Stepper>\n`} />
 			<h3>Next and Previous</h3>
 			<p>Events are fired when the next or previous steps are pressed.</p>
-			<CodeBlock language="html" code={`<Stepper on:next={onNextHandler} on:back={onBackHandler}>...</Stepper>`} />
+			<CodeBlock language="html" code={`<Stepper on:next={onNextHandler} on:back={onBackHandler}>...</Stepper>\n`} />
 		</section>
 
 		<section class="space-y-4">
@@ -147,8 +147,8 @@
 				Each Step can have a <code>locked</code> property set, when set to <em>TRUE</em> this locks progression for that step. For example, you
 				can lock a step until a form within it becomes valid.
 			</p>
-			<CodeBlock language="ts" code={`let lockedState: boolean = true;`} />
-			<CodeBlock language="html" code={`<Step locked={lockedState}>...</Step>`} />
+			<CodeBlock language="ts" code={`let lockedState: boolean = true;\n`} />
+			<CodeBlock language="html" code={`<Step locked={lockedState}>...</Step>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/components/table-of-contents/+page.svelte
+++ b/src/routes/(inner)/components/table-of-contents/+page.svelte
@@ -44,7 +44,7 @@
 				<p class="w-full text-center">Please note the example above is simulated.</p>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<TableOfContents target="#toc-target" />`} />
+				<CodeBlock language="html" code={`<TableOfContents target="#toc-target" />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -102,13 +102,13 @@
 				By default, the Table of Contents creates links for <em>all headings</em> within the target region. If you wish to ignore certain headings,
 				add the following data attribute to that heading.
 			</p>
-			<CodeBlock language="html" code={`<h2 data-toc-ignore>Ignore Me!</h2>`} />
+			<CodeBlock language="html" code={`<h2 data-toc-ignore>Ignore Me!</h2>\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Screen Reader Headings</h2>
 			<!-- prettier-ignore -->
 			<p>If you wish to include a section link that's not visibly shown within the target element, use <a href="https://tailwindcss.com/docs/screen-readers#screen-reader-only-elements" target="_blank" rel="noreferrer">Screen Reader</a> <code>.sr-only</code> class from Tailwind.</p>
-			<CodeBlock language="html" code={`<h2 class="sr-only">Include Me!</h2>`} />
+			<CodeBlock language="html" code={`<h2 class="sr-only">Include Me!</h2>\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Sticky Positioning</h2>

--- a/src/routes/(inner)/components/tables/+page.svelte
+++ b/src/routes/(inner)/components/tables/+page.svelte
@@ -92,7 +92,7 @@ const sourceData = [
 	{ position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be' },
 	{ position: 5, name: 'Boron', weight: 10.811, symbol: 'B' },
 ];
-				`}
+`}
 				/>
 				<p>Create a <code>TableSource</code> object. use <code>body: tableMapperValues(sourceData)</code> to map the data.</p>
 				<CodeBlock
@@ -108,10 +108,10 @@ const tableSimple: TableSource = {
 	// Optional: A list of footer labels.
 	foot: ['Total', '', '<code>${totalWeight}</code>']
 };
-				`}
+`}
 				/>
 				<p>Finally, we pass our table source data to the component for display.</p>
-				<CodeBlock language="html" code={`<Table source={tableSimple} />`} />
+				<CodeBlock language="html" code={`<Table source={tableSimple} />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -124,7 +124,7 @@ const tableSimple: TableSource = {
 				Use the <code>interactive</code> to make the table interactive. When a row is clicked, <code>on:selected</code> will pass the row's
 				<code>meta</code> value.
 			</p>
-			<CodeBlock language="html" code={`<Table ... interactive={true} on:selected={mySelectionHandler} />`} />
+			<CodeBlock language="html" code={`<Table ... interactive={true} on:selected={mySelectionHandler} />\n`} />
 		</section>
 		<!-- Table Utilities -->
 		<section class="space-y-4">
@@ -135,7 +135,7 @@ const tableSimple: TableSource = {
 				<Tab bind:group={$storeService} name="tableSourceMapper" value="tableSourceMapper">Source Mapper</Tab>
 				<Tab bind:group={$storeService} name="tableSourceValues" value="tableSourceValues">Source Values</Tab>
 			</TabGroup>
-			<CodeBlock language="ts" code={`import { ${$storeService} } from '@skeletonlabs/skeleton';`} />
+			<CodeBlock language="ts" code={`import { ${$storeService} } from '@skeletonlabs/skeleton';\n`} />
 			{#if $storeService === 'tableMapperValues'}
 				<!-- Table Mapper Values -->
 				<p>
@@ -151,7 +151,7 @@ tableMapperValues(sourceData, ['name', 'symbol', 'weight'])\n
 //		['Helium', 'He', '4.0026'],
 //		...
 //	]
-				`}
+`}
 				/>
 			{:else if $storeService === 'tableSourceMapper'}
 				<!-- Source Mapper -->
@@ -165,7 +165,7 @@ tableSourceMapper(sourceData, ['name', 'symbol', 'weight']);\n
 //		{ name: 'Helium', symbol: 'He', weight: '4.0026' },
 //		...
 //]
-					`}
+`}
 				/>
 			{:else if $storeService === 'tableSourceValues'}
 				<!-- Source Values -->
@@ -176,7 +176,8 @@ tableSourceMapper(sourceData, ['name', 'symbol', 'weight']);\n
 				<CodeBlock
 					language="ts"
 					code={`
-tableSourceValues(sourceData);\n
+tableSourceValues(sourceData);
+
 //[
 //		[ 1, 'Hydrogen', '1.0079', 'H' ],
 //		[ 2, 'Helium', '4.0026', 'He' ],

--- a/src/routes/(inner)/components/tabs/+page.svelte
+++ b/src/routes/(inner)/components/tabs/+page.svelte
@@ -60,7 +60,7 @@
 				</section>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let tabSet: number = 0;`} />
+				<CodeBlock language="ts" code={`let tabSet: number = 0;\n`} />
 				<CodeBlock
 					language="html"
 					code={`
@@ -79,7 +79,7 @@
 		{/if}
 	</svelte:fragment>
 </TabGroup>
-			`}
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -108,7 +108,7 @@
 					</TabGroup>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<TabGroup justify="justify-center">...<TabGroup>`} />
+					<CodeBlock language="html" code={`<TabGroup justify="justify-center">...<TabGroup>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -161,7 +161,8 @@
 		(label))
 	</Tab>
 	<!-- ... -->
-<TabGroup>`}
+<TabGroup>
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -175,9 +176,9 @@
 			</p>
 			<CodeBlock
 				language="ts"
-				code={`import { writable, type Writable } from 'svelte/store';\n\nconst tabSet: Writable<number> = writable(0);`}
+				code={`import { writable, type Writable } from 'svelte/store';\n\nconst tabSet: Writable<number> = writable(0);\n`}
 			/>
-			<CodeBlock language="ts" code={`<Tab bind:group={$tabSet} name="tab1" value={0}>(label)</Tab>`} />
+			<CodeBlock language="ts" code={`<Tab bind:group={$tabSet} name="tab1" value={0}>(label)</Tab>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/docs/colors/+page.svelte
+++ b/src/routes/(inner)/docs/colors/+page.svelte
@@ -38,12 +38,12 @@
 	<!-- Reference -->
 	<section class="space-y-4">
 		<h2>Usage</h2>
-		<CodeBlock language="html" code={`<!-- Inlined classes -->\n<div class="bg-primary-500 text-secondary-500">Skeleton</div>`} />
-		<CodeBlock language="html" code={`<!-- Tailwind opacity scale -->\n<div class="border border-primary-500/50">Skeleton</div>`} />
-		<CodeBlock language="css" code={`/* Using Tailwind @apply */\n.example { @apply text-primary-500; }`} />
+		<CodeBlock language="html" code={`<!-- Inlined classes -->\n<div class="bg-primary-500 text-secondary-500">Skeleton</div>\n`} />
+		<CodeBlock language="html" code={`<!-- Tailwind opacity scale -->\n<div class="border border-primary-500/50">Skeleton</div>\n`} />
+		<CodeBlock language="css" code={`/* Using Tailwind @apply */\n.example { @apply text-primary-500; }\n`} />
 		<CodeBlock
 			language="css"
-			code={`/* Using CSS custom properties. Note that colors are RGB values! */\nbody { background: rgba(var(--color-surface-900) / 1); }`}
+			code={`/* Using CSS custom properties. Note that colors are RGB values! */\nbody { background: rgba(var(--color-surface-900) / 1); }\n`}
 		/>
 	</section>
 </LayoutPage>

--- a/src/routes/(inner)/docs/contributing/documentation/+page.svelte
+++ b/src/routes/(inner)/docs/contributing/documentation/+page.svelte
@@ -50,7 +50,7 @@
 			code={`
 /** Set the preferred search method. */
 export let mode = 'fuzz';
-			`}
+`}
 		/>
 		<p>
 			The <code>CssClasses</code> class denotes properties that use Tailwind utility classes. Set this to aid IntelliSense features.
@@ -61,7 +61,7 @@ export let mode = 'fuzz';
 import type { CssClasses } from '$lib';\n
 /** Provide classes to set vertical item spacing. */
 export let spacing: CssClasses = 'space-y-1';
-			`}
+`}
 		/>
 
 		<p>
@@ -110,7 +110,8 @@ export let hover: string = getContext('hover');
 /**
  * @slot lead - Provide a leading element, such as an icon.
  * @slot content - Provide the alert message text.
- */`}
+ */
+`}
 		/>
 		<aside class="alert variant-ghost-warning">
 			<i class="fa-solid fa-lightbulb text-2xl" />
@@ -135,7 +136,8 @@ export let hover: string = getContext('hover');
 			language="js"
 			code={`
 /** @event {{ event: DragEvent }} dragover - When a file is dragged over. */
-dispatch('dragover', event);`}
+dispatch('dragover', event);
+`}
 		/>
 	</section>
 
@@ -190,8 +192,8 @@ dispatch('dragover', event);`}
 		<p>When showcasing examples of new features we typically handle this by one of two methods:</p>
 		<ul class="list-disc list-outside ml-8 space-y-1">
 			<li>
-				<strong>Sandbox</strong> (e.g. <a href="/components/app-shell">App Shell</a>) - which provide a dynamic and interactive
-				example that can be adjusted live.
+				<strong>Sandbox</strong> (e.g. <a href="/components/app-shell">App Shell</a>) - which provide a dynamic and interactive example that
+				can be adjusted live.
 			</li>
 			<li>
 				<strong>Static</strong> (e.g. <a href="/components/app-bar">App Bar</a>) - with multiple static examples displaying various

--- a/src/routes/(inner)/docs/contributing/style-guide/+page.svelte
+++ b/src/routes/(inner)/docs/contributing/style-guide/+page.svelte
@@ -42,12 +42,12 @@
 				>event forwarding</a
 			>.
 		</p>
-		<CodeBlock language="html" code={`<button on:click on:mouseover>Skeleton</button>`} />
+		<CodeBlock language="html" code={`<button on:click on:mouseover>Skeleton</button>\n`} />
 		<p>
 			Follow conventions set by existing components when naming slots. These should be short, semantic, and agnostic. Avoid names that are
 			too specific, such as <code>name="icon"</code>.
 		</p>
-		<CodeBlock language="html" code={`{#if $$slots.lead}<slot name="lead" />{/if}`} />
+		<CodeBlock language="html" code={`{#if $$slots.lead}<slot name="lead" />{/if}\n`} />
 		<p>
 			Use caution when inlining Tailwind color classes that would clash with custom themes. Ideally use a custom component property to allow
 			for customization.
@@ -57,7 +57,7 @@
 			code={`
 ❌ <div class="bg-orange-500">Skeleton</div>
 ✅ <div class="bg-secondary-500">Skeleton</div> 
-		`.trim()}
+`}
 		/>
 		<!-- prettier-ignore -->
 		<p>
@@ -72,7 +72,7 @@ function prunedRestProps(): any {
 	return $$restProps;
 }`}
 		/>
-		<CodeBlock language="html" code={`<button class="... {$$props.class ?? ''}" {...prunedRestProps()}>Skeleton</button>`} />
+		<CodeBlock language="html" code={`<button class="... {$$props.class ?? ''}" {...prunedRestProps()}>Skeleton</button>\n`} />
 	</section>
 
 	<hr />
@@ -98,7 +98,7 @@ export let background: string = 'bg-primary-500'; // background color
 export let color: string = 'text-primary-500'; // text color
 export let rounded: string = 'rounded-xl'; // border radius
 export let visible: boolean = false;
-		`}
+`}
 		/>
 	</section>
 
@@ -122,11 +122,14 @@ export let visible: boolean = false;
 			code={`
 let cBase: string = 'bg-surface-500 p-4 rounded'; // parent element styles
 let cLabel: string = 'text-base'; // child element label styles
-		`}
+`}
 		/>
 		<!-- Dynamic Classes -->
 		<h3>Dynamic Classes</h3>
-		<p>If you expect to set one or more styles based on the current value of a property, handle this within a reactive statement as shown below.</p>
+		<p>
+			If you expect to set one or more styles based on the current value of a property, handle this within a reactive statement as shown
+			below.
+		</p>
 		<CodeBlock
 			language="ts"
 			code={`
@@ -135,7 +138,7 @@ export let outlined: boolean;
 
 // Create a reactive property that uses a tertiary statement
 $: classesOutlined = outlined ? 'border-2 border-primary-500' : 'border-none';
-		`}
+`}
 		/>
 		<!-- Reactive Classes -->
 		<h3>Reactive Classes</h3>
@@ -145,7 +148,7 @@ $: classesOutlined = outlined ? 'border-2 border-primary-500' : 'border-none';
 			code={`
 $: classesTab = \`\${cBase} \${classesOutlined}\`; // parent element
 $: classesLabel = \`\${cBaseLabel}\`; // child element
-		`}
+`}
 		/>
 		<p>Classes are applied in three ways:</p>
 		<ol class="list-decimal list-outside ml-4 space-y-1">
@@ -159,7 +162,7 @@ $: classesLabel = \`\${cBaseLabel}\`; // child element
 <div class="tab {classesTab} {$$props.classes ?? ''}">
 	<span class="tab-label {classesLabel}">Label</span>
 </div>
-		`}
+`}
 		/>
 	</section>
 

--- a/src/routes/(inner)/docs/generator/+page.svelte
+++ b/src/routes/(inner)/docs/generator/+page.svelte
@@ -33,12 +33,14 @@
 			language="ts"
 			code={`
 // Your custom Skeleton theme:
-import '../theme.postcss';\n
+import '../theme.postcss';
+
 // This contains the bulk of Skeletons required styles:
-import '@skeletonlabs/skeleton/styles/all.css';\n
+import '@skeletonlabs/skeleton/styles/all.css';
+
 // Finally, your application's global stylesheet (sometimes labeled 'app.css')
 import '../app.postcss';
-						`}
+`}
 		/>
 	</section>
 

--- a/src/routes/(inner)/docs/get-started/SectionInstall.svelte
+++ b/src/routes/(inner)/docs/get-started/SectionInstall.svelte
@@ -25,7 +25,7 @@
 npm create skeleton-app@latest my-skeleton-app
 	- Enable SvelteKit's Typescript syntax (recommended)
 cd my-skeleton-app
-						`}
+`}
 				/>
 			{:else if $storeOnboardMethod === 'manual'}
 				<!-- prettier-ignore -->
@@ -38,14 +38,14 @@ cd my-skeleton-app
 npm create svelte@latest my-skeleton-app
 cd my-skeleton-app
 npm install
-		`}
+`}
 				/>
 				<!-- Install NPM Package -->
 				<p>
 					Install the <a href="https://www.npmjs.com/package/@skeletonlabs/skeleton" target="_blank" rel="noreferrer">Skeleton package</a> from
 					NPM.
 				</p>
-				<CodeBlock language="console" code={`npm i @skeletonlabs/skeleton --save-dev`} />
+				<CodeBlock language="console" code={`npm i @skeletonlabs/skeleton --save-dev\n`} />
 			{/if}
 		</svelte:fragment>
 	</TabGroup>

--- a/src/routes/(inner)/docs/get-started/SectionStylesheets.svelte
+++ b/src/routes/(inner)/docs/get-started/SectionStylesheets.svelte
@@ -40,12 +40,14 @@
 					language="ts"
 					code={`
 // Your selected Skeleton theme:
-import '@skeletonlabs/skeleton/themes/theme-skeleton.css';\n
+import '@skeletonlabs/skeleton/themes/theme-skeleton.css';
+
 // This contains the bulk of Skeletons required styles:
-import '@skeletonlabs/skeleton/styles/all.css';\n
+import '@skeletonlabs/skeleton/styles/all.css';
+
 // Finally, your application's global stylesheet (sometimes labeled 'app.css')
 import '../app.postcss';
-						`}
+`}
 				/>
 			{/if}
 		</svelte:fragment>

--- a/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
+++ b/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
@@ -31,7 +31,7 @@
 						<a href="https://github.com/svelte-add/tailwindcss" target="_blank" rel="noreferrer">Svelte-Add</a> makes it easy to setup Tailwind
 						in your project. Run the following commands in your terminal.
 					</p>
-					<CodeBlock language="console" code={`npx svelte-add@latest tailwindcss\nnpm install`} />
+					<CodeBlock language="console" code={`npx svelte-add@latest tailwindcss\nnpm install\n`} />
 					<!-- prettier-ignore -->
 					<p>Then open your global stylesheet in <code>/src/app.postcss</code> and remove the following three <a href="https://tailwindcss.com/docs/functions-and-directives" target="_blank" rel="noreferrer">@tailwind directives</a> introduced by Svelte-Add. These are redudant as Skeleton automatically handles these in our stylesheets for you.</p>
 					<div class="space-y-[1px]">
@@ -64,7 +64,7 @@ module.exports = {
 		...require('@skeletonlabs/skeleton/tailwind/skeleton.cjs')()
 	]
 }
-			`}
+`}
 				/>
 				<aside class="alert variant-ghost-warning">
 					<i class="fa-solid fa-triangle-exclamation text-2xl" />

--- a/src/routes/(inner)/docs/get-started/SectionThemes.svelte
+++ b/src/routes/(inner)/docs/get-started/SectionThemes.svelte
@@ -87,7 +87,7 @@
 			<p>
 				You may opt into custom fonts and backgrounds per each theme by adding this paired data attribute in <code>app.html</code>
 			</p>
-			<CodeBlock language="html" code={`<body data-theme="` + activeThemeName + `">`} />
+			<CodeBlock language="html" code={`<body data-theme="` + activeThemeName + `">\n`} />
 		{/if}
 	</div>
 

--- a/src/routes/(inner)/docs/quickstart/+page.svelte
+++ b/src/routes/(inner)/docs/quickstart/+page.svelte
@@ -24,7 +24,7 @@ npm create skeleton-app@latest my-skeleton-app
 	- Select the "Welcome" template
 cd my-skeleton-app
 npm run dev
-			`}
+`}
 		/>
 		<p>
 			By selecting the "Welcome" template the project will come preconfigured with both an <a href="/components/app-shell">App Shell</a>
@@ -38,7 +38,7 @@ npm run dev
 			Let's customize our App Shell's sidebar slot. Open <code>/src/routes/+layout.svelte</code> and add the following Tailwind utility
 			classes to the AppShell <code>slotSidebarLeft</code> prop.
 		</p>
-		<CodeBlock language="html" code={`<AppShell slotSidebarLeft="bg-surface-500/5 w-56 p-4">`} />
+		<CodeBlock language="html" code={`<AppShell slotSidebarLeft="bg-surface-500/5 w-56 p-4">\n`} />
 		<p>
 			Next, let's implement a <a href="/elements/lists">navigation list</a> within the App Shell's left sidebar slot. Append this slot
 			fragement alongside any other fragment within the <code>AppShell</code>.
@@ -93,7 +93,8 @@ npm run dev
 			code={`
 \<script\>
 	import { Avatar } from '@skeletonlabs/skeleton';
-\</script\>\n
+\</script\>
+
 <Avatar src="https://i.pravatar.cc/" />
 `}
 		/>

--- a/src/routes/(inner)/docs/styling/+page.svelte
+++ b/src/routes/(inner)/docs/styling/+page.svelte
@@ -26,7 +26,7 @@
 			This is the recommended manner to style most components. Each component provides a set of style <em>props</em> (read: properties) that
 			allow you to override the default style classes. See a list of available options under the "Props" tab per each feature in Skeleton.
 		</p>
-		<CodeBlock language="html" code={`<ExampleComponent background="bg-secondary-500 md:bg-primary-500">Skeleton</ExampleComponent>`} />
+		<CodeBlock language="html" code={`<ExampleComponent background="bg-secondary-500 md:bg-primary-500">Skeleton</ExampleComponent>\n`} />
 		<blockquote>
 			TIP: You may provide multiple utility classes per each prop, as well as use variations such as <code>dark:bg-green-500</code>.
 		</blockquote>
@@ -40,7 +40,7 @@
 			If a style prop is not available, you can still provide arbitrary utility classes via a standard <code>class</code> attribute. These styles
 			are always applied to the parent element in the component template.
 		</p>
-		<CodeBlock language="html" code={`<ExampleComponent class="text-3xl px-10 py-5">Skeleton</ExampleComponent>`} />
+		<CodeBlock language="html" code={`<ExampleComponent class="text-3xl px-10 py-5">Skeleton</ExampleComponent>\n`} />
 	</section>
 
 	<hr />
@@ -54,7 +54,7 @@
 				rel="noreferrer">Tailwind's arbitrary variant syntax</a
 			>.
 		</p>
-		<CodeBlock language="html" code={`<ExampleComponent class="[&>.foo-label]:p-4">...</ExampleComponent>`} />
+		<CodeBlock language="html" code={`<ExampleComponent class="[&>.foo-label]:p-4">...</ExampleComponent>\n`} />
 		<p>This will affect the Parent > .foo-label element and apply a Tailwind class of <code>p-4</code>.</p>
 	</section>
 
@@ -66,9 +66,9 @@
 			Skeleton components include selector classes, such as <code>.avatar-image</code> within the
 			<a href="/components/avatars">Avatar component</a>. Please note that selector classes are always the first listed.
 		</p>
-		<CodeBlock language="html" code={`<img class="avatar-image ...">...</img>`} />
+		<CodeBlock language="html" code={`<img class="avatar-image ...">...</img>\n`} />
 		<p>Use these selector classes to target global style overrides to all instances of this feature in your global stylesheet.</p>
-		<CodeBlock language="css" code={`.avatar-image { @apply border-2 border-red-500; }`} />
+		<CodeBlock language="css" code={`.avatar-image { @apply border-2 border-red-500; }\n`} />
 		<blockquote>
 			In some cases you may need to use <code>!</code>
 			<a href="https://tailwindcss.com/docs/configuration#important-modifier" target="_blank" rel="noreferrer">important</a> or style light and

--- a/src/routes/(inner)/docs/variants/+page.svelte
+++ b/src/routes/(inner)/docs/variants/+page.svelte
@@ -21,7 +21,7 @@
 		<section class="space-y-4">
 			<h2>Usage</h2>
 			<p>Implement using <code>.variant-[style]-[color]</code>. Automatically applies an accessible text or SVG fill color.</p>
-			<CodeBlock language="html" code={`<div class="variant-filled-primary">primary</div>`} />
+			<CodeBlock language="html" code={`<div class="variant-filled-primary">primary</div>\n`} />
 		</section>
 		<!-- Filled -->
 		<section class="space-y-4">
@@ -39,13 +39,13 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<div class="variant-filled-primary">primary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-filled-secondary">secondary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-filled-tertiary">tertiary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-filled-success">success</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-filled-warning">warning</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-filled-error">error</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-filled-surface">surface</div>`} />
+					<CodeBlock language="html" code={`<div class="variant-filled-primary">primary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-filled-secondary">secondary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-filled-tertiary">tertiary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-filled-success">success</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-filled-warning">warning</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-filled-error">error</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-filled-surface">surface</div>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -65,13 +65,13 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<div class="variant-ghost-primary">primary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ghost-secondary">secondary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ghost-tertiary">tertiary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ghost-success">success</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ghost-warning">warning</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ghost-error">error</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ghost-surface">surface</div>`} />
+					<CodeBlock language="html" code={`<div class="variant-ghost-primary">primary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ghost-secondary">secondary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ghost-tertiary">tertiary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ghost-success">success</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ghost-warning">warning</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ghost-error">error</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ghost-surface">surface</div>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -91,13 +91,13 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<div class="variant-soft-primary">primary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-soft-secondary">secondary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-soft-tertiary">tertiary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-soft-success">success</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-soft-warning">warning</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-soft-error">error</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-soft-surface">surface</div>`} />
+					<CodeBlock language="html" code={`<div class="variant-soft-primary">primary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-soft-secondary">secondary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-soft-tertiary">tertiary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-soft-success">success</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-soft-warning">warning</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-soft-error">error</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-soft-surface">surface</div>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -117,13 +117,13 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<div class="variant-ringed-primary">primary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ringed-secondary">secondary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ringed-tertiary">tertiary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ringed-success">success</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ringed-warning">warning</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ringed-error">error</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-ringed-surface">surface</div>`} />
+					<CodeBlock language="html" code={`<div class="variant-ringed-primary">primary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ringed-secondary">secondary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ringed-tertiary">tertiary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ringed-success">success</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ringed-warning">warning</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ringed-error">error</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-ringed-surface">surface</div>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -152,13 +152,13 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<div class="variant-glass-primary">primary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-glass-secondary">secondary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-glass-tertiary">tertiary</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-glass-success">success</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-glass-warning">warning</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-glass-error">error</div>`} />
-					<CodeBlock language="html" code={`<div class="variant-glass-surface">surface</div>`} />
+					<CodeBlock language="html" code={`<div class="variant-glass-primary">primary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-glass-secondary">secondary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-glass-tertiary">tertiary</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-glass-success">success</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-glass-warning">warning</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-glass-error">error</div>\n`} />
+					<CodeBlock language="html" code={`<div class="variant-glass-surface">surface</div>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/src/routes/(inner)/elements/alerts/+page.svelte
+++ b/src/routes/(inner)/elements/alerts/+page.svelte
@@ -64,7 +64,7 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="ts" code={`let visible: boolean = true;`} />
+				<CodeBlock language="ts" code={`let visible: boolean = true;\n`} />
 				<CodeBlock
 					language="html"
 					code={`
@@ -81,7 +81,7 @@
         <div class="alert-actions">(buttons)</div>
     </aside>
 {/if}
-            `}
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -96,17 +96,17 @@
 			<h2>Sections</h2>
 			<h3>Message Content</h3>
 			<p>Use the <code>.alert-message</code> to create a vertical set of text information that fills the available width of the alert.</p>
-			<CodeBlock language="html" code={`<div class="alert-message">\n\t<h3>(title)</h3>\n\t<p>{message}</p>\n</div>`} />
-			<CodeBlock language="html" code={`<h3 class="alert-message">(title)</h3>`} />
+			<CodeBlock language="html" code={`<div class="alert-message">\n\t<h3>(title)</h3>\n\t<p>{message}</p>\n</div>\n`} />
+			<CodeBlock language="html" code={`<h3 class="alert-message">(title)</h3>\n`} />
 			<h3>Action Buttons</h3>
 			<p>Use the <code>.alert-actions</code> to create a trailing area to house interactive action buttons.</p>
-			<CodeBlock language="html" code={`<div class="alert-actions">(buttons)</div>`} />
+			<CodeBlock language="html" code={`<div class="alert-actions">(buttons)</div>\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Animation</h2>
 			<!-- prettier-ignore -->
 			<p><a href="https://svelte.dev/tutorial/transition" target="_blank" rel="noreferrer">Svelte Transitions</a> can provide smooth transition animations when the alert state changes.</p>
-			<CodeBlock language="html" code={`<aside class="alert" transition:fade|local={{ duration: 200 }}>(content)</div>`} />
+			<CodeBlock language="html" code={`<aside class="alert" transition:fade|local={{ duration: 200 }}>(content)</div>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/elements/badges/+page.svelte
+++ b/src/routes/(inner)/elements/badges/+page.svelte
@@ -46,7 +46,7 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<span class="badge variant-filled">Badge</span>`} />
+				<CodeBlock language="html" code={`<span class="badge variant-filled">Badge</span>\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -61,7 +61,7 @@
 					<span class="badge-icon variant-filled"><i class="fa-solid fa-skull" /></span>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<span class="badge-icon variant-filled"> (icon) </span>`} />
+					<CodeBlock language="html" code={`<span class="badge-icon variant-filled"> (icon) </span>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 			<section class="space-y-4">
@@ -82,7 +82,7 @@
 	<span class="badge-icon variant-filled-warning absolute -top-0 -right-0 z-10">2</span>
 	<Avatar />
 </div>
-					`}
+`}
 						/>
 					</svelte:fragment>
 				</DocsPreview>

--- a/src/routes/(inner)/elements/breadcrumbs/+page.svelte
+++ b/src/routes/(inner)/elements/breadcrumbs/+page.svelte
@@ -49,7 +49,7 @@
 	<li class="crumb-separator" aria-hidden>&rsaquo;</li>
 	<li>Breadcrumbs</li>
 </ol>
-				`}
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -84,7 +84,7 @@
 	<li class="crumb-separator" aria-hidden>/</li>
 	<li>Article</li>
 </ol>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -115,7 +115,7 @@
 	<li class="crumb-separator" aria-hidden>&rsaquo;</li>
 	<li>Current</li>
 </ol>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -150,7 +150,7 @@
 	<li class="crumb-separator" aria-hidden>&rsaquo;</li>
 	<li>Profile</li>
 </ol>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -161,7 +161,7 @@
 				Breadcrumbs are responsive by default and will auto-hide all but the last two crumb elements on small screens. If you wish to
 				disable this behavior, replace <code>.breadcrumb</code> with <code>.breadcrumb-nonresponsive</code>.
 			</p>
-			<CodeBlock language="html" code={`<ol class="breadcrumb-nonresponsive">...</ol>`} />
+			<CodeBlock language="html" code={`<ol class="breadcrumb-nonresponsive">...</ol>\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Using #Each Loops</h2>
@@ -177,7 +177,7 @@ const myBreadcrumbs = [
 	{ label: 'Fizz', link: '/fizz' },
 	{ label: 'Buzz', link: '/buzz' }
 ];
-			`}
+`}
 			/>
 			<CodeBlock
 				language="html"
@@ -193,7 +193,7 @@ const myBreadcrumbs = [
 		{/if}
 	{/each}
 </ol>
-			`}
+`}
 			/>
 		</section>
 	</svelte:fragment>

--- a/src/routes/(inner)/elements/buttons/+page.svelte
+++ b/src/routes/(inner)/elements/buttons/+page.svelte
@@ -156,7 +156,7 @@
 					/>
 					<!-- prettier-ignore -->
 					<p>Customize the vertical dividers using <a href="https://tailwindcss.com/blog/tailwindcss-v3-1#arbitrary-values-but-for-variants" target="_blank" rel="noreferrer">Tailwind's arbitrary variant syntax</a>.</p>
-					<CodeBlock language="html" code={`<div class="btn-group variant-ghost-primary [&>*+*]:border-red-500">...</div>`} />
+					<CodeBlock language="html" code={`<div class="btn-group variant-ghost-primary [&>*+*]:border-red-500">...</div>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 			<DocsPreview background="neutral">
@@ -187,7 +187,7 @@
 			<p>
 				While using native anchor elements, you can take advantage of <a href="https://kit.svelte.dev/docs/link-options" target="_blank" rel="noreferrer">SvelteKit's Link Options</a> such as a <em>prefetch</em>.
 			</p>
-			<CodeBlock language="html" code={`<a href="/" class="btn variant-filled" data-sveltekit-preload-data="hover">Button</a>`} />
+			<CodeBlock language="html" code={`<a href="/" class="btn variant-filled" data-sveltekit-preload-data="hover">Button</a>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/elements/cards/+page.svelte
+++ b/src/routes/(inner)/elements/cards/+page.svelte
@@ -80,8 +80,8 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<div class="card p-4">Basic</div>`} />
-				<CodeBlock language="html" code={`<a href="/" class="card p-4">Link</a>`} />
+				<CodeBlock language="html" code={`<div class="card p-4">Basic</div>\n`} />
+				<CodeBlock language="html" code={`<a href="/" class="card p-4">Link</a>\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -116,7 +116,7 @@
 	<section class="p-4">(content)</section>
 	<footer class="card-footer">(footer)</footer>
 </div>
-				`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -131,7 +131,7 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<a class="block card card-hover p-4" href="/elements/cards">Hover Me!</a>`} />
+					<CodeBlock language="html" code={`<a class="block card card-hover p-4" href="/elements/cards">Hover Me!</a>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/src/routes/(inner)/elements/chips/+page.svelte
+++ b/src/routes/(inner)/elements/chips/+page.svelte
@@ -70,7 +70,7 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<span class="chip variant-filled">Chip</span>`} />
+				<CodeBlock language="html" code={`<span class="chip variant-filled">Chip</span>\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -111,8 +111,8 @@
 		<section class="space-y-4">
 			<h2>State</h2>
 			<p>Dynamically modify chip classes to represent state. See the examples below using this technique.</p>
-			<CodeBlock language="ts" code={`$: chipStateClass = (someCondition) ? 'variant-filled-primary' : 'variant-soft-primary';`} />
-			<CodeBlock language="html" code={`<span class="chip {chipStateClass}">...</span>`} />
+			<CodeBlock language="ts" code={`$: chipStateClass = (someCondition) ? 'variant-filled-primary' : 'variant-soft-primary';\n`} />
+			<CodeBlock language="html" code={`<span class="chip {chipStateClass}">...</span>\n`} />
 			<!-- Single Selection -->
 			<h3>Single Selection</h3>
 			<DocsPreview background="neutral">
@@ -132,7 +132,7 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="ts" code={`let color = 'red';`} />
+					<CodeBlock language="ts" code={`let color = 'red';\n`} />
 					<CodeBlock
 						language="html"
 						code={`

--- a/src/routes/(inner)/elements/core/+page.svelte
+++ b/src/routes/(inner)/elements/core/+page.svelte
@@ -25,7 +25,7 @@
 					>design token</a
 				> class. Adjust your theme's color scheme to customize. This affects both light and dark mode.
 			</p>
-			<CodeBlock language="css" code={`body { @apply bg-surface-50-900-token; }`} />
+			<CodeBlock language="css" code={`body { @apply bg-surface-50-900-token; }\n`} />
 			<aside class="alert variant-ghost-warning">
 				<i class="fa-solid fa-lightbulb text-2xl" />
 				<div class="alert-message">Consider pairing this with a <strong>CSS Mesh Gradient</strong> or other background image.</div>
@@ -51,7 +51,7 @@
 					<p class="w-full text-center">Try selecting the text above.</p>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="css" code={`::selection { @apply bg-primary-500/30; }`} />
+					<CodeBlock language="css" code={`::selection { @apply bg-primary-500/30; }\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -70,7 +70,7 @@
 					<button class="btn variant-soft">Tap Me</button>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="css" code={`html { -webkit-tap-highlight-color: rgba(128, 128, 128, 0.5); }`} />
+					<CodeBlock language="css" code={`html { -webkit-tap-highlight-color: rgba(128, 128, 128, 0.5); }\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -121,7 +121,7 @@
 		Lorem ipsum, dolor sit...
 	</p>
 </div>			
-			`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -154,7 +154,7 @@
 <hr class="!border-t-2" />
 <hr class="!border-t-4" />
 <hr class="!border-t-8" />
-					`}
+`}
 						/>
 					</svelte:fragment>
 				</DocsPreview>
@@ -175,7 +175,7 @@
 <hr class="!border-dashed" />
 <hr class="!border-dotted" />
 <hr class="!border-t-8 !border-double" />
-					`}
+`}
 						/>
 					</svelte:fragment>
 				</DocsPreview>
@@ -193,7 +193,7 @@
 						</div>
 					</svelte:fragment>
 					<svelte:fragment slot="source">
-						<CodeBlock language="html" code={`<span class="divider-vertical h-20" />`} />
+						<CodeBlock language="html" code={`<span class="divider-vertical h-20" />\n`} />
 					</svelte:fragment>
 				</DocsPreview>
 			</div>

--- a/src/routes/(inner)/elements/forms/+page.svelte
+++ b/src/routes/(inner)/elements/forms/+page.svelte
@@ -69,7 +69,7 @@
 	<span>Input</span>
 	<input class="input" type="text" placeholder="Input" />
 </label>
-				`}
+`}
 				/>
 				<CodeBlock
 					language="html"
@@ -84,7 +84,7 @@
 		<option value="5">Option 5</option>
 	</select>
 </label>
-				`}
+`}
 				/>
 				<CodeBlock
 					language="html"
@@ -93,7 +93,7 @@
 	<span>Textarea</span>
 	<textarea class="textarea" rows="4" placeholder="Lorem ipsum dolor sit amet consectetur adipisicing elit." />
 </label>
-				`}
+`}
 				/>
 			</svelte:fragment>
 		</DocsPreview>
@@ -130,7 +130,7 @@ module.exports = {
 		// NOTE: Insert above the 'skeleton.cjs' plugin
 	],
 }
-				`}
+`}
 				/>
 			</div>
 		</section>
@@ -155,7 +155,7 @@ module.exports = {
 	<span>Label</span>
 	<!-- (input here) -->
 </label>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -180,7 +180,7 @@ module.exports = {
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<input class="input" />`} />
+					<CodeBlock language="html" code={`<input class="input" />\n`} />
 					<pre>Attributes: {JSON.stringify(currentInput, null, 2)}</pre>
 				</svelte:fragment>
 			</DocsPreview>
@@ -202,8 +202,8 @@ module.exports = {
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<input class="input" type="file" />`} />
-					<CodeBlock language="html" code={`<input class="input" type="file" multiple />`} />
+					<CodeBlock language="html" code={`<input class="input" type="file" />\n`} />
+					<CodeBlock language="html" code={`<input class="input" type="file" multiple />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -220,7 +220,7 @@ module.exports = {
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<textarea class="textarea" rows="4" placeholder="Enter some long form content." />`} />
+					<CodeBlock language="html" code={`<textarea class="textarea" rows="4" placeholder="Enter some long form content." />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -273,7 +273,7 @@ module.exports = {
 	<option value="4">Option 4</option>
 	<option value="5">Option 5</option>
 </select>
-					`}
+`}
 					/>
 					<CodeBlock
 						language="html"
@@ -285,7 +285,7 @@ module.exports = {
 	<option value="4">Option 4</option>
 	<option value="5">Option 5</option>
 </select>
-					`}
+`}
 					/>
 					<CodeBlock
 						language="html"
@@ -297,7 +297,7 @@ module.exports = {
 	<option value="4">Option 4</option>
 	<option value="5">Option 5</option>
 </select>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -340,7 +340,7 @@ module.exports = {
 		<p>Option 3</p>
 	</label>
 </div>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -383,7 +383,7 @@ module.exports = {
 		<p>Option 3</p>
 	</label>
 </div>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -398,7 +398,7 @@ module.exports = {
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<input type="range" value="75" max="100" />`} />
+					<CodeBlock language="html" code={`<input type="range" value="75" max="100" />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -420,7 +420,7 @@ module.exports = {
 	<input class="input" type="color" bind:value={colorValue} />
 	<input class="input" type="text" bind:value={colorValue} readonly tabindex="-1" />
 </div>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -497,7 +497,7 @@ module.exports = {
 	<input type="search" placeholder="Search..." />
 	<button class="variant-filled-secondary">Submit</button>
 </div>
-		`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -533,9 +533,9 @@ module.exports = {
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<input ... class="input variant-form-material" />`} />
-					<CodeBlock language="html" code={`<select ... class="select variant-form-material" />`} />
-					<CodeBlock language="html" code={`<textarea ... class="textarea variant-form-material" />`} />
+					<CodeBlock language="html" code={`<input ... class="input variant-form-material" />\n`} />
+					<CodeBlock language="html" code={`<select ... class="select variant-form-material" />\n`} />
+					<CodeBlock language="html" code={`<textarea ... class="textarea variant-form-material" />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -564,9 +564,9 @@ module.exports = {
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<input ... class="input-success" />`} />
-					<CodeBlock language="html" code={`<input ... class="input-warning" />`} />
-					<CodeBlock language="html" code={`<input ... class="input-error" />`} />
+					<CodeBlock language="html" code={`<input ... class="input-success" />\n`} />
+					<CodeBlock language="html" code={`<input ... class="input-warning" />\n`} />
+					<CodeBlock language="html" code={`<input ... class="input-error" />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/src/routes/(inner)/elements/gradient-headings/+page.svelte
+++ b/src/routes/(inner)/elements/gradient-headings/+page.svelte
@@ -74,7 +74,7 @@
 }
 `}
 			/>
-			<CodeBlock language="html" code={`<h1><span class="gradient-heading">Skeleton</span></h1>`} />
+			<CodeBlock language="html" code={`<h1><span class="gradient-heading">Skeleton</span></h1>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/elements/lists/+page.svelte
+++ b/src/routes/(inner)/elements/lists/+page.svelte
@@ -191,8 +191,8 @@
 				</svelte:fragment>
 			</DocsPreview>
 			<p>To highlight active state, we recommend conditionally applying a background color to the anchor tag.</p>
-			<CodeBlock language="ts" code={`$: classesActive = (href: string) => (href === $page.url.pathname ? '!bg-primary-500' : '');`} />
-			<CodeBlock language="html" code={`<a {href} class="{classesActive(href)}">Page</a>`} />
+			<CodeBlock language="ts" code={`$: classesActive = (href: string) => (href === $page.url.pathname ? '!bg-primary-500' : '');\n`} />
+			<CodeBlock language="html" code={`<a {href} class="{classesActive(href)}">Page</a>\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/elements/logo-clouds/+page.svelte
+++ b/src/routes/(inner)/elements/logo-clouds/+page.svelte
@@ -148,8 +148,8 @@
 					</section>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<div class="logo-cloud [&>.logo-item]:bg-red-500">...</div>`} />
-					<CodeBlock language="html" code={`<div class="logo-cloud [&>.logo-item]:variant-filled-secondary">...</div>`} />
+					<CodeBlock language="html" code={`<div class="logo-cloud [&>.logo-item]:bg-red-500">...</div>\n`} />
+					<CodeBlock language="html" code={`<div class="logo-cloud [&>.logo-item]:variant-filled-secondary">...</div>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/src/routes/(inner)/elements/placeholders/+page.svelte
+++ b/src/routes/(inner)/elements/placeholders/+page.svelte
@@ -56,7 +56,7 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<div class="placeholder" />`} />
+				<CodeBlock language="html" code={`<div class="placeholder" />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -126,7 +126,7 @@
 					<div class="placeholder-circle w-16" class:animate-pulse={animate} />
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<div class="placeholder-circle w-16" />`} />
+					<CodeBlock language="html" code={`<div class="placeholder-circle w-16" />\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -134,7 +134,7 @@
 		<div class="space-y-4">
 			<h2>Animated</h2>
 			<p>Apply the <code>.animate-pulse</code> utility class provided by Tailwind.</p>
-			<CodeBlock language="html" code={`<div class="placeholder animate-pulse" />`} />
+			<CodeBlock language="html" code={`<div class="placeholder animate-pulse" />\n`} />
 		</div>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/elements/tables/+page.svelte
+++ b/src/routes/(inner)/elements/tables/+page.svelte
@@ -137,7 +137,7 @@
 						<p>
 							Apply classes <code>.table-compact</code> or <code>.table-comfortable</code> to the <em>table</em> for tighter or looser row spacing.
 						</p>
-						<CodeBlock language="html" code={`<table class="table-compact">...</table>`} />
+						<CodeBlock language="html" code={`<table class="table-compact">...</table>\n`} />
 					{:else if tabSet === 1}
 						<!-- Hover -->
 						<p>
@@ -145,28 +145,28 @@
 							You can also use the <code>.table-interactive</code> class if the table rows is intended to be interactive on click. Avoid using
 							both classes.
 						</p>
-						<CodeBlock language="html" code={`<table class="table-hover">...</table>`} />
-						<CodeBlock language="html" code={`<table class="table-interactive">...</table>`} />
+						<CodeBlock language="html" code={`<table class="table-hover">...</table>\n`} />
+						<CodeBlock language="html" code={`<table class="table-interactive">...</table>\n`} />
 					{:else if tabSet === 2}
 						<!-- Selection -->
 						<p>Apply the <code>.table-row-checked</code> class to a table body row to indicate an active selection state.</p>
-						<CodeBlock language="html" code={`<tr class=".table-row-checked">...</tr>`} />
+						<CodeBlock language="html" code={`<tr class=".table-row-checked">...</tr>\n`} />
 					{:else if tabSet === 3}
 						<!-- Fit -->
 						<p>
 							Use the <code>.table-cell-fit</code> class on a cell element to fit the cell to the content widths. This can be useful for small
 							columns that contain elements such as avatars or IDs. Be sure to apply to both the table header and table cell.
 						</p>
-						<CodeBlock language="html" code={`<th class="table-cell-fit">Avatar</th>`} />
-						<CodeBlock language="html" code={`<td class="table-cell-fit">(avatar)</td>`} />
+						<CodeBlock language="html" code={`<th class="table-cell-fit">Avatar</th>\n`} />
+						<CodeBlock language="html" code={`<td class="table-cell-fit">(avatar)</td>\n`} />
 					{:else if tabSet === 4}
 						<!-- Sorting -->
 						<p>
 							Apply <code>.table-sort-asc</code> or <code>.table-sort-dsc</code> to the <em>table head</em> elements to sort by ascending or
 							descending order respectively.
 						</p>
-						<CodeBlock language="html" code={`<th class="table-sort-asc">Skeleton</th>`} />
-						<CodeBlock language="html" code={`<th class="table-sort-dsc">Skeleton</th>`} />
+						<CodeBlock language="html" code={`<th class="table-sort-asc">Skeleton</th>\n`} />
+						<CodeBlock language="html" code={`<th class="table-sort-dsc">Skeleton</th>\n`} />
 					{/if}
 				</svelte:fragment>
 			</TabGroup>

--- a/src/routes/(inner)/elements/typography/+page.svelte
+++ b/src/routes/(inner)/elements/typography/+page.svelte
@@ -37,7 +37,7 @@
 <h2 class="unstyled">Unstyled H2</h2>
 <p class="unstyled">Unstyled paragraph element.</p>
 <a href="/" class="unstyled">Unstyled anchor element.</a>
-					`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -72,7 +72,7 @@
 <h4>Skeleton H4</h4>
 <h5>Skeleton H5</h5>
 <h6>Skeleton H6</h6>
-						`}
+`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
@@ -85,7 +85,7 @@
 					<p class="w-full text-center">The quick brown fox jumps over the lazy dog.</p>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<p>The quick brown fox jumps over the lazy dog.</p>`} />
+					<CodeBlock language="html" code={`<p>The quick brown fox jumps over the lazy dog.</p>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -99,7 +99,7 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<a href="/">Anchor</a>`} />
+					<CodeBlock language="html" code={`<a href="/">Anchor</a>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -114,7 +114,7 @@
 					</blockquote>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<blockquote>Skeleton</blockquote>`} />
+					<CodeBlock language="html" code={`<blockquote>Skeleton</blockquote>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -126,7 +126,7 @@
 					<pre class="w-full">The quick brown fox jumps over the lazy dog.</pre>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<pre>The quick brown fox jumps over the lazy dog.</pre>`} />
+					<CodeBlock language="html" code={`<pre>The quick brown fox jumps over the lazy dog.</pre>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -138,7 +138,7 @@
 					<div class="text-center"><code>.myExampleClass</code></div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<code>.myExampleClass</code>`} />
+					<CodeBlock language="html" code={`<code>.myExampleClass</code>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -152,7 +152,7 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`Press <kbd>⌘ + C</kbd> to copy.`} />
+					<CodeBlock language="html" code={`Press <kbd>⌘ + C</kbd> to copy.\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
@@ -167,10 +167,10 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<del><s>Always</s> Gonna Give You Up</del>`} />
+					<CodeBlock language="html" code={`<del><s>Always</s> Gonna Give You Up</del>\n`} />
 					<CodeBlock
 						language="html"
-						code={`<ins cite="https://youtu.be/dQw4w9WgXcQ" datetime="10-31-2022">Never Gonna Give You Up</ins>`}
+						code={`<ins cite="https://youtu.be/dQw4w9WgXcQ" datetime="10-31-2022">Never Gonna Give You Up</ins>\n`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>

--- a/src/routes/(inner)/template/+page.svelte
+++ b/src/routes/(inner)/template/+page.svelte
@@ -39,7 +39,7 @@
 				<p>(feature)</p>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`(code snippet)`} />
+				<CodeBlock language="html" code={`(code snippet)\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -49,12 +49,12 @@
 		<section class="space-y-4">
 			<h2>Title 1</h2>
 			<p>Describe how to use the feature.</p>
-			<CodeBlock language="html" code={`(code)`} />
+			<CodeBlock language="html" code={`(code)\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Title 2</h2>
 			<p>Describe how to use the feature.</p>
-			<CodeBlock language="html" code={`(code)`} />
+			<CodeBlock language="html" code={`(code)\n`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/src/routes/(inner)/utilities/codeblocks/+page.svelte
+++ b/src/routes/(inner)/utilities/codeblocks/+page.svelte
@@ -27,15 +27,15 @@
 		<DocsPreview>
 			<svelte:fragment slot="preview">
 				<div class="w-full space-y-4">
-					<CodeBlock language="html" code={`<div>This is meta</div>`} />
-					<CodeBlock language="css" code={`.skeleton { color: #bada55; }`} />
-					<CodeBlock language="ts" code={`const skeleton: string = 'awesome';`} />
+					<CodeBlock language="html" code={`<div>This is meta</div>\n`} />
+					<CodeBlock language="css" code={`.skeleton { color: #bada55; }\n`} />
+					<CodeBlock language="ts" code={`const skeleton: string = 'awesome';\n`} />
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<CodeBlock language="html" code={\`<div>This is meta</div>\`}></CodeBlock>`} />
-				<CodeBlock language="html" code={`<CodeBlock language="css" code={\`.skeleton { color: #bada55; }\`}></CodeBlock>`} />
-				<CodeBlock language="html" code={`<CodeBlock language="ts" code={\`const skeleton: string = 'awesome';\`}></CodeBlock>`} />
+				<CodeBlock language="html" code={`<CodeBlock language="html" code={\`<div>This is meta</div>\`}></CodeBlock>\n`} />
+				<CodeBlock language="html" code={`<CodeBlock language="css" code={\`.skeleton { color: #bada55; }\`}></CodeBlock>\n`} />
+				<CodeBlock language="html" code={`<CodeBlock language="ts" code={\`const skeleton: string = 'awesome';\`}></CodeBlock>\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -52,15 +52,15 @@
 		<section class="space-y-4">
 			<h2>Configure Your Project</h2>
 			<p>Apply the following changes to your app's root component in <code>/src/routes/+layout.svelte</code>.</p>
-			<CodeBlock language="ts" code={`import hljs from 'highlight.js';`} />
+			<CodeBlock language="ts" code={`import hljs from 'highlight.js';\n`} />
 			<p>
 				Import any <a href="https://github.com/highlightjs/highlight.js/tree/main/src/styles" target="_blank" rel="noreferrer"
 					>Highlight.js CSS theme</a
 				> of your choice.
 			</p>
-			<CodeBlock language="ts" code={`import 'highlight.js/styles/github-dark.css';`} />
+			<CodeBlock language="ts" code={`import 'highlight.js/styles/github-dark.css';\n`} />
 			<p>Finally, import the CodeBlock's writable store and pass a referenced to Highlight.js.</p>
-			<CodeBlock language="ts" code={`import { storeHighlightJs } from '@skeletonlabs/skeleton';\n\nstoreHighlightJs.set(hljs);`} />
+			<CodeBlock language="ts" code={`import { storeHighlightJs } from '@skeletonlabs/skeleton';\n\nstoreHighlightJs.set(hljs);\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Supported Languages</h2>

--- a/src/routes/(inner)/utilities/data-tables/+page.svelte
+++ b/src/routes/(inner)/utilities/data-tables/+page.svelte
@@ -156,7 +156,8 @@ import {
 	// Svelte Actions
 	tableInteraction,
 	tableA11y
-} from '@skeletonlabs/skeleton';`}
+} from '@skeletonlabs/skeleton';
+`}
 			/>
 			<!-- prettier-ignore -->
 			<p>
@@ -177,7 +178,8 @@ const sourceData = [
 	{ position: 8, name: 'Oxygen', weight: 15.9994, symbol: 'O' },
 	{ position: 9, name: 'Fluorine', weight: 18.9984, symbol: 'F' },
 	{ position: 10, name: 'Neon', weight: 20.1797, symbol: 'Ne' }
-];`}
+];
+`}
 			/>
 			<p>
 				We'll make use of Skeleton's <a href="/elements/tables">table element classes</a> to provide base styles to our native HTML table element.
@@ -199,7 +201,8 @@ const sourceData = [
 			</tr>
 		</tbody>
 	</table>
-</div>`}
+</div>
+`}
 			/>
 		</section>
 		<section class="space-y-4">
@@ -225,7 +228,8 @@ const dataTableStore = createDataTableStore(
 	}
 );\n
 // This automatically handles search, sort, etc when the model updates.
-dataTableStore.subscribe((model) => dataTableHandler(model));`}
+dataTableStore.subscribe((model) => dataTableHandler(model));
+`}
 			/>
 			<p>
 				Next, we'll update our table markup to display our model data. Implement matching parent headings and body cells. We'll use an <code
@@ -252,7 +256,8 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 			<!-- ... --->
 		</tr>
 	{/each}
-</tbody>`}
+</tbody>
+`}
 			/>
 		</section>
 		<hr />
@@ -263,7 +268,7 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 				To update the content of the data table, just call the <code>dataTableStore.updateSource()</code> method and pass in your new source
 				data.
 			</p>
-			<CodeBlock language="ts" code={`dataTableStore.updateSource(newSourceData)`} />
+			<CodeBlock language="ts" code={`dataTableStore.updateSource(newSourceData)\n`} />
 		</section>
 		<!-- Search -->
 		<section class="space-y-4">
@@ -272,7 +277,7 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 				To implement search, bind <code>$dataTableStore.search</code> to any search input. You may add this anywhere as long as it has scope
 				of your table model (the store).
 			</p>
-			<CodeBlock language="html" code={`<input bind:value={$dataTableStore.search} type="search" placeholder="Search..." />`} />
+			<CodeBlock language="html" code={`<input bind:value={$dataTableStore.search} type="search" placeholder="Search..." />\n`} />
 		</section>
 		<!-- Sort -->
 		<section class="space-y-4">
@@ -281,7 +286,7 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 				We'll use the <code>dataTableStore.sort()</code> method to automatically set <code>$dataTableStore.sort</code> when a table heading
 				is tapped. Add the following click method once to your table's <code>thead</code> element.
 			</p>
-			<CodeBlock language="html" code={`<thead on:click={(e) => { dataTableStore.sort(e) }} on:keypress>`} />
+			<CodeBlock language="html" code={`<thead on:click={(e) => { dataTableStore.sort(e) }} on:keypress>\n`} />
 			<p>
 				Add a <code>data-sort="(key)"</code> attribute to each heading you wish to be sortable. Tapping a heading will set the
 				<code>$dataTableStore.sort</code>
@@ -293,7 +298,7 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 <th data-sort="position">Position</th>
 <th data-sort="name">Name</th>
 <!-- ... -->
-			`}
+`}
 			/>
 			<p>
 				While sort is working, there's currently no visual UI indicator. To handle this, implement the Svelte Action called <code
@@ -301,26 +306,26 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 				>
 				to your table element. This will toggle the appropriate CSS classes and show &uarr and &darr; sort arrows.
 			</p>
-			<CodeBlock language="html" code={`<table ... use:tableInteraction>`} />
+			<CodeBlock language="html" code={`<table ... use:tableInteraction>\n`} />
 		</section>
 		<!-- Selection -->
 		<section class="space-y-4">
 			<h2>Selection</h2>
 			<h3>Per Row</h3>
 			<p>To handle row selection, we'll add a new heading column. Keep the comment shown, as we'll replace it in a following step.</p>
-			<CodeBlock language="html" code={`<th><!-- selection --></th>`} />
+			<CodeBlock language="html" code={`<th><!-- selection --></th>\n`} />
 			<p>
 				Pair this with a matching table body cell that includes a checkbox input. Append <code>bind:checked</code> to the input to extend
 				the row object source data. When checked on/off, the <code>dataTableHandler</code> will automatically include/exclude the entire row
 				object in
 				<code>$dataTableStore.selection</code>.
 			</p>
-			<CodeBlock language="html" code={`<td><input type="checkbox" bind:checked={row.dataTableChecked} /></td>`} />
+			<CodeBlock language="html" code={`<td><input type="checkbox" bind:checked={row.dataTableChecked} /></td>\n`} />
 			<p>
 				If you wish to visually highlight the row selection, Tailwind Elements includes a semantic class for this. Append this to your table
 				body row element.
 			</p>
-			<CodeBlock language="html" code={`<tr class:table-row-checked={row.dataTableChecked}>`} />
+			<CodeBlock language="html" code={`<tr class:table-row-checked={row.dataTableChecked}>\n`} />
 			<h3>Pre-Selected</h3>
 			<p>
 				You may wish to pre-select certain table rows. We've provided a utility method to handle this. Pass in the key to query against, and
@@ -329,7 +334,7 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 			</p>
 			<CodeBlock
 				language="ts"
-				code={`// Selects all objects with a position value of 1 or 2:\ndataTableStore.select('position', [1,2]);`}
+				code={`// Selects all objects with a position value of 1 or 2:\ndataTableStore.select('position', [1,2]);\n`}
 			/>
 			<h3>Select All</h3>
 			<p>
@@ -337,7 +342,7 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 			</p>
 			<CodeBlock
 				language="html"
-				code={`<th><input type="checkbox" on:click={(e) => { dataTableStore.selectAll(e.currentTarget.checked) }} /></th>`}
+				code={`<th><input type="checkbox" on:click={(e) => { dataTableStore.selectAll(e.currentTarget.checked) }} /></th>\n`}
 			/>
 		</section>
 		<!-- Pagination -->
@@ -347,7 +352,7 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 				Please refer to the <a href="/components/paginators">Paginators component</a> to learn more about this feature. For data tables, use
 				<code>$dataTableStore.pagination</code> to ensures the model updates reactively. The wrapping <em>if</em> statement is required.
 			</p>
-			<CodeBlock language="html" code={`{#if $dataTableStore.pagination}<Paginator bind:settings={$dataTableStore.pagination} />{/if}`} />
+			<CodeBlock language="html" code={`{#if $dataTableStore.pagination}<Paginator bind:settings={$dataTableStore.pagination} />{/if}\n`} />
 		</section>
 		<!-- A11y -->
 		<section class="space-y-4">
@@ -357,12 +362,12 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 				simplified this by providing a Svelte Action called <code>tableA11y</code>. This implements the required event listeners for
 				keyboard interaction. Start by appending <em>role</em> and <em>action</em> to your <em>table</em> element.
 			</p>
-			<CodeBlock language="html" code={`<table ... role="grid" use:tableA11y>`} />
+			<CodeBlock language="html" code={`<table ... role="grid" use:tableA11y>\n`} />
 			<p>
 				Implement the <code>aria-rowindex</code> attribute. This starts at <strong>1</strong> and increments per <em>tr</em> row. We can
 				utilize the <em>#each</em> loop index value, named <code>rowIndex</code>.
 			</p>
-			<CodeBlock language="html" code={`<tr ... aria-rowindex={rowIndex + 1}>`} />
+			<CodeBlock language="html" code={`<tr ... aria-rowindex={rowIndex + 1}>\n`} />
 			<p>
 				Implement three attributes per table body <em>td</em> cell. <code>role</code> and <code>tabindex</code> are static, while
 				<code>aria-colindex</code>
@@ -373,7 +378,8 @@ dataTableStore.subscribe((model) => dataTableHandler(model));`}
 				code={`
 <td ... role="gridcell" aria-colindex={1} tabindex="0">...</td>
 <td ... role="gridcell" aria-colindex={2} tabindex="0">...</td>
-<!-- ... -->`}
+<!-- ... -->
+`}
 			/>
 			<p>Reference the <em>Keyboard</em> tab section at the top of this page for a list of available keyboard interactions.</p>
 		</section>

--- a/src/routes/(inner)/utilities/drawers/+page.svelte
+++ b/src/routes/(inner)/utilities/drawers/+page.svelte
@@ -80,7 +80,7 @@
 			</svelte:fragment>
 			<svelte:fragment slot="source">
 				<p>Implement a single instance of the drawer component in your app's root layout above the App Shell (if present).</p>
-				<CodeBlock language="html" code={`<Drawer />\n\n<!-- <AppShell>...</AppShell> -->`} />
+				<CodeBlock language="html" code={`<Drawer />\n\n<!-- <AppShell>...</AppShell> -->\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -98,9 +98,9 @@
 			<h2>Drawer Store</h2>
 			<p>Import this anywhere you wish to control the Drawer. Provides an interface to control the drawer component.</p>
 			<h3>Open</h3>
-			<CodeBlock language="ts" code={`drawerStore.open();`} />
+			<CodeBlock language="ts" code={`drawerStore.open();\n`} />
 			<h3>Close</h3>
-			<CodeBlock language="ts" code={`drawerStore.close();`} />
+			<CodeBlock language="ts" code={`drawerStore.close();\n`} />
 		</section>
 		<section class="space-y-4">
 			<h2>Passing Metadata</h2>
@@ -124,7 +124,7 @@ drawerStore.open(drawerSettings);
 `}
 					/>
 					<p>To retrieve this data, use:</p>
-					<CodeBlock language="html" code={`<div>{$drawerStore.meta}</div>`} />
+					<CodeBlock language="html" code={`<div>{$drawerStore.meta}</div>\n`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
@@ -198,12 +198,12 @@ drawerStore.open(settings);
 				To animate the contents behind your drawer while it's open, first create a reactive property based on the state of the Drawer. Then
 				implement a Tailwind <em>translate</em> class when the drawer is open.
 			</p>
-			<CodeBlock language="ts" code={`$: positionClasses = $drawerStore.open ? 'translate-x-[50%]' : '';`} />
+			<CodeBlock language="ts" code={`$: positionClasses = $drawerStore.open ? 'translate-x-[50%]' : '';\n`} />
 			<p>
 				Then apply this value to the proper wrapping page element, such as the <em>App Shell</em> or a <em>main</em> element.
 			</p>
-			<CodeBlock language="html" code={`<AppShell class="transition-transform {positionClasses}">...</AppShell>`} />
-			<CodeBlock language="html" code={`<main class="transition-transform {positionClasses}">...</main>`} />
+			<CodeBlock language="html" code={`<AppShell class="transition-transform {positionClasses}">...</AppShell>\n`} />
+			<CodeBlock language="html" code={`<main class="transition-transform {positionClasses}">...</main>\n`} />
 			<p>For best results, be sure to take into account the Drawer position as well via <code>$drawerStore.position</code>.</p>
 		</section>
 		<section class="space-y-4">

--- a/src/routes/(inner)/utilities/lightswitches/+page.svelte
+++ b/src/routes/(inner)/utilities/lightswitches/+page.svelte
@@ -55,7 +55,7 @@
 								<LightSwitch />
 							</svelte:fragment>
 							<svelte:fragment slot="source">
-								<CodeBlock language="ts" code={`<LightSwitch />`} />
+								<CodeBlock language="ts" code={`<LightSwitch />\n`} />
 							</svelte:fragment>
 						</DocsPreview>
 						<p>
@@ -69,7 +69,7 @@
 							of a Lightswitch component.
 						</p>
 						<p>First, import the following in <code>/src/routes/+layout.svelte</code>.</p>
-						<CodeBlock language="ts" code={`import { autoModeWatcher } from '@skeletonlabs/skeleton';`} />
+						<CodeBlock language="ts" code={`import { autoModeWatcher } from '@skeletonlabs/skeleton';\n`} />
 						<p>Then add the following in your root layout template markup.</p>
 						<CodeBlock language="html" code={snippetAutoModeWatcher} />
 						<p>Note that Mac OS will update immediately, while other operating systems require a browser refresh.</p>
@@ -84,7 +84,7 @@
 							Import and add the following to your component. This will set the <code>.dark</code> class on the root HTML element in a highly
 							performant manner.
 						</p>
-						<CodeBlock language="ts" code={`import { setInitialClassState } from '@skeletonlabs/skeleton';`} />
+						<CodeBlock language="ts" code={`import { setInitialClassState } from '@skeletonlabs/skeleton';\n`} />
 						<CodeBlock language="html" code={snippetSetInitClass} />
 						<h2>Interface Methods</h2>
 						<p>Light mode is represented by <code>true</code>, while dark mode is represented by <code>false</code>.</p>
@@ -96,7 +96,10 @@
 							<svelte:fragment slot="panel">
 								{#if tabInterface === 0}
 									<!-- Stores -->
-									<CodeBlock language="ts" code={`import { modeOsPrefers, modeUserPrefers, modeCurrent } from '@skeletonlabs/skeleton';`} />
+									<CodeBlock
+										language="ts"
+										code={`import { modeOsPrefers, modeUserPrefers, modeCurrent } from '@skeletonlabs/skeleton';\n`}
+									/>
 									<div class="table-container">
 										<table class="table table-hover">
 											<thead>
@@ -129,7 +132,7 @@
 									<!-- Getters -->
 									<CodeBlock
 										language="ts"
-										code={`import { getModeOsPrefers, getModeUserPrefers, getModeAutoPrefers } from '@skeletonlabs/skeleton';`}
+										code={`import { getModeOsPrefers, getModeUserPrefers, getModeAutoPrefers } from '@skeletonlabs/skeleton';\n`}
 									/>
 									<div class="table-container">
 										<table class="table table-hover">
@@ -161,7 +164,7 @@
 									</div>
 								{:else if tabInterface === 2}
 									<!-- Setters -->
-									<CodeBlock language="ts" code={`import { setModeUserPrefers, setModeCurrent } from '@skeletonlabs/skeleton';`} />
+									<CodeBlock language="ts" code={`import { setModeUserPrefers, setModeCurrent } from '@skeletonlabs/skeleton';\n`} />
 									<div class="table-container">
 										<table class="table table-hover">
 											<thead>

--- a/src/routes/(inner)/utilities/local-storage-stores/+page.svelte
+++ b/src/routes/(inner)/utilities/local-storage-stores/+page.svelte
@@ -22,8 +22,8 @@
 			<p>
 				The first parameter <code>storeExample</code> is the local storage key name. The second parameter is the initial value of the store.
 			</p>
-			<CodeBlock language="ts" code={`import type { Writable } from 'svelte/store';`} />
-			<CodeBlock language="ts" code={`const storeExample: Writable<string> = localStorageStore('storeExample', 'initialValueHere');`} />
+			<CodeBlock language="ts" code={`import type { Writable } from 'svelte/store';\n`} />
+			<CodeBlock language="ts" code={`const storeExample: Writable<string> = localStorageStore('storeExample', 'initialValueHere');\n`} />
 			<p>
 				Operates as a standard Svelte writable store but with the added benefit of automatic persistence via <a
 					href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage"

--- a/src/routes/(inner)/utilities/modals/+page.svelte
+++ b/src/routes/(inner)/utilities/modals/+page.svelte
@@ -157,7 +157,7 @@
 			</svelte:fragment>
 			<svelte:fragment slot="source">
 				<p>Implement a single instance of the modal component in your app's root layout above the App Shell (if present).</p>
-				<CodeBlock language="html" code={`<Modal />\n\n<!-- <AppShell>...</AppShell> -->`} />
+				<CodeBlock language="html" code={`<Modal />\n\n<!-- <AppShell>...</AppShell> -->\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -176,7 +176,7 @@
 		<section class="space-y-4">
 			<h2>Modal Store</h2>
 			<p>When you wish to trigger a modal, import the <code>modalStore</code>, which acts as the modal queue.</p>
-			<CodeBlock language="ts" code={`import { modalStore } from '@skeletonlabs/skeleton';`} />
+			<CodeBlock language="ts" code={`import { modalStore } from '@skeletonlabs/skeleton';\n`} />
 			<h3>Trigger</h3>
 			<p>The <code>title</code>, <code>body</code>, and <code>image</code> are available to all modals.</p>
 			<!-- Alert -->
@@ -253,11 +253,11 @@ modalStore.trigger(prompt);
 			<!-- Close -->
 			<h3>Close</h3>
 			<p>Trigger the <code>close()</code> method to remove the first modal in the modal queue.</p>
-			<CodeBlock language="ts" code={`modalStore.close();`} />
+			<CodeBlock language="ts" code={`modalStore.close();\n`} />
 			<!-- Clear -->
 			<h3>Clear</h3>
 			<p>Trigger the <code>clear()</code> method to completely empty the modal queue.</p>
-			<CodeBlock language="ts" code={`modalStore.clear();`} />
+			<CodeBlock language="ts" code={`modalStore.clear();\n`} />
 		</section>
 		<!-- Modal Settings -->
 		<section class="space-y-4">
@@ -267,13 +267,17 @@ modalStore.trigger(prompt);
 			<CodeBlock
 				language="ts"
 				code={`
-const d: ModalSettings = {\n
+const d: ModalSettings = {
+	
 	// Provide arbitrary classes to the backdrop and modal elements:
 	backdropClasses: '!bg-green-500',
-	modalClasses: '!bg-red-500',\n
+	modalClasses: '!bg-red-500',
+	
 	// Provide arbitrary metadata to your modal instance:
-	meta: { foo: 'bar', fizz: 'buzz', fn: myCustomFunction }\n
-};`}
+	meta: { foo: 'bar', fizz: 'buzz', fn: myCustomFunction }
+	
+};
+`}
 			/>
 		</section>
 		<!-- Component Modals -->
@@ -313,8 +317,10 @@ const d: ModalSettings = {\n
 									language="ts"
 									code={`
 // import ModalComponentOne from '...';
-// import ModalComponentTwo from '...';\n
-const modalComponentRegistry: Record<string, ModalComponent> = {\n
+// import ModalComponentTwo from '...';
+
+const modalComponentRegistry: Record<string, ModalComponent> = {
+	
 	// Custom Modal 1
 	modalComponentOne: {
 		// Pass a reference to your custom component
@@ -323,14 +329,16 @@ const modalComponentRegistry: Record<string, ModalComponent> = {\n
 		props: { background: 'bg-red-500' },
 		// Provide a template literal for the default component slot
 		slot: '<p>Skeleton</p>'
-	},\n
+	},
+	
 	// Custom Modal 2
-	modalComponentTwo: { ref: ModalComponentTwo },\n
+	modalComponentTwo: { ref: ModalComponentTwo },
+	
 	// ...
 };
-									`}
+`}
 								/>
-								<CodeBlock language="html" code={`<Modal components={modalComponentRegistry} />`} />
+								<CodeBlock language="html" code={`<Modal components={modalComponentRegistry} />\n`} />
 								<p>When triggering a component, pass <code>component: string</code>, where the value represents the registry object key.</p>
 								<CodeBlock
 									language="ts"
@@ -341,7 +349,7 @@ const d: ModalSettings = {
 	component: 'modalComponentOne',
 };
 modalStore.trigger(d);
-									`}
+`}
 								/>
 							{:else if tabCustom === 'direct'}
 								<p>
@@ -350,7 +358,8 @@ modalStore.trigger(d);
 								<CodeBlock
 									language="ts"
 									code={`
-// import MyCustomComponent from '...';\n
+// import MyCustomComponent from '...';
+
 const modalComponent: ModalComponent = {
 	// Pass a reference to your custom component
 	ref: MyCustomComponent,
@@ -359,7 +368,7 @@ const modalComponent: ModalComponent = {
 	// Provide a template literal for the default component slot
 	slot: '<p>Skeleton</p>'
 };
-									`}
+`}
 								/>
 								<p>
 									When triggering a component, pass the <code>component: ModalComponent</code> directly to <code>ModalSettings</code>.
@@ -373,7 +382,7 @@ const d: ModalSettings = {
 	component: modalComponent,
 };
 modalStore.trigger(d);
-									`}
+`}
 								/>
 							{/if}
 						</svelte:fragment>

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -125,9 +125,9 @@ let popupSettings: PopupSettings = {
 `}
 				/>
 				<p>Apply the <code>use:popup</code> action to your trigger element.</p>
-				<CodeBlock language="html" code={`<button ... use:popup={popupSettings}>Trigger</button>`} />
+				<CodeBlock language="html" code={`<button ... use:popup={popupSettings}>Trigger</button>\n`} />
 				<p>Apply a <code>data-popup</code> attribute to your desired popup element.</p>
-				<CodeBlock language="html" code={`<div ... data-popup="examplePopup">(popup)</div>`} />
+				<CodeBlock language="html" code={`<div ... data-popup="examplePopup">(popup)</div>\n`} />
 				<p>
 					You may optionally append a <code>.arrow</code> element within the popup to add an arrow. Match your popup's background color!
 				</p>
@@ -153,11 +153,11 @@ let popupSettings: PopupSettings = {
 			<p>Install <a href="https://floating-ui.com/" target="_blank" rel="noreferrer">Floating UI</a> from NPM. <u>This is required.</u></p>
 			<CodeBlock language="console" code={`npm install @floating-ui/dom`} />
 			<p>Import Floating UI into your application's root layout <code>/src/routes/+layout.svelte</code>.</p>
-			<CodeBlock language="ts" code={`import { computePosition, autoUpdate, flip, shift, offset, arrow } from '@floating-ui/dom';`} />
+			<CodeBlock language="ts" code={`import { computePosition, autoUpdate, flip, shift, offset, arrow } from '@floating-ui/dom';\n`} />
 			<p>Then import <code>storePopup</code> in your root layout as well.</p>
-			<CodeBlock language="ts" code={`import { storePopup } from '@skeletonlabs/skeleton';`} />
+			<CodeBlock language="ts" code={`import { storePopup } from '@skeletonlabs/skeleton';\n`} />
 			<p>Finally, pass an object containing each of the Floating UI modules to the store.</p>
-			<CodeBlock language="ts" code={`storePopup.set({ computePosition, autoUpdate, flip, shift, offset, arrow });`} />
+			<CodeBlock language="ts" code={`storePopup.set({ computePosition, autoUpdate, flip, shift, offset, arrow });\n`} />
 		</section>
 		<!-- PopupSettings -->
 		<section class="space-y-4">
@@ -259,7 +259,7 @@ let popupSettings: PopupSettings = {
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="ts" code={`let comboboxValue: string;`} />
+					<CodeBlock language="ts" code={`let comboboxValue: string;\n`} />
 					<CodeBlock
 						language="ts"
 						code={`

--- a/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -107,7 +107,7 @@
 					Import and add a single instance of the Toast component in your app's root layout. Since this is in global scope it will be
 					possible to reuse this feature throughout your entire application.
 				</p>
-				<CodeBlock language="html" code={`<Toast />`} />
+				<CodeBlock language="html" code={`<Toast />\n`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -125,11 +125,7 @@
 		<section class="space-y-4">
 			<h2>Toast Store</h2>
 			<p>The Modal Store acts as a queue for your toast messages.</p>
-			<CodeBlock
-				language="ts"
-				code={`import { toastStore } from '@skeletonlabs/skeleton';
-			`}
-			/>
+			<CodeBlock language="ts" code={`import { toastStore } from '@skeletonlabs/skeleton';\n`} />
 			<!-- Trigger -->
 			<h3>Trigger</h3>
 			<p>To add a message to the queue, use the <code>toastStore.trigger()</code> method and pass a toast settings object.</p>
@@ -220,7 +216,7 @@ toastStore.trigger(t);
 			<!-- Clear -->
 			<h3>Clear</h3>
 			<p>Use <code>toastStore.clear()</code> to clear the entire toast store queue.</p>
-			<CodeBlock language="ts" code={`toastStore.clear();`} />
+			<CodeBlock language="ts" code={`toastStore.clear();\n`} />
 		</section>
 		<!-- Styling -->
 		<section class="space-y-4">


### PR DESCRIPTION
- [X] Does your PR reference an issue? Kicked off from a discussion and code review by @niktek .
- [X] Did you update and run tests before submission using `npm run test`? Note some expected prop 'name' issues.
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [X] Did you update documentation related to your new feature or changes? This is pure documentation.

# What does your PR address?
This gives us consistent cut and paste behavior of all code samples.

# Changes
- All multiline CodeBlock items now end on a white space free newline.
- All single CodeBlock line items now end on a /n
- All /t /n in multilines expanded
- Removed some spurious trim() that did nothing, or specifically added whitestace to trim.

# Exceptions:
- Shell commands
- The quickstart Avatar include
- Some cases where a text variable was used. Probably a TODO for later.

# Note
- I would add this to our style manual?