### PR TITLE
Fix: apply sort to filtered list

### DIFF
--- a/src/lib/utilities/DataTable/DataTable.ts
+++ b/src/lib/utilities/DataTable/DataTable.ts
@@ -80,7 +80,9 @@ export function createDataTableStore<T extends Record<PropertyKey, any>>(source:
 
 /** Listens for changes to `$dataTableModel` and triggers: search, selection, sort, and pagination. */
 export function dataTableHandler<T extends Record<PropertyKey, any>>(model: DataTableModel<T>): void {
+	// First create filtered list
 	searchHandler(model);
+	// Then apply selection, sort order and pagnation to filtered list
 	selectionHandler(model);
 	sortHandler(model);
 	paginationHandler(model);
@@ -98,7 +100,7 @@ function searchHandler<T extends Record<PropertyKey, unknown>>(store: DataTableM
 // Selection ---
 
 function selectionHandler<T extends Record<PropertyKey, unknown>>(store: DataTableModel<T>): void {
-	store.selection = store.base.filter((row) => row.dataTableChecked === true); // ? should this be filtered by source or filter?
+	store.selection = store.filtered.filter((row) => row.dataTableChecked === true); // ? should this be filtered by source or filter?
 }
 
 // Sort ---
@@ -111,7 +113,7 @@ function sortHandler<T extends Record<PropertyKey, unknown>>(store: DataTableMod
 
 function sortOrder<T extends Record<PropertyKey, unknown>>(order: string, store: DataTableModel<T>): void {
 	const key = store.sort;
-	store.filtered = store.base.sort((x, y) => {
+	store.filtered = store.filtered.sort((x, y) => {
 		// If descending, swap x/y
 		if (order === 'dsc') [x, y] = [y, x];
 		// Sort logic

--- a/src/lib/utilities/DataTable/DataTable.ts
+++ b/src/lib/utilities/DataTable/DataTable.ts
@@ -91,10 +91,13 @@ export function dataTableHandler<T extends Record<PropertyKey, any>>(model: Data
 // Search ---
 
 function searchHandler<T extends Record<PropertyKey, unknown>>(store: DataTableModel<T>): void {
-	store.filtered = store.base.filter((rowObj) => {
-		const formattedSearchTerm = store.search?.toLowerCase() || '';
-		return Object.values(rowObj).join(' ').toLowerCase().includes(formattedSearchTerm);
-	});
+	if (store.search && store.search !== '') {
+		store.filtered = store.base.filter((rowObj) => {
+			return Object.values(rowObj).join(' ').toLowerCase().includes(store.search.toLowerCase());
+		});
+	} else {
+		store.filtered = store.base;
+	}
 }
 
 // Selection ---


### PR DESCRIPTION
## What does your PR address?

The Utility DataTable search doesn't work when column sort is applied. To replicate sort any col and then attempt to search. Then to fix it, remove the sort and the search once again works.

Very simple fix was to replace store.base with store.filtered in sortOrder.


