### PR TITLE
Fixed hide scrollbar in TabGroup

### DIFF
--- a/src/lib/components/Tab/TabGroup.svelte
+++ b/src/lib/components/Tab/TabGroup.svelte
@@ -51,7 +51,7 @@
 
 	// Classes
 	const cBase = 'space-y-4';
-	const cList = 'flex overflow-x-auto hide-scrollbars';
+	const cList = 'flex overflow-x-auto hide-scrollbar';
 	const cPanel = '';
 
 	// Reactive


### PR DESCRIPTION
## What does your PR address?

The PR fixes a wrong class name for hiding scrollbar in TabGroup component.
