### PR TITLE
rename docSell to docShell

### DIFF
--- a/src/docs/layouts/DocsShell/DocsShell.svelte
+++ b/src/docs/layouts/DocsShell/DocsShell.svelte
@@ -11,13 +11,13 @@
 	// Partials
 	import Header from '$docs/layouts/DocsShell/partials/Header.svelte';
 	import PanelProps from '$docs/layouts/DocsShell/partials/PanelProps.svelte';
-	import PanelParams from './partials/PanelParams.svelte';
-	import PanelSlots from './partials/PanelSlots.svelte';
 	import PanelClasses from './partials/PanelClasses.svelte';
 	import PanelEvents from './partials/PanelEvents.svelte';
 	import PanelKeyboard from './partials/PanelKeyboard.svelte';
+	import PanelParams from './partials/PanelParams.svelte';
+	import PanelSlots from './partials/PanelSlots.svelte';
 	// Utilities
-	import { docSellDefaults } from '$docs/layouts/DocsShell/defaults';
+	import { docShellDefaults } from '$docs/layouts/DocsShell/defaults';
 
 	// Props
 	export let settings: DocsShellSettings;
@@ -34,7 +34,7 @@
 	// Page Data
 	const pageData: DocsShellSettings = {
 		// Define defaults first
-		...docSellDefaults,
+		...docShellDefaults,
 		// Local Overrides
 		...{ docsPath: $page.url.pathname },
 		// Prop Settings Values

--- a/src/docs/layouts/DocsShell/defaults.ts
+++ b/src/docs/layouts/DocsShell/defaults.ts
@@ -1,6 +1,6 @@
 import { DocsFeature, type DocsShellSettings } from '$docs/layouts/DocsShell/types';
 
-export let docSellDefaults: DocsShellSettings = {
+export let docShellDefaults: DocsShellSettings = {
 	// Heading
 	feature: DocsFeature.Component,
 	name: '(name)',


### PR DESCRIPTION
To have more clarity `docSellDefaults` was renamed to `docShellDefaults`. The placement swap of the imports is due to import sorting. Can be reverted if not wanted.

I do prefer automatic import sorting on projects with multiple contributors to have consistent import orders.