### PR TITLE
Popups display not being correctly set on Close()

### DIFF
--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -158,7 +158,6 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		render(); // update
 		elemPopup.style.display = 'block';
 		elemPopup.style.opacity = '1';
-		elemPopup.style.pointerEvents = 'initial';
 		isVisible = true;
 		stateEventHandler(true);
 		// Utilize autoUpdate ONLY when the popup is.
@@ -171,7 +170,6 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		const cssTransitionDuration = parseFloat(window.getComputedStyle(elemPopup).transitionDuration.replace('s', '')) * 1000;
 		setTimeout(() => {
 			elemPopup.style.display = 'none';
-			elemPopup.style.pointerEvents = 'none';
 			isVisible = false;
 			stateEventHandler(false);
 		}, cssTransitionDuration);
@@ -189,19 +187,13 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		if (!isVisible) return;
 		// Handle keys
 		const key: string = event.key;
-        // Tab should also close the popup, in a future version, popup will not do anything on key down or key up.
-        // that will be handled by a separate action.
-		if (key === 'Escape') {
+		// Handle keyboard interaction
+		if (key === 'Escape' || (document.activeElement === node && key === 'Tab')) {
 			event.preventDefault();
 			close();
 			node.focus();
 			return;
-		} else if (key === 'Tab' && node instanceof HTMLInputElement){
-            event.preventDefault();
-            close();
-            node.focus();
-            return;
-        }else if (key === 'ArrowDown') {
+		} else if (key === 'ArrowDown') {
 			event.preventDefault();
 			if (activeFocusIdx < focusableElems.length - 1) {
 				// Move down the menu

--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -170,7 +170,7 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		elemPopup.style.opacity = '0';
 		const cssTransitionDuration = parseFloat(window.getComputedStyle(elemPopup).transitionDuration.replace('s', '')) * 1000;
 		setTimeout(() => {
-			elemPopup.style.display = 'hidden';
+			elemPopup.style.display = 'none';
 			elemPopup.style.pointerEvents = 'none';
 			isVisible = false;
 			stateEventHandler(false);
@@ -189,8 +189,9 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		if (!isVisible) return;
 		// Handle keys
 		const key: string = event.key;
-		// TODO: || (document.activeElement !== node && key === 'Tab')
-		if (key === 'Escape') {
+        // Tab should also close the popup, in a future version, popup will not do anything on key down or key up.
+        // that will be handled by a separate action.
+		if (key === 'Escape' || key === 'Tab') {
 			event.preventDefault();
 			close();
 			node.focus();

--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -191,12 +191,17 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		const key: string = event.key;
         // Tab should also close the popup, in a future version, popup will not do anything on key down or key up.
         // that will be handled by a separate action.
-		if (key === 'Escape' || key === 'Tab') {
+		if (key === 'Escape') {
 			event.preventDefault();
 			close();
 			node.focus();
 			return;
-		} else if (key === 'ArrowDown') {
+		} else if (key === 'Tab' && node instanceof HTMLInputElement){
+            event.preventDefault();
+            close();
+            node.focus();
+            return;
+        }else if (key === 'ArrowDown') {
 			event.preventDefault();
 			if (activeFocusIdx < focusableElems.length - 1) {
 				// Move down the menu


### PR DESCRIPTION
Fixes #1305
Fixes #1306 

## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`

## What does your PR address?
`elemPopup.style.display` was being set to `hidden` instead of `none`

This causes an issue when using the autocomplete with popup, because its list items are buttons, and when it wasn't actually being set to `display:none` properly it was causing focus to be given to the button even though the popup wasn't visible to the users.

Please briefly describe your changes here.
Updated `elemPopup.style.display` to `none` as `hidden` is a tailwind class name for `display:none`. 

Also updated so that `Tab` and `Escape` close the popup. To match the default functionality for tabbing in an input. 

@endigo9740 ~~If you think its better, I can resubmit this PR with tab only closing the popup is `node` is an instance of `HTMLInputElement` instead?~~ 
Actually after thinking about this for like 10 minutes, I decided also checking if node is an input element is probably better anyways.  
