### PR TITLE
use namespaced `Skeleton.ModalMeta`

### DIFF
--- a/src/lib/ambient.d.ts
+++ b/src/lib/ambient.d.ts
@@ -1,0 +1,3 @@
+declare namespace Skeleton {
+	type ModalMeta = any;
+}

--- a/src/lib/utilities/Modal/types.ts
+++ b/src/lib/utilities/Modal/types.ts
@@ -1,5 +1,5 @@
 // Modal Types
-
+import '../../ambient';
 export interface ModalComponent {
 	/** Import and provide your component reference. */
 	ref: any;
@@ -39,5 +39,5 @@ export interface ModalSettings {
 	/** Override the Submit button label. */
 	buttonTextSubmit?: string;
 	/** Pass arbitrary data per modal instance. */
-	meta?: any;
+	meta?: Skeleton.ModalMeta;
 }


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Fixes  #1231
By adding a namespaced type `Skeleton.ModalMeta`, users of Skeleton can overwrite the type to fit their application, similar to SvelteKit's `App.Locals` etc.
This will cause type errors similar to props, and if using typeguards, intellisense for the specific modal component, not just all modal components
