### PR TITLE
Level the horizontal padding  on table cells 

### DIFF
--- a/src/lib/styles/elements/tables.css
+++ b/src/lib/styles/elements/tables.css
@@ -50,7 +50,7 @@
 	}
 
 	.table thead th {
-		@apply font-bold p-4;
+		@apply font-bold px-3 py-4;
 	}
 
 	/* === Table Body === */
@@ -84,7 +84,7 @@
 
 	.table tfoot th,
 	.table tfoot td {
-		@apply p-4;
+		@apply px-3 py-4;
 	}
 
 	/* === Rows Specific === */


### PR DESCRIPTION
Horizontal padding  on table cells  (th / td) no matter in which area of the table should stay in line

- gives all cells a px-3 so that everything stays in line.
- `<th /> `bold formatting is good enough to let it stand out from the rest

## Before submitting the PR:
- [ x ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ x ] Did you update and run tests before submission using `npm run test`?
- [ x ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

[Fixes #1212]

Smoothening the layout of tables
