### PR TITLE
Removed problem causing dot from Font instructions.

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -6,22 +6,22 @@
 /* Google Fonts */
 @font-face {
 	font-family: 'Quicksand';
-	src: url('./fonts/Quicksand.ttf');
+	src: url('/fonts/Quicksand.ttf');
 	font-display: swap;
 }
 @font-face {
 	font-family: 'Space Grotesk';
-	src: url('./fonts/SpaceGrotesk.ttf');
+	src: url('/fonts/SpaceGrotesk.ttf');
 	font-display: swap;
 }
 @font-face {
 	font-family: 'Playfair Display';
-	src: url('./fonts/PlayfairDisplay-Italic.ttf');
+	src: url('/fonts/PlayfairDisplay-Italic.ttf');
 	font-display: swap;
 }
 @font-face {
 	font-family: 'Abril Fatface';
-	src: url('./fonts/AbrilFatface.ttf');
+	src: url('/fonts/AbrilFatface.ttf');
 	font-display: swap;
 }
 

--- a/src/routes/(inner)/docs/themes/+page.svelte
+++ b/src/routes/(inner)/docs/themes/+page.svelte
@@ -140,7 +140,7 @@ body {
 	/* Reference name */
 	font-family: '${f.name}';
 	/* For multiple files use commas, ex: url(), url(), ... */
-	src: url('./fonts/${f.file}');
+	src: url('/fonts/${f.file}');
 }
 							`}
 						/>


### PR DESCRIPTION
Not an issue but the new Theme-Docs had a small mistake that we all missed:

The font-family src-import needs to be ``src: url('/fonts/${f.file}');`` instead of ``src: url('./fonts/${f.file}');``