### PR TITLE
Update theme generator so no error occurs while typing in hex colors 

### DIFF
--- a/src/docs/layouts/DocsThemer/DocsThemer.svelte
+++ b/src/docs/layouts/DocsThemer/DocsThemer.svelte
@@ -15,9 +15,9 @@
 
 	// Local Utils
 	import { storePreview } from './stores';
-	import type { ColorSettings, FormTheme } from './types';
+	import type { ColorSettings, FormTheme, ContrastReport } from './types';
 	import { inputSettings, fontSettings } from './settings';
-	import { type Palette, generatePalette, generateA11yOnColor, getPassReport } from './colors';
+	import { type Palette, generatePalette, generateA11yOnColor, hexValueIsValid, getPassReport } from './colors';
 	import type { PopupSettings } from '$lib/utilities/Popup/types';
 
 	// Stores
@@ -44,6 +44,7 @@
 	// Local
 	let cssOutput: string = '';
 	let showThemeCSS: boolean = false;
+	let conReports: ContrastReport[] = getContrastReports();
 
 	function randomize(): void {
 		$storeThemGenForm.colors.forEach((_, i: number) => {
@@ -78,33 +79,55 @@
 		}
 	}
 
+	function getContrastReports(): ContrastReport[] {
+		return $storeThemGenForm.colors.map((value: ColorSettings) => ({
+			...value,
+			contrastReport: getPassReport(value.hex, value.on)
+		}));
+	}
+
 	const tooltipSettings: Omit<PopupSettings, 'target'> = {
 		event: 'hover',
 		placement: 'top'
 	};
 
+	const hexValuesAreValid = (colors: ColorSettings[]) => {
+		// Check all hex values for validity.
+		let valid = true;
+		colors?.forEach((color: ColorSettings) => {
+			valid = valid && hexValueIsValid(color.hex);
+		});
+
+		return valid;
+	};
+
 	// Reactive
-	$: if ($storeThemGenForm) {
+	$: if (hexValuesAreValid($storeThemGenForm.colors)) {
+		// Update contrast reports when hex values change and when they are valid.
+		conReports = getContrastReports();
+	}
+
+	$: if ($storeThemGenForm && hexValuesAreValid($storeThemGenForm.colors)) {
 		cssOutput = `
 :root {
-    /* =~= Theme Properties =~= */
-    --theme-font-family-base: ${fontSettings[$storeThemGenForm.fontBase]};
-    --theme-font-family-heading: ${fontSettings[$storeThemGenForm.fontHeadings]};
-    --theme-font-color-base: ${$storeThemGenForm.textColorLight};
-    --theme-font-color-dark: ${$storeThemGenForm.textColorDark};
-    --theme-rounded-base: ${$storeThemGenForm.roundedBase};
-    --theme-rounded-container: ${$storeThemGenForm.roundedContainer};
-    --theme-border-base: ${$storeThemGenForm.borderBase};
-    /* =~= Theme On-X Colors =~= */
-    --on-primary: ${$storeThemGenForm.colors[0]?.on};
-    --on-secondary: ${$storeThemGenForm.colors[1]?.on};
-    --on-tertiary: ${$storeThemGenForm.colors[2]?.on};
-    --on-success: ${$storeThemGenForm.colors[3]?.on};
-    --on-warning: ${$storeThemGenForm.colors[4]?.on};
-    --on-error: ${$storeThemGenForm.colors[5]?.on};
-    --on-surface: ${$storeThemGenForm.colors[6]?.on};
-    /* =~= Theme Colors  =~= */
-    ${generateColorCSS()}
+	/* =~= Theme Properties =~= */
+	--theme-font-family-base: ${fontSettings[$storeThemGenForm.fontBase]};
+	--theme-font-family-heading: ${fontSettings[$storeThemGenForm.fontHeadings]};
+	--theme-font-color-base: ${$storeThemGenForm.textColorLight};
+	--theme-font-color-dark: ${$storeThemGenForm.textColorDark};
+	--theme-rounded-base: ${$storeThemGenForm.roundedBase};
+	--theme-rounded-container: ${$storeThemGenForm.roundedContainer};
+	--theme-border-base: ${$storeThemGenForm.borderBase};
+	/* =~= Theme On-X Colors =~= */
+	--on-primary: ${$storeThemGenForm.colors[0]?.on};
+	--on-secondary: ${$storeThemGenForm.colors[1]?.on};
+	--on-tertiary: ${$storeThemGenForm.colors[2]?.on};
+	--on-success: ${$storeThemGenForm.colors[3]?.on};
+	--on-warning: ${$storeThemGenForm.colors[4]?.on};
+	--on-error: ${$storeThemGenForm.colors[5]?.on};
+	--on-surface: ${$storeThemGenForm.colors[6]?.on};
+	/* =~= Theme Colors  =~= */
+	${generateColorCSS()}
 }`;
 	}
 
@@ -132,7 +155,6 @@
 			<hr />
 			<div class="p-4 grid grid-cols-1 gap-4">
 				{#each $storeThemGenForm.colors as colorRow, i}
-					{@const contrastReport = getPassReport($storeThemGenForm.colors[i].hex, $storeThemGenForm.colors[i].on)}
 					<div class="grid grid-cols-1 lg:grid-cols-[170px_1fr_200px] gap-2 lg:gap-4">
 						<label class="label">
 							<span>{colorRow.label}</span>
@@ -156,14 +178,14 @@
 										<div
 											class="input-group-shim !px-3"
 											use:popup={{ ...tooltipSettings, ...{ target: 'popup-' + i } }}
-											class:!text-stone-900={contrastReport.fails}
-											class:!bg-red-500={contrastReport.fails}
-											class:!text-zinc-900={contrastReport.largeAA}
-											class:!bg-amber-500={contrastReport.largeAA}
-											class:!text-slate-900={contrastReport.smallAAA || contrastReport.smallAA}
-											class:!bg-green-500={contrastReport.smallAAA || contrastReport.smallAA}
+											class:!text-stone-900={conReports[i].contrastReport.fails}
+											class:!bg-red-500={conReports[i].contrastReport.fails}
+											class:!text-zinc-900={conReports[i].contrastReport.largeAA}
+											class:!bg-amber-500={conReports[i].contrastReport.largeAA}
+											class:!text-slate-900={conReports[i].contrastReport.smallAAA || conReports[i].contrastReport.smallAA}
+											class:!bg-green-500={conReports[i].contrastReport.smallAAA || conReports[i].contrastReport.smallAA}
 										>
-											{@html contrastReport.report.emoji}
+											{@html conReports[i].contrastReport.report.emoji}
 										</div>
 									{/if}
 								</div>
@@ -171,11 +193,11 @@
 								<div
 									data-popup={'popup-' + i}
 									class="text-xs card variant-filled p-2 whitespace-nowrap"
-									class:!variant-filled-red-500={contrastReport.fails}
-									class:!variant-filled-amber-500={contrastReport.largeAA}
-									class:!variant-filled-green-500={contrastReport.smallAAA || contrastReport.smallAA}
+									class:!variant-filled-red-500={conReports[i].contrastReport.fails}
+									class:!variant-filled-amber-500={conReports[i].contrastReport.largeAA}
+									class:!variant-filled-green-500={conReports[i].contrastReport.smallAAA || conReports[i].contrastReport.smallAA}
 								>
-									{contrastReport.report.note}
+									{conReports[i].contrastReport.report.note}
 									<!-- Arrow -->
 									<div class="arrow variant-filled" />
 								</div>

--- a/src/docs/layouts/DocsThemer/Swatch.svelte
+++ b/src/docs/layouts/DocsThemer/Swatch.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { SemanticNames } from '$lib/components/ConicGradient/settings';
+	import type { SemanticNames } from '$lib/types/tailwind';
 	import { swatchColorClasses } from './settings';
 
 	/** Pass the color key name. */

--- a/src/docs/layouts/DocsThemer/colors.ts
+++ b/src/docs/layouts/DocsThemer/colors.ts
@@ -1,5 +1,6 @@
 // This script is based 'tailwindcolorshades' by Javis V. Pérez:
 // https://github.com/javisperez/tailwindcolorshades/blob/master/src/composables/colors.ts
+import type { PassReport } from "./types";
 
 export type Palette = {
 	[key: number]: {
@@ -194,8 +195,12 @@ export function textPasses(textColor: string, backgroundColor: string, size: Con
 	return ratio <= contrastLevels[size][level];
 }
 
+export function hexValueIsValid(textColor: string) {
+	return /^#[0-9A-F]{6}$/i.test(textColor);
+}
+
 /** A catch-all function to give a report on what size and level a given combination achieves.  */
-export function getPassReport(textColor: string, backgroundColor: string) {
+export function getPassReport(textColor: string, backgroundColor: string): PassReport {
 	const _textColor = handleStringColor(textColor, 'hex');
 	const _backgroundColor = handleStringColor(backgroundColor, 'hex');
 	const contrast = calculateRatio(_textColor, _backgroundColor);

--- a/src/docs/layouts/DocsThemer/types.ts
+++ b/src/docs/layouts/DocsThemer/types.ts
@@ -20,3 +20,29 @@ export interface FormTheme {
 	roundedContainer: string;
 	borderBase: string;
 }
+
+export interface Report {
+	emoji: string;
+	note: string;
+}
+
+export interface PassReport {
+	textColor: string;
+	backgroundColor: string;
+	contrast: number;
+	report: Report;
+	smallAA: boolean;
+	smallAAA: boolean;
+	largeAA: boolean;
+	largeAAA: boolean;
+	fails: boolean;
+}
+
+export interface ContrastReport {
+	key: SemanticNames;
+	label: string;
+	hex: string;
+	rgb: string;
+	on: string;
+	contrastReport: PassReport;
+}

--- a/src/lib/types/tailwind.ts
+++ b/src/lib/types/tailwind.ts
@@ -2,6 +2,6 @@ export const tailwindNumbers = ['50', '100', '200', '300', '400', '500', '600', 
 
 export type TailwindNumbers = (typeof tailwindNumbers)[number];
 
-export const semanticNames = ['primary', 'secondary', 'tertiary', 'success', 'warning'] as const;
+export const semanticNames = ['primary', 'secondary', 'tertiary', 'success', 'warning', 'error' , 'surface'] as const;
 
 export type SemanticNames = (typeof semanticNames)[number];


### PR DESCRIPTION
## Before submitting the PR:
- [X] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Please briefly describe your changes here.

Changes made:
- added a validity checker for hex values
- added a contrastReports list variable that calls the `getPassReport` function only when hex value is valid
- html now gets generated with this new list instead of using `{@const contrastReport = ...}` calculation
- added some types
- updated an import in `Swatch.svelte` which was pointing at the wrong type
- added missing `semanticNames` (`'error'` and `'surface'`) to the `tailwind.ts` file

This would Close #1111 

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
