### PR TITLE
Fix off-center text rendering for avatar

### DIFF
--- a/src/lib/components/Avatar/Avatar.svelte
+++ b/src/lib/components/Avatar/Avatar.svelte
@@ -52,7 +52,7 @@
 		<img class="avatar-image {cImage}" style={$$props.style ?? ''} {src} alt={$$props.alt || ''} use:action={actionParams} {...prunedRestProps()} />
 	{:else}
 		<svg class="avatar-initials w-full h-full" viewBox="0 0 512 512">
-			<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-weight="bold" font-size={150} class="avatar-text {fill}">
+			<text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-weight="bold" font-size={150} class="avatar-text {fill}">
 				{String(initials).substring(0, 2).toUpperCase()}
 			</text>
 		</svg>


### PR DESCRIPTION
## Before submitting the PR:
- [x] Did you update and run tests before submission using `npm run test`?
  - Ran test but there was un-related error: `src/lib/components/RangeSlider/RangeSlider.test.ts > RangeSlider.svelte > Ticks enabled
AssertionError: expected null to be truthy`
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`

## What does your PR address?
Fix the SVG off-center text rendering for the Avatar component. Fixed by changing `dominant-baseline` HTML value to "central"
