### PR TITLE
bugfix: only dispatch `backdrop` event if backdrop clicked

### DIFF
--- a/src/lib/utilities/Modal/Modal.svelte
+++ b/src/lib/utilities/Modal/Modal.svelte
@@ -102,10 +102,12 @@
 
 	function onBackdropInteraction(event: MouseEvent | TouchEvent): void {
 		if (!(event.target instanceof Element)) return;
-		if (event.target.classList.contains('modal-backdrop')) onClose();
-		if (event.target.classList.contains('modal-transition')) onClose();
-		/** @event {{ event }} backdrop - Fires on backdrop interaction.  */
-		dispatch('backdrop', event);
+		const classList = event.target.classList;
+		if (classList.contains('modal-backdrop') || classList.contains('modal-transition')) {
+			onClose();
+			/** @event {{ event }} backdrop - Fires on backdrop interaction.  */
+			dispatch('backdrop', event);
+		}
 	}
 
 	function onClose(): void {


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Fixes #1240 
Before, the `backdrop` event was dispatched whenever an element inside the modal component was clicked.
Now, it only dispatches the event when the backdrop is clicked
