### PR TITLE
Fix Dismissed Toast Timeouts Closing Other Toast

### DIFF
--- a/src/lib/utilities/Toast/types.ts
+++ b/src/lib/utilities/Toast/types.ts
@@ -26,5 +26,5 @@ export interface Toast extends ToastSettings {
 	/** A UUID will be auto-assigned on `.trigger()`. */
 	id: string;
 	/** The id of the `setTimeout` if `autohide` is enabled  */
-	timeoutId?: NodeJS.Timeout;
+	timeoutId?: ReturnType<typeof setTimeout>;
 }

--- a/src/lib/utilities/Toast/types.ts
+++ b/src/lib/utilities/Toast/types.ts
@@ -25,4 +25,6 @@ export interface ToastSettings {
 export interface Toast extends ToastSettings {
 	/** A UUID will be auto-assigned on `.trigger()`. */
 	id: string;
+	/** The id of the `setTimeout` if `autohide` is enabled  */
+	timeoutId?: NodeJS.Timeout;
 }


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?
- Fixes #1197 
- Adds `timeoutId` to the `Toast` type
- Clears timeout for closed Toasts
- Adds conditional check before removing toasts from the `tStore`

### Additional Notes
I welcome any and all feedback! Just let me know if you noticed anything that seem "off". As well I attempted to add a test for this change, but was running into some issues with the Vitest mocked timers. If anyone has some experience with those I'd love to get some tests to double check this fix! Also I noticed the test file is misspelled (`Toats.test.ts`), but decided to keep this MR focused on fixing the base issue. I'd gladly open another PR to fix that if it's a concern.
