### PR TITLE
Add `focus` event to `popup`

### DIFF
--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -31,7 +31,7 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 	let autoUpdateCleanup: any;
 
 	// Local A11y Variables
-	const elemWhitelist: string = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
+	const elemWhitelist = ':is(a[href], button, input, textarea, select, details, [tabindex]):not([tabindex="-1"])';
 	let activeFocusIdx: number;
 	let focusableElems: HTMLElement[];
 

--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -39,22 +39,22 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 	function render(): void {
 		if (!elemPopup || !computePosition) return;
 
-		// Construct Middlware
+		// Construct Middleware
 		// Note the order: https://floating-ui.com/docs/middleware#ordering
-		const genMiddlware = [];
+		const genMiddleware = [];
 		// https://floating-ui.com/docs/offset
-		if (offset) genMiddlware.push(offset(middleware?.offset ?? 8));
+		if (offset) genMiddleware.push(offset(middleware?.offset ?? 8));
 		// https://floating-ui.com/docs/shift
-		if (shift) genMiddlware.push(shift(middleware?.shift ?? { padding: 8 }));
+		if (shift) genMiddleware.push(shift(middleware?.shift ?? { padding: 8 }));
 		// https://floating-ui.com/docs/flip
-		if (flip) genMiddlware.push(flip(middleware?.flip));
+		if (flip) genMiddleware.push(flip(middleware?.flip));
 		// https://floating-ui.com/docs/arrow
-		if (arrow && elemArrow) genMiddlware.push(arrow(middleware?.arrow ?? { element: elemArrow }));
+		if (arrow && elemArrow) genMiddleware.push(arrow(middleware?.arrow ?? { element: elemArrow }));
 
 		// https://floating-ui.com/docs/computePosition
 		computePosition(node, elemPopup, {
 			placement: placement ?? 'bottom',
-			middleware: genMiddlware
+			middleware: genMiddleware
 		}).then(({ x, y, placement, middlewareData }: any) => {
 			Object.assign(elemPopup.style, {
 				left: `${x}px`,
@@ -135,7 +135,7 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		stateEventHandler(false);
 	};
 
-	// Visbility
+	// Visibility
 	function show(): void {
 		if (!elemPopup) return;
 		render(); // update
@@ -224,7 +224,7 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 	// On Init
 	render();
 
-	// Event Listners
+	// Event Listeners
 	if (event === 'click') {
 		window.addEventListener('click', onWindowClick, true);
 	}

--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -3,6 +3,7 @@ import { get, writable, type Writable } from 'svelte/store';
 // Types
 import type { PopupSettings } from './types';
 import type { Middleware } from '@floating-ui/dom';
+import { tick } from 'svelte';
 
 // Store
 type PopupStore = {
@@ -254,7 +255,22 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		// we must use mousedown instead of click because click fires after focusin, meaning isVisible would always be true
 		// if the active element (one with current focus) is the same as the node (the element with the use:popup directive),
 		// then the user clicked on the node, so we should toggle the state of the popup
-		node.addEventListener('mousedown', () => (document.activeElement?.isSameNode(node) && isVisible ? close() : open()), true);
+		node.addEventListener(
+			'mousedown',
+			async (e) => {
+				// buttons lose focus after click, this keeps the focus on the node
+				e.preventDefault();
+				if (isNode(document.activeElement)) {
+					if (!node.isSameNode(document.activeElement)) {
+						node.focus();
+						return;
+					}
+					if (isVisible) close();
+					else show();
+				}
+			},
+			true
+		);
 	}
 	// A11y Event Listeners
 	window.addEventListener('keydown', onWindowKeyDown, true);

--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -265,6 +265,11 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 			window.removeEventListener('click', onWindowClick, true);
 			node.removeEventListener('mouseover', onMouseOver, true);
 			node.removeEventListener('mouseout', onMouseOut, true);
+			node.removeEventListener('focusin', show, true);
+			node.removeEventListener('focusout', closeOnFocusOut, true);
+			node.removeEventListener('mousedown', onFocusClick, true);
+			elemPopup?.removeEventListener('focusin', moveFocusToNode, true);
+			elemPopup?.removeEventListener('focusout', closeOnFocusOut, true);
 			// ---
 			window.removeEventListener('keydown', onWindowKeyDown, true);
 		}

--- a/src/lib/utilities/Popup/types.ts
+++ b/src/lib/utilities/Popup/types.ts
@@ -20,7 +20,7 @@ interface Middlware {
 // Action Arguments
 export interface PopupSettings {
 	/** Provide the event type. */
-	event: 'click' | 'hover' | 'hover-click';
+	event: 'click' | 'hover' | 'hover-click' | 'focus' | 'focus-click';
 	/** Match the popup data value `[data-popup]="targetNameHere"` */
 	target: string;
 	/** Set the placement position. Defaults 'bottom'. */

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -124,21 +124,18 @@
 								</a>
 							</div>
 						</div>
-						<div>
-							<button class="btn variant-filled" use:popup={interactiveMenu}>Interactive</button>
-							<div
-								class="text-xs text-center card variant-filled p-2 whitespace-nowrap shadow-xl flex flex-col"
-								data-popup="interactiveMenu"
-							>
-								<p>This is an interactive example tooltip.</p>
-								<button class="btn variant-ringed-primary">I won't close the menu</button>
-								<!-- Arrow -->
-								<div class="arrow variant-filled" />
-							</div>
+					</div>
+					<div>
+						<button class="btn variant-filled" use:popup={interactiveMenu}>Interactive</button>
+						<div class="text-xs text-center card variant-filled p-2 whitespace-nowrap shadow-xl flex flex-col" data-popup="interactiveMenu">
+							<p>This is an interactive example tooltip.</p>
+							<button class="btn variant-ringed-primary">I won't close the menu</button>
+							<!-- Arrow -->
+							<div class="arrow variant-filled" />
 						</div>
 					</div>
-				</div></svelte:fragment
-			>
+				</div>
+			</svelte:fragment>
 			<svelte:fragment slot="source">
 				<!-- prettier-ignore -->
 				<p>Create a <code>PopupSettings</code> object that maps to <a href="https://floating-ui.com/" target="_blank" rel="noreferrer">Floating UI</a> settings.</p>
@@ -268,8 +265,7 @@ let popupSettings: PopupSettings = {
 		<section class="space-y-4">
 			<h2>Combobox</h2>
 			<p>
-				By combining popups and Skeleton listboxes we can create a functional combobox element. 
-				We can use the <code>focus-click</code> event
+				By combining popups and Skeleton listboxes we can create a functional combobox element. We can use the <code>focus-click</code> event
 				so it opens for keyboard users when focussed.
 			</p>
 			<DocsPreview background="neutral">
@@ -396,9 +392,8 @@ let focusClickPopup: PopupSettings = {
 		<section class="space-y-4">
 			<h2>Z-Index</h2>
 			<p>
-				Neither Skeleton nor Floating-UI will provide a Z-Index out of the box for the reasons layed out in the <a
-					href="https://floating-ui.com/docs/misc#z-index-stacking">Floating-UI docs</a
-				>.
+				Neither Skeleton nor Floating-UI will provide a Z-Index out of the box for the reasons layed out in the
+				<a href="https://floating-ui.com/docs/misc#z-index-stacking">Floating-UI docs</a>.
 			</p>
 		</section>
 		<!-- Browser Support -->

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -66,12 +66,7 @@
 	let exampleMenu: PopupSettings = {
 		event: 'click',
 		target: 'exampleMenu',
-		placement: 'bottom',
-		middleware: {
-			arrow: {
-				element: '#myArrow'
-			}
-		}
+		placement: 'bottom'
 	};
 	let inputPopupFocus: PopupSettings = {
 		event: 'focus',

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -67,7 +67,16 @@
 		event: 'click',
 		target: 'exampleMenu',
 		placement: 'bottom'
-		// state: (e: any) => console.log('tooltip', e)
+	};
+	let exampleFocus: PopupSettings = {
+		event: 'focus',
+		target: 'exampleFocus',
+		placement: 'bottom'
+	};
+	let exampleFocusClick: PopupSettings = {
+		event: 'focus-click',
+		target: 'exampleFocusClick',
+		placement: 'bottom'
 	};
 </script>
 
@@ -103,6 +112,30 @@
 								<a class="btn variant-soft w-full" href="https://twitter.com/SkeletonUI" target="_blank" rel="noreferrer">
 									View on Twitter
 								</a>
+							</div>
+							<!-- Arrow -->
+							<div class="arrow bg-surface-100-800-token" />
+						</div>
+					</div>
+					<div>
+						<button class="btn variant-filled" use:popup={exampleFocus}> Focus </button>
+						<div class="card p-4 w-72 shadow-xl" data-popup="exampleFocus">
+							<!-- NOTE: Keep this wrapper, .space-y will affect the arrow -->
+							<div class="space-y-4">
+								<span> This element will stick around until you click or focus outside of it. </span>
+								<button class="btn variant-soft w-full"> Click me </button>
+							</div>
+							<!-- Arrow -->
+							<div class="arrow bg-surface-100-800-token" />
+						</div>
+					</div>
+					<div>
+						<button class="btn variant-filled" use:popup={exampleFocusClick}> Focus-Click </button>
+						<div class="card p-4 w-72 shadow-xl" data-popup="exampleFocusClick">
+							<!-- NOTE: Keep this wrapper, .space-y will affect the arrow -->
+							<div class="space-y-4">
+								<span> This will close if you click or focus outside, or if you click the Focus-Click button again. </span>
+								<button class="btn variant-soft w-full"> Click me </button>
 							</div>
 							<!-- Arrow -->
 							<div class="arrow bg-surface-100-800-token" />

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -117,9 +117,9 @@
 								<a class="btn variant-soft w-full" href="https://twitter.com/SkeletonUI" target="_blank" rel="noreferrer">
 									View on Twitter
 								</a>
-								<!-- Arrow -->
-								<div class="arrow variant-filled" />
 							</div>
+							<!-- Arrow -->
+							<div class="arrow bg-surface-100-800-token" />
 						</div>
 					</div>
 					<div>

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -66,7 +66,12 @@
 	let exampleMenu: PopupSettings = {
 		event: 'click',
 		target: 'exampleMenu',
-		placement: 'bottom'
+		placement: 'bottom',
+		middleware: {
+			arrow: {
+				element: '#myArrow'
+			}
+		}
 	};
 	let exampleFocus: PopupSettings = {
 		event: 'focus',
@@ -113,8 +118,7 @@
 									View on Twitter
 								</a>
 							</div>
-							<!-- Arrow -->
-							<div class="arrow bg-surface-100-800-token" />
+							<div id="myArrow" class="arrow bg-surface-500" />
 						</div>
 					</div>
 					<div>

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -154,7 +154,7 @@
 					language="ts"
 					code={`
 let popupSettings: PopupSettings = {
-	// Set the event as: click | hover | hover-click
+	// Set the event as: click | hover | hover-click | focus | focus-click
 	event: 'click',
 	// Provide a matching 'data-popup' value.
 	target: 'examplePopup'

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -117,6 +117,8 @@
 								<a class="btn variant-soft w-full" href="https://twitter.com/SkeletonUI" target="_blank" rel="noreferrer">
 									View on Twitter
 								</a>
+								<!-- Arrow -->
+								<div class="arrow variant-filled" />
 							</div>
 						</div>
 					</div>

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -52,7 +52,7 @@
 	let tabSettings: number = 0;
 	let comboboxValue: string;
 	let popupCombobox: PopupSettings = {
-		event: 'click',
+		event: 'focus-click',
 		target: 'combobox',
 		placement: 'bottom',
 		closeQuery: '.listbox-item'
@@ -73,15 +73,14 @@
 			}
 		}
 	};
-	let exampleFocus: PopupSettings = {
+	let inputPopupFocus: PopupSettings = {
 		event: 'focus',
-		target: 'exampleFocus',
-		placement: 'bottom'
+		target: 'inputPopupFocus',
+		placement: 'top'
 	};
-	let exampleFocusClick: PopupSettings = {
+	let inputPopupFocusClick: PopupSettings = {
 		event: 'focus-click',
-		target: 'exampleFocusClick',
-		placement: 'bottom'
+		target: 'inputPopupFocusClick'
 	};
 	let interactiveMenu: PopupSettings = {
 		event: 'click',
@@ -124,44 +123,22 @@
 									View on Twitter
 								</a>
 							</div>
-							<div id="myArrow" class="arrow bg-surface-500" />
 						</div>
-					</div>
-					<div>
-						<button class="btn variant-filled" use:popup={exampleFocus}> Focus </button>
-						<div class="card p-4 w-72 shadow-xl" data-popup="exampleFocus">
-							<!-- NOTE: Keep this wrapper, .space-y will affect the arrow -->
-							<div class="space-y-4">
-								<span> This element will stick around until you click or focus outside of it. </span>
-								<button class="btn variant-soft w-full"> Click me </button>
+						<div>
+							<button class="btn variant-filled" use:popup={interactiveMenu}>Interactive</button>
+							<div
+								class="text-xs text-center card variant-filled p-2 whitespace-nowrap shadow-xl flex flex-col"
+								data-popup="interactiveMenu"
+							>
+								<p>This is an interactive example tooltip.</p>
+								<button class="btn variant-ringed-primary">I won't close the menu</button>
+								<!-- Arrow -->
+								<div class="arrow variant-filled" />
 							</div>
-							<!-- Arrow -->
-							<div class="arrow bg-surface-100-800-token" />
 						</div>
 					</div>
-					<div>
-						<button class="btn variant-filled" use:popup={exampleFocusClick}> Focus-Click </button>
-						<div class="card p-4 w-72 shadow-xl" data-popup="exampleFocusClick">
-							<!-- NOTE: Keep this wrapper, .space-y will affect the arrow -->
-							<div class="space-y-4">
-								<span> This will close if you click or focus outside, or if you click the Focus-Click button again. </span>
-								<button class="btn variant-soft w-full"> Click me </button>
-							</div>
-							<!-- Arrow -->
-							<div class="arrow bg-surface-100-800-token" />
-						</div>
-					</div>
-					<div>
-						<button class="btn variant-filled" use:popup={interactiveMenu}>Interactive</button>
-						<div class="text-xs text-center card variant-filled p-2 whitespace-nowrap shadow-xl flex flex-col" data-popup="interactiveMenu">
-							<p>This is an interactive example tooltip.</p>
-							<button class="btn variant-ringed-primary">I won't close the menu</button>
-							<!-- Arrow -->
-							<div class="arrow variant-filled" />
-						</div>
-					</div>
-				</div>
-			</svelte:fragment>
+				</div></svelte:fragment
+			>
 			<svelte:fragment slot="source">
 				<!-- prettier-ignore -->
 				<p>Create a <code>PopupSettings</code> object that maps to <a href="https://floating-ui.com/" target="_blank" rel="noreferrer">Floating UI</a> settings.</p>
@@ -290,7 +267,11 @@ let popupSettings: PopupSettings = {
 		<!-- Combobox -->
 		<section class="space-y-4">
 			<h2>Combobox</h2>
-			<p>By combining popups and Skeleton listboxes we can create a functional combobox element.</p>
+			<p>
+				By combining popups and Skeleton listboxes we can create a functional combobox element. 
+				We can use the <code>focus-click</code> event
+				so it opens for keyboard users when focussed.
+			</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<!-- Combobox -->
@@ -316,7 +297,7 @@ let popupSettings: PopupSettings = {
 						language="ts"
 						code={`
 let popupCombobox: PopupSettings = {
-	event: 'click',
+	event: 'focus-click',
 	target: 'combobox',
 	placement: 'bottom',
 	// Close the popup when the item is clicked
@@ -356,11 +337,68 @@ let popupCombobox: PopupSettings = {
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
+		<section class="space-y-4">
+			<h2>Focus Event</h2>
+			<p>
+				We can use the <code>focus</code> event to open the popup when the trigger is focussed. This is helpful for elements like
+				<code>input</code> since the popup will remain open while the user has their cursor in the input. <code>focus-click</code> works the
+				same, but if the popup is open and the target is clicked, it will close.
+			</p>
+			<DocsPreview>
+				<svelte:fragment slot="preview">
+					<div class="flex flex-col space-y-4">
+						<div class="text-token">
+							<input type="text" class="input" placeholder="Focus" use:popup={inputPopupFocus} />
+							<div data-popup="inputPopupFocus" class="card p-4">
+								<span> You can dismiss me by clicking or focusing outside </span>
+							</div>
+						</div>
+						<div class="text-token">
+							<input type="text" class="input" placeholder="Focus Click" use:popup={inputPopupFocusClick} />
+							<div data-popup="inputPopupFocusClick" class="card p-4">
+								<span> You can dismiss me by clicking on the input, or outside of it </span>
+							</div>
+						</div>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`	let focusPopup: PopupSettings = {
+	event: 'focus',
+	target: 'focus'
+};
+let focusClickPopup: PopupSettings = {
+	event: 'focus-click',
+	target: 'focusClick'
+};`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`<div class="text-token">
+	<input type="text" class="input" placeholder="Focus" use:popup={focus} />
+	<div data-popup="focus" class="card p-4">
+		<span> You can dismiss me by clicking or focusing outside </span>
+	</div>
+</div>
+<div class="text-token">
+	<input type="text" class="input" placeholder="Focus Click" use:popup={focusClick} />
+	<div data-popup="focusClick" class="card p-4">
+		<span> You can dismiss me by clicking on the input, or outside of it </span>
+	</div>
+</div>
+								`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
 		<!-- Z-index -->
 		<section class="space-y-4">
 			<h2>Z-Index</h2>
 			<p>
-				Neither Skeleton nor Floating-UI will provide a Z-Index out of the box for the reasons layed out in the <a href="https://floating-ui.com/docs/misc#z-index-stacking">Floating-UI docs</a>.
+				Neither Skeleton nor Floating-UI will provide a Z-Index out of the box for the reasons layed out in the <a
+					href="https://floating-ui.com/docs/misc#z-index-stacking">Floating-UI docs</a
+				>.
 			</p>
 		</section>
 		<!-- Browser Support -->

--- a/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/src/routes/(inner)/utilities/popups/+page.svelte
@@ -30,7 +30,7 @@
 			['<code>[data-popup] .arrow</code>', '', 'Provides base styles to the arrow element.']
 		],
 		parameters: [
-			['<code>event</code>', 'string', 'click', 'click | hover | hover-click', 'Provide the event type'],
+			['<code>event</code>', 'string', 'click', 'click | hover | hover-click | focus | focus-click', 'Provide the popup event type.'],
 			['<code>target</code>', 'string', '-', '-', 'Match the popup data value of <code>[data-popup]</code>'],
 			['<code>placement</code>', 'string', '-', 'bottom', 'Set the placement position.'],
 			['<code>closeQuery</code>', 'string', 'a[href], button', '-', 'Query list of elements that will close the popup.'],
@@ -51,13 +51,6 @@
 	// Local
 	let tabSettings: number = 0;
 	let comboboxValue: string;
-	let popupCombobox: PopupSettings = {
-		event: 'focus-click',
-		target: 'combobox',
-		placement: 'bottom',
-		closeQuery: '.listbox-item'
-		// state: (e: any) => console.log('tooltip', e)
-	};
 	let exampleTooltip: PopupSettings = {
 		event: 'hover',
 		target: 'exampleTooltip',
@@ -77,11 +70,12 @@
 		event: 'focus-click',
 		target: 'inputPopupFocusClick'
 	};
-	let interactiveMenu: PopupSettings = {
-		event: 'click',
-		target: 'interactiveMenu',
-		placement: 'right',
-		closeQuery: ''
+	let popupCombobox: PopupSettings = {
+		event: 'focus-click',
+		target: 'combobox',
+		placement: 'bottom',
+		closeQuery: '.listbox-item'
+		// state: (e: any) => console.log('tooltip', e)
 	};
 </script>
 
@@ -120,15 +114,6 @@
 							</div>
 							<!-- Arrow -->
 							<div class="arrow bg-surface-100-800-token" />
-						</div>
-					</div>
-					<div>
-						<button class="btn variant-filled" use:popup={interactiveMenu}>Interactive</button>
-						<div class="text-xs text-center card variant-filled p-2 whitespace-nowrap shadow-xl flex flex-col" data-popup="interactiveMenu">
-							<p>This is an interactive example tooltip.</p>
-							<button class="btn variant-ringed-primary">I won't close the menu</button>
-							<!-- Arrow -->
-							<div class="arrow variant-filled" />
 						</div>
 					</div>
 				</div>
@@ -187,8 +172,8 @@ let popupSettings: PopupSettings = {
 			<h2>Popup Settings</h2>
 			<TabGroup regionPanel="space-y-4">
 				<Tab bind:group={tabSettings} name="settings" value={0}>Placement</Tab>
-				<Tab bind:group={tabSettings} name="settings" value={1}>State</Tab>
-				<Tab bind:group={tabSettings} name="settings" value={2}>Close Query</Tab>
+				<Tab bind:group={tabSettings} name="settings" value={1}>Close Query</Tab>
+				<Tab bind:group={tabSettings} name="settings" value={2}>State</Tab>
 				<Tab bind:group={tabSettings} name="settings" value={3}>Middleware</Tab>
 				<!-- Tab Panels --->
 				<svelte:fragment slot="panel">
@@ -207,13 +192,36 @@ let popupSettings: PopupSettings = {
 `}
 						/>
 					{:else if tabSettings === 1}
+						<!-- Close Query -->
+						<!-- prettier-ignore -->
+						<p>Query the list of elements that will close the drawer when clicked. This is set to <code>'a[href], button'</code> by default, but to limited to <code>.listbox-item</code> only we would use:</p>
+						<CodeBlock
+							language="ts"
+							code={`
+let popupSettings: PopupSettings = {
+	// Only listbox items will close the popup:
+	closeQuery: '.listbox-item',
+};
+`}
+						/>
+						<p>To disable any child elements from closing the popup, use the following:</p>
+						<CodeBlock
+							language="ts"
+							code={`
+let popupSettings: PopupSettings = {
+	// No chidren will close the popup:
+	closeQuery: '',
+};
+`}
+						/>
+					{:else if tabSettings === 2}
 						<!-- State Handler -->
 						<p>You can optionally monitor the show and hide state of a popup using <code>state</code>.</p>
 						<CodeBlock
 							language="ts"
 							code={`
 let popupSettings: PopupSettings = {
-	state: (e) => console.log(e)
+state: (e) => console.log(e)
 };
 `}
 						/>
@@ -221,42 +229,87 @@ let popupSettings: PopupSettings = {
 						<!-- Middlware -->
 						<!-- prettier-ignore -->
 						<p>
-						You can provide <a href="https://floating-ui.com/docs/middleware" target="_blank" rel="noreferrer">Floating UI middleware</a> settings within <code>PopupSettings</code>. These settings are passed verbatim.
-					</p>
+					You can provide <a href="https://floating-ui.com/docs/middleware" target="_blank" rel="noreferrer">Floating UI middleware</a> settings within <code>PopupSettings</code>. These settings are passed verbatim.
+				</p>
 						<CodeBlock
 							language="ts"
 							code={`
 let popupSettings: PopupSettings = {
-	middleware: {
-		// Floating UI Middlware
-		/** https://floating-ui.com/docs/offset */
-		offset: 24, // or { ... }
-		/** https://floating-ui.com/docs/shift */
-		shift: { ... },
-		/** https://floating-ui.com/docs/flip */
-		flip: { ... },
-		/** https://floating-ui.com/docs/arrow */
-		arrow: { ... }
-	}
-};
-`}
-						/>
-					{:else if tabSettings === 2}
-						<!-- Close Query -->
-						<!-- prettier-ignore -->
-						<p>Query the list of elements that will close the drawer when clicked. This is set to <code>'a[href], button'</code> by default.</p>
-						<CodeBlock
-							language="ts"
-							code={`
-let popupSettings: PopupSettings = {
-	// Limit to listbox items only:
-	closeQuery: '.listbox-item',
+middleware: {
+	// Floating UI Middlware
+	/** https://floating-ui.com/docs/offset */
+	offset: 24, // or { ... }
+	/** https://floating-ui.com/docs/shift */
+	shift: { ... },
+	/** https://floating-ui.com/docs/flip */
+	flip: { ... },
+	/** https://floating-ui.com/docs/arrow */
+	arrow: { ... }
+}
 };
 `}
 						/>
 					{/if}
 				</svelte:fragment>
 			</TabGroup>
+		</section>
+		<!-- Focus Event -->
+		<section class="space-y-4">
+			<h2>Focus Event</h2>
+			<p>
+				Use the <code>focus</code> event to display popups while the trigger element is focused. Likewise use <code>focus-click</code> to toggle
+				the popup even when tapping the same trigger element repeatedly.
+			</p>
+			<DocsPreview>
+				<svelte:fragment slot="preview">
+					<div class="flex flex-col space-y-4">
+						<div class="text-token">
+							<input type="text" class="input" placeholder="Focus" use:popup={inputPopupFocus} />
+							<div data-popup="inputPopupFocus" class="card variant-filled p-4">Click outside to close.</div>
+						</div>
+						<div class="text-token">
+							<input type="text" class="input" placeholder="Focus Click" use:popup={inputPopupFocusClick} />
+							<div data-popup="inputPopupFocusClick" class="card variant-filled p-4">Click the input or outside to close.</div>
+						</div>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<h3>Focus</h3>
+					<CodeBlock
+						language="ts"
+						code={`
+let focusPopup: PopupSettings = {
+	event: 'focus',
+	target: 'focus'
+};
+						`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<input type="text" class="input" placeholder="Focus" use:popup={focus} />
+<div data-popup="focus" class="card variant-filled p-4">Click outside to close.</div>
+						`}
+					/>
+					<h3>Focus-Click</h3>
+					<CodeBlock
+						language="ts"
+						code={`
+let focusClickPopup: PopupSettings = {
+	event: 'focus-click',
+	target: 'focusClick'
+};
+						`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<input type="text" class="input" placeholder="Focus Click" use:popup={focusClick} />
+<div data-popup="focusClick" class="card variant-filled p-4">Click the input or outside to close.</div>
+						`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
 		</section>
 		<!-- Combobox -->
 		<section class="space-y-4">
@@ -326,61 +379,6 @@ let popupCombobox: PopupSettings = {
 	<div class="arrow bg-surface-100-800-token" />
 </div>
 `}
-					/>
-				</svelte:fragment>
-			</DocsPreview>
-		</section>
-		<section class="space-y-4">
-			<h2>Focus Event</h2>
-			<p>
-				We can use the <code>focus</code> event to open the popup when the trigger is focussed. This is helpful for elements like
-				<code>input</code> since the popup will remain open while the user has their cursor in the input. <code>focus-click</code> works the
-				same, but if the popup is open and the target is clicked, it will close.
-			</p>
-			<DocsPreview>
-				<svelte:fragment slot="preview">
-					<div class="flex flex-col space-y-4">
-						<div class="text-token">
-							<input type="text" class="input" placeholder="Focus" use:popup={inputPopupFocus} />
-							<div data-popup="inputPopupFocus" class="card p-4">
-								<span> You can dismiss me by clicking or focusing outside </span>
-							</div>
-						</div>
-						<div class="text-token">
-							<input type="text" class="input" placeholder="Focus Click" use:popup={inputPopupFocusClick} />
-							<div data-popup="inputPopupFocusClick" class="card p-4">
-								<span> You can dismiss me by clicking on the input, or outside of it </span>
-							</div>
-						</div>
-					</div>
-				</svelte:fragment>
-				<svelte:fragment slot="source">
-					<CodeBlock
-						language="ts"
-						code={`	let focusPopup: PopupSettings = {
-	event: 'focus',
-	target: 'focus'
-};
-let focusClickPopup: PopupSettings = {
-	event: 'focus-click',
-	target: 'focusClick'
-};`}
-					/>
-					<CodeBlock
-						language="html"
-						code={`<div class="text-token">
-	<input type="text" class="input" placeholder="Focus" use:popup={focus} />
-	<div data-popup="focus" class="card p-4">
-		<span> You can dismiss me by clicking or focusing outside </span>
-	</div>
-</div>
-<div class="text-token">
-	<input type="text" class="input" placeholder="Focus Click" use:popup={focusClick} />
-	<div data-popup="focusClick" class="card p-4">
-		<span> You can dismiss me by clicking on the input, or outside of it </span>
-	</div>
-</div>
-								`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>


### PR DESCRIPTION
## What does your PR address?

Adds a `focus` event to the options passed to `use:popup`. This allows us to trigger the menu when an element is either clicked or tabbed to, and close it when focus moves outside the menu.
In `focus-click`, we do the same, but add a listener to the `click` event on the trigger node, so when the node already has focus, it can still be toggled by clicking the button.

It might be worth adding a notice at the top of the page that this might not work unless you enable the "Press tab to highlight each option on a webpage" toggle in Safari.
