### PR TITLE
Apply same height to scrollbars as width

### DIFF
--- a/src/lib/styles/core.css
+++ b/src/lib/styles/core.css
@@ -28,6 +28,7 @@
 
 	::-webkit-scrollbar {
 		@apply w-2;
+		@apply h-2;
 	}
 	::-webkit-scrollbar-track {
 		@apply !bg-surface-50-900-token px-[1px];


### PR DESCRIPTION
Before change

<img width="572" alt="Screenshot 2023-04-24 at 11 35 49" src="https://user-images.githubusercontent.com/43420049/233959261-5c664f75-bf77-4e40-a7c2-79033b2dfbca.png">

After change

<img width="568" alt="Screenshot 2023-04-24 at 11 39 03" src="https://user-images.githubusercontent.com/43420049/233959705-4c4fd7fa-f9fa-4db1-a193-24cbaf67419d.png">


Note: I've overwritten the behavior of CodeBlock to showcase the before and after - by default there is no overflow on the CodeBlock.