### PR TITLE
Bugfix: Resolved index bug causing first index items to get skipped with `focus` or `focus-click` events.

### DIFF
--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -82,11 +82,11 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		focusableElems = Array.from(elemPopup?.querySelectorAll(elemWhitelist));
 		// reset the focus index
 		activeFocusIdx = -1;
-		// Automatically focus the element if openWithFocus is true (for example if
-		// the menu was opened with Enter instead of with a click
-		activeFocusIdx = 0;
 		// if the popup was triggered via focus, we don't want to move that focus
+        // we also only want to set activeFocusIdx to 0 if the popup wasn't triggered via `focus` or `focus-click`
 		if (args.event !== 'focus' && args.event !== 'focus-click') {
+            // Automatically focus the element if the event is not `focus` or `focus-click`
+            activeFocusIdx = 0;
 			focusableElems[0]?.focus();
 		}
 	}

--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -83,10 +83,10 @@ export function popup(node: HTMLElement, args: PopupSettings) {
 		// reset the focus index
 		activeFocusIdx = -1;
 		// if the popup was triggered via focus, we don't want to move that focus
-        // we also only want to set activeFocusIdx to 0 if the popup wasn't triggered via `focus` or `focus-click`
+		// we also only want to set activeFocusIdx to 0 if the popup wasn't triggered via `focus` or `focus-click`
 		if (args.event !== 'focus' && args.event !== 'focus-click') {
-            // Automatically focus the element if the event is not `focus` or `focus-click`
-            activeFocusIdx = 0;
+			// Automatically focus the element if the event is not `focus` or `focus-click`
+			activeFocusIdx = 0;
 			focusableElems[0]?.focus();
 		}
 	}


### PR DESCRIPTION
## Before submitting the PR:
- [X] Does your PR reference an issue? Fixes #1337 
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`

## What does your PR address?
The variable `activeFocusIdx` was being set to 0 no matter what, when it should only be set to 0 if the event is not a `focus` or `focus-click` event just like call to focus the first `focusableElems` is. This caused the first item to get skipped when the down arrow was pressed when using a `focus` or `focus-click` event.

Please briefly describe your changes here.
Moved `activeFocusIdx = 0` into the same if that contains `focusableElems[0].focus();`