### PR TITLE
Update `get-started` docs to be a bit more explicit on manual install for stylesheets

### DIFF
--- a/src/routes/(inner)/docs/get-started/SectionStylesheets.svelte
+++ b/src/routes/(inner)/docs/get-started/SectionStylesheets.svelte
@@ -37,15 +37,19 @@
 					</div>
 				</aside>
 				<CodeBlock
-					language="ts"
+					language="html"
 					code={`
-// Your selected Skeleton theme:
-import '@skeletonlabs/skeleton/themes/theme-skeleton.css';\n
-// This contains the bulk of Skeletons required styles:
-import '@skeletonlabs/skeleton/styles/all.css';\n
-// Finally, your application's global stylesheet (sometimes labeled 'app.css')
-import '../app.postcss';
-						`}
+\<script\>
+	// Your selected Skeleton theme:
+	import '@skeletonlabs/skeleton/themes/theme-skeleton.css';\n
+	// This contains the bulk of Skeletons required styles:
+	import '@skeletonlabs/skeleton/styles/all.css';\n
+	// Finally, your application's global stylesheet (sometimes labeled 'app.css')
+	import '../app.postcss';
+\</script\>\n
+
+<slot />
+`}
 				/>
 			{/if}
 		</svelte:fragment>


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

Hey Skeleton team!

I've been enjoying Skeleton thus far and I wanted to maybe suggest a small doc change! The manual install for stylesheets in the `Get Started` section was mildly confusing as I'm newer to Svelte/SvelteKit (just learned it today!) so I was thinking this could help some folks who may have potentially run in to the same issue.

I assume this won't be an issue to anyone more experienced to Svelte as they'd immediately know, but for newbies it could help feel a bit more grounded (like the `tailwind.config.cjs` example does) so they're a little more assured they're doing the correct thing.

It's a minor change and didn't trip me up for too long (maybe a minute max), but I was thinking reducing every bit of friction could help for adoption!

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
