### PR TITLE
Add ability to set modal animation duration In/Out seperately

### DIFF
--- a/src/lib/utilities/Modal/Modal.svelte
+++ b/src/lib/utilities/Modal/Modal.svelte
@@ -23,7 +23,7 @@
 	// Props (transitions)
 	// Set JSDoc annotation for duration below manually so it's picked up properly by Sveld.
 	/**
- 	* Set the open/close animation duration. Set '0' (zero) to disable, or set as Array to control In/Out duration seperately.
+ 	* Set the open/close animation duration. Set '0' (zero) to disable, or set as Array to control In[0]/Out[1] duration seperately.
 	* @type {number | [number, number]} 
 	*/
 	export let duration: number | [number, number] = 150;

--- a/src/lib/utilities/Modal/Modal.svelte
+++ b/src/lib/utilities/Modal/Modal.svelte
@@ -21,7 +21,11 @@
 	export let components: Record<string, ModalComponent> = {};
 
 	// Props (transitions)
-	/** The open/close animation duration. Set '0' (zero) to disable, or set as Array to control In/Out duration seperately. */
+	// Set JSDoc annotation for duration below manually so it's picked up properly by Sveld.
+	/**
+ 	* Set the open/close animation duration. Set '0' (zero) to disable, or set as Array to control In/Out duration seperately.
+	* @type {number | [number, number]} 
+	*/
 	export let duration: number | [number, number] = 150;
 	/** Set the fly transition opacity. */
 	export let flyOpacity = 0;

--- a/src/lib/utilities/Modal/Modal.svelte
+++ b/src/lib/utilities/Modal/Modal.svelte
@@ -21,8 +21,8 @@
 	export let components: Record<string, ModalComponent> = {};
 
 	// Props (transitions)
-	/** The open/close animation duration. Set '0' (zero) to disable. */
-	export let duration = 150;
+	/** The open/close animation duration. Set '0' (zero) to disable, or set as Array to control In/Out duration seperately. */
+	export let duration: number | [number, number] = 150;
 	/** Set the fly transition opacity. */
 	export let flyOpacity = 0;
 	/** Set the fly transition X axis value. */
@@ -143,6 +143,9 @@
 	$: classesModal = `${cModal} ${background} ${width} ${height} ${padding} ${spacing} ${rounded} ${shadow} ${
 		$modalStore[0]?.modalClasses ?? ''
 	}`;
+	$: durationIn = Array.isArray(duration) ? duration[0] : duration;
+	$: durationOut = Array.isArray(duration) ? duration[1] : duration;
+
 	// IMPORTANT: add values to pass to the children templates.
 	// There is a way to self-reference component values, but it involes svelte-internal and is not yet stable.
 	// REPL: https://svelte.dev/repl/badd0f11aa99450ca69dca6690d4d5a4?version=3.52.0
@@ -188,11 +191,12 @@
 			data-testid="modal-backdrop"
 			on:mousedown={onBackdropInteraction}
 			on:touchstart={onBackdropInteraction}
-			transition:fade={{ duration }}
+			in:fade={{ duration: durationIn }}
+			out:fade={{ duration: durationOut }}
 			use:focusTrap={true}
 		>
 			<!-- Transition Layer -->
-			<div class="modal-transition {classesTransitionLayer}" transition:fly={{ duration, opacity: flyOpacity, x: flyX, y: flyY }}>
+			<div class="modal-transition {classesTransitionLayer}" in:fly={{ duration: durationIn, opacity: flyOpacity, x: flyX, y: flyY }} out:fly={{ duration: durationOut, opacity: flyOpacity, x: flyX, y: flyY }}>
 				{#if $modalStore[0].type !== 'component'}
 					<!-- Modal: Presets -->
 					<div
@@ -201,7 +205,8 @@
 						role="dialog"
 						aria-modal="true"
 						aria-label={$modalStore[0].title ?? ''}
-						transition:fly={{ duration, opacity: 0, y: 100 }}
+						in:fly={{ duration: durationIn, opacity: 0, y: 100 }}
+						out:fly={{ duration: durationOut, opacity: 0, y: 100 }}
 					>
 						<!-- Header -->
 						{#if $modalStore[0]?.title}


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`? (only un-related errors found)
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

Add the ability to set the modal duration as Number or Array. If set as Array, use the first number as the transition duration In, and the second number as the transition duration Out. If single non-array number is used, use for both In/Out durations.

I added this as an optional Array, rather than splitting the duration prop into two separate Number props, such as durationIn, and durationOut, for a couple of reasons. One being that it would be a breaking change. And the second reason is that I like keeping values that are related to one another, together. It makes more sense and reduces the amount of props you have to pass. I know it's not entirely within the pattern of Skeleton's current prop syntax, so feel free to change it.

Fixes #1301.
