### PR TITLE
Bugfix/fix file button not taking files list

### DIFF
--- a/src/lib/components/FileButton/FileButton.svelte
+++ b/src/lib/components/FileButton/FileButton.svelte
@@ -2,6 +2,12 @@
 	// Types
 	import type { CssClasses } from '$lib';
 
+	//Props
+	/**
+	 * Bind FileList to the file input.
+	 * @type {FileList}
+	 */
+	export let files: FileList | undefined = undefined;
 	/**
 	 * Required. Set a unique name for the file input.
 	 * @type {string}
@@ -35,7 +41,7 @@
 <div class="file-button {classesBase}" data-testid="file-button">
 	<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
 	<div class="w-0 h-0 overflow-hidden">
-		<input type="file" bind:this={elemFileInput} {name} {...prunedRestProps()} on:change />
+		<input type="file" bind:this={elemFileInput} bind:files {name} {...prunedRestProps()} on:change />
 	</div>
 	<!-- Button -->
 	<button

--- a/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -24,7 +24,7 @@
 
 	function onChangeHandler(e: Event): void {
 		console.log('file data:', e);
-		console.log(files);
+		console.log('files:', files);
 	}
 </script>
 

--- a/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -24,6 +24,7 @@
 
 	function onChangeHandler(e: Event): void {
 		console.log('file data:', e);
+		console.log(files);
 	}
 </script>
 

--- a/src/routes/(inner)/components/file-dropzone/+page.svelte
+++ b/src/routes/(inner)/components/file-dropzone/+page.svelte
@@ -24,6 +24,7 @@
 
 	function onChangeHandler(e: any): void {
 		console.log('file data:', e);
+		console.log('files:', files);
 	}
 </script>
 


### PR DESCRIPTION
Does your PR reference an issue?
No, fixes one though: https://discord.com/channels/1003691521280856084/1084785138099048448
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

Added the exported files-FileList of the FileDropzone to the FileButton as well so that you can do bind:files to get the list of uploaded files.

Fixes #1021 