### PR TITLE
bugfix: add `onPopupClick` listener to close when closeQuery matches

### DIFF
--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -118,10 +118,6 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 			}
 		}
 	};
-	function onPopupClick(e: MouseEvent) {
-		if (!isNode(e.target)) return;
-		closeOnQueryClick(e.target);
-	}
 
 	// Hover Handlers
 	const onMouseOver = () => {
@@ -246,7 +242,7 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		// when we focus off the end of the list, close the popup
 		elemPopup.addEventListener('focusout', onFocusOut, true);
 		// when an element inside the popup is clicked, close the popup if the element matches the closeQuery
-		elemPopup.addEventListener('click', onPopupClick, true);
+		elemPopup.addEventListener('click', onWindowClick, true);
 	}
 	if (args.event === 'focus-click') {
 		// we must use mousedown instead of click because click fires after focusin, meaning isVisible would always be true

--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -91,6 +91,16 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		}
 	}
 
+	// Close popup if element matching closeQuery is clicked
+	function closeOnQueryClick(clickedEl: Node) {
+		if (!clickedEl) return;
+		const interactiveMenuElems = elemPopup?.querySelectorAll(args.closeQuery || '');
+		if (!interactiveMenuElems?.length) return;
+		interactiveMenuElems.forEach((elem) => {
+			if (elem.contains(clickedEl)) close();
+		});
+	}
+
 	// Window Click Handler
 	const onWindowClick = (event: any) => {
 		if (!node || !elemPopup) return;
@@ -104,15 +114,14 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 			if (clickedOutsidePopup) {
 				close();
 			} else {
-				// If click is interactive child element within popup (ex: anchor or button)
-				const interactiveMenuElems = elemPopup?.querySelectorAll(args.closeQuery || '');
-				if (!interactiveMenuElems.length) return;
-				interactiveMenuElems.forEach((elem) => {
-					if (elem.contains(event.target)) close();
-				});
+				closeOnQueryClick(event.target);
 			}
 		}
 	};
+	function onPopupClick(e: MouseEvent) {
+		if (!isNode(e.target)) return;
+		closeOnQueryClick(e.target);
+	}
 
 	// Hover Handlers
 	const onMouseOver = () => {
@@ -236,6 +245,8 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		elemPopup.addEventListener('focusin', onFocusIn, true);
 		// when we focus off the end of the list, close the popup
 		elemPopup.addEventListener('focusout', onFocusOut, true);
+		// when an element inside the popup is clicked, close the popup if the element matches the closeQuery
+		elemPopup.addEventListener('click', onPopupClick, true);
 	}
 	if (args.event === 'focus-click') {
 		// we must use mousedown instead of click because click fires after focusin, meaning isVisible would always be true


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Fixes #1229
Adds an `onPopupClick` handler to close when an element which matches `closeQuery` or is a descendant of an element that matches `closeQuery`, as in `onWindowClick`.

I've moved the logic for closing based on `closeQuery` to its own function, `closeOnQueryClick` since the code is reused by both `onWindowClick` and `onPopupClick`. 

