### PR TITLE
Delete role + tabindex from non-interactive labels

### DIFF
--- a/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/src/lib/components/ListBox/ListBoxItem.svelte
@@ -71,31 +71,35 @@
 	$: classesLabel = `${cLabel}`;
 </script>
 
-<!-- WARNING: avoid click handlers on <label>; will fire twice -->
-<label
-	class="listbox-item {classesBase}"
-	aria-selected={selected}
-	data-testid="listbox-item"
-	on:keydown={onKeyDown}
-	on:keydown
-	on:keyup
-	on:keypress
->
-	<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
-	<div class="h-0 w-0 overflow-hidden">
-		{#if multiple}
-			<input bind:this={elemInput} type="checkbox" {name} {value} bind:checked tabindex="-1" on:click on:change />
-		{:else}
-			<input bind:this={elemInput} type="radio" bind:group {name} {value} tabindex="-1" on:click on:change />
-		{/if}
-	</div>
-	<!-- <slot /> -->
-	<div class="listbox-label {classesLabel}">
-		<!-- Slot: Lead -->
-		{#if $$slots.lead}<div class="listbox-label-lead"><slot name="lead" /></div>{/if}
-		<!-- Slot: Default -->
-		<div class="listbox-label-content flex-1"><slot /></div>
-		<!-- Slot: Trail -->
-		{#if $$slots.trail}<div class="listbox-label-trail"><slot name="trail" /></div>{/if}
+<label>
+	<!-- A11y attributes are not allowed on <label> -->
+	<div
+		class="listbox-item {classesBase}"
+		data-testid="listbox-item"
+		role="option"
+		aria-selected={selected}
+		tabindex="0"
+		on:keydown={onKeyDown}
+		on:keydown
+		on:keyup
+		on:keypress
+	>
+		<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
+		<div class="h-0 w-0 overflow-hidden">
+			{#if multiple}
+				<input bind:this={elemInput} type="checkbox" {name} {value} bind:checked tabindex="-1" on:click on:change />
+			{:else}
+				<input bind:this={elemInput} type="radio" bind:group {name} {value} tabindex="-1" on:click on:change />
+			{/if}
+		</div>
+		<!-- <slot /> -->
+		<div class="listbox-label {classesLabel}">
+			<!-- Slot: Lead -->
+			{#if $$slots.lead}<div class="listbox-label-lead"><slot name="lead" /></div>{/if}
+			<!-- Slot: Default -->
+			<div class="listbox-label-content flex-1"><slot /></div>
+			<!-- Slot: Trail -->
+			{#if $$slots.trail}<div class="listbox-label-trail"><slot name="trail" /></div>{/if}
+		</div>
 	</div>
 </label>

--- a/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/src/lib/components/ListBox/ListBoxItem.svelte
@@ -74,9 +74,7 @@
 <!-- WARNING: avoid click handlers on <label>; will fire twice -->
 <label
 	class="listbox-item {classesBase}"
-	role="option"
 	aria-selected={selected}
-	tabindex="0"
 	data-testid="listbox-item"
 	on:keydown={onKeyDown}
 	on:keydown

--- a/src/lib/components/Radio/RadioItem.svelte
+++ b/src/lib/components/Radio/RadioItem.svelte
@@ -65,10 +65,8 @@
 <label
 	class="radio-item {classesBase}"
 	{title}
-	role="radio"
 	aria-checked={checked}
 	aria-label={label}
-	tabindex="0"
 	data-testid="radio-item"
 	on:keydown={onKeyDown}
 	on:keydown

--- a/src/lib/components/Radio/RadioItem.svelte
+++ b/src/lib/components/Radio/RadioItem.svelte
@@ -39,9 +39,8 @@
 	// Local
 	let elemInput: HTMLElement;
 
-	// A11y Input Handlers
-	function onKeyDown(event: any): void {
-		// Enter/Space triggers selecton event
+	// A11y Key Down Handler
+	function onKeyDown(event: KeyboardEvent): void {
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();
 			elemInput.click();
@@ -61,21 +60,25 @@
 	}
 </script>
 
-<!-- WARNING: avoid click handlers on <label>; will fire twice -->
-<label
-	class="radio-item {classesBase}"
-	{title}
-	aria-checked={checked}
-	aria-label={label}
-	data-testid="radio-item"
-	on:keydown={onKeyDown}
-	on:keydown
-	on:keyup
-	on:keypress
->
-	<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
-	<div class="h-0 w-0 overflow-hidden">
-		<input bind:this={elemInput} type="radio" bind:group {name} {value} {...prunedRestProps()} tabindex="-1" on:click on:change />
+<label>
+	<!-- A11y attributes are not allowed on <label> -->
+	<div
+		class="radio-item {classesBase}"
+		data-testid="radio-item"
+		role="radio"
+		aria-checked={checked}
+		aria-label={label}
+		tabindex="0"
+		{title}
+		on:keydown={onKeyDown}
+		on:keydown
+		on:keyup
+		on:keypress
+	>
+		<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
+		<div class="h-0 w-0 overflow-hidden">
+			<input bind:this={elemInput} type="radio" bind:group {name} {value} {...prunedRestProps()} tabindex="-1" on:click on:change />
+		</div>
+		<slot />
 	</div>
-	<slot />
 </label>

--- a/src/lib/components/Tab/Tab.svelte
+++ b/src/lib/components/Tab/Tab.svelte
@@ -51,8 +51,8 @@
 	// Local
 	let elemInput: HTMLElement;
 
-	function onKeypress(event: any): void {
-		// Enter/Space to toggle element
+	// A11y Key Down Handler
+	function onKeyDown(event: KeyboardEvent): void {
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();
 			elemInput.click();
@@ -72,24 +72,28 @@
 	}
 </script>
 
-<!-- WARNING: avoid click handlers on <label>; will fire twice -->
-<label
-	class="tab {classesBase}"
-	aria-controls={controls}
-	aria-selected={selected}
-	data-testid="tab"
-	on:keypress={onKeypress}
-	on:keypress
-	on:keydown
-	on:keyup
->
-	<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
-	<div class="h-0 w-0 overflow-hidden">
-		<input bind:this={elemInput} type="radio" bind:group {name} {value} {...prunedRestProps()} tabindex="-1" on:click on:change />
-	</div>
-	<!-- Interface -->
-	<div class="tab-interface {classesInterface}">
-		{#if $$slots.lead}<div class="tab-lead"><slot name="lead" /></div>{/if}
-		<div class="tab-label"><slot /></div>
+<label>
+	<!-- A11y attributes are not allowed on <label> -->
+	<div
+		class="tab {classesBase}"
+		data-testid="tab"
+		role="tab"
+		aria-controls={controls}
+		aria-selected={selected}
+		tabindex="0"
+		on:keydown={onKeyDown}
+		on:keydown
+		on:keyup
+		on:keypress
+	>
+		<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
+		<div class="h-0 w-0 overflow-hidden">
+			<input bind:this={elemInput} type="radio" bind:group {name} {value} {...prunedRestProps()} tabindex="-1" on:click on:change />
+		</div>
+		<!-- Interface -->
+		<div class="tab-interface {classesInterface}">
+			{#if $$slots.lead}<div class="tab-lead"><slot name="lead" /></div>{/if}
+			<div class="tab-label"><slot /></div>
+		</div>
 	</div>
 </label>

--- a/src/lib/components/Tab/Tab.svelte
+++ b/src/lib/components/Tab/Tab.svelte
@@ -75,10 +75,8 @@
 <!-- WARNING: avoid click handlers on <label>; will fire twice -->
 <label
 	class="tab {classesBase}"
-	role="tab"
 	aria-controls={controls}
 	aria-selected={selected}
-	tabindex="0"
 	data-testid="tab"
 	on:keypress={onKeypress}
 	on:keypress


### PR DESCRIPTION
This gets rid of the SK warnings and seems to make sense in that the role and tab index were on the label as well as the actual active input.