### PR TITLE
Fix: Optimized sponsor images

### DIFF
--- a/src/routes/home-partials/HomeSponsors.svelte
+++ b/src/routes/home-partials/HomeSponsors.svelte
@@ -14,7 +14,7 @@
 		<!-- Brain & Bones -->
 		<a href="https://www.brainandbonesllc.com/" target="_blank" rel="noreferrer" use:popup={popupBrainBones}>
 			<Avatar
-				src="https://pbs.twimg.com/profile_images/1504272980687441922/pkVimygY_400x400.png"
+				src="https://pbs.twimg.com/profile_images/1504272980687441922/pkVimygY_200x200.png"
 				width="w-full max-w-[180px]"
 				background="bg-neutral-900"
 				shadow="shadow-xl"
@@ -28,7 +28,7 @@
 		</div>
 		<!-- Luke -->
 		<a href="https://lukehagar.com/" target="_blank" rel="noreferrer" use:popup={popupLukeHagar}>
-			<Avatar src="https://i.imgur.com/ySBlLmQ.png" width="w-full max-w-[180px]" shadow="shadow-xl" />
+			<Avatar src="https://i.imgur.com/u8sOah2.png" width="w-full max-w-[180px]" shadow="shadow-xl" />
 		</a>
 		<div class="text-xs text-center card variant-filled-primary p-2 whitespace-nowrap shadow-xl" data-popup="popupLukeHagar">
 			<p class="font-bold">Premium Sponsor</p>


### PR DESCRIPTION
The size of images for sponsors were causing a "jerk" effect when trying to smooth scroll on the home page. Those images have been shrunken from 136kB -> 40kB (Brain & Bones) and 654kB -> 30kB (Luke).