### PR TITLE
Remove duplicate class in modal example.

### DIFF
--- a/src/docs/modals/examples/ModalExampleImage.svelte
+++ b/src/docs/modals/examples/ModalExampleImage.svelte
@@ -9,7 +9,7 @@
 
 {#if $modalStore[0]}
 	<!-- Button -->
-	<button class="btn-icon btn-icon variant-filled {cButton}" on:click={parent.onClose}>×</button>
+	<button class="btn-icon variant-filled {cButton}" on:click={parent.onClose}>×</button>
 	<!-- Image -->
 	<img src={$modalStore[0]?.image} class={cImage} alt="Example" title="Source: {$modalStore[0]?.meta.source}" />
 {/if}


### PR DESCRIPTION
Remove duplicate class `btn-icon` in `ModalExampleImage.svelte`.
