### PR TITLE
Removed svelte field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
 		"./src/lib/themes/*",
 		"!./dist/**/*.test.*"
 	],
-	"svelte": "./dist/index.js",
 	"typesVersions": {
 		">4.0": {
 			"index": [


### PR DESCRIPTION
Fixes #1359
Removed the top level `svelte` field from package.json