### PR TITLE
Fix: `package.json` exported type path mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,10 +90,7 @@
 		},
 		"./styles/*": "./dist/styles/*",
 		"./themes/*": "./dist/themes/*",
-		"./tailwind/skeleton.cjs": {
-			"default": "./dist/tailwind/skeleton.cjs",
-			"types": "./dist/tailwind/skeleton.d.cts"
-		}
+		"./tailwind/skeleton.cjs": "./dist/tailwind/skeleton.cjs"
 	},
 	"files": [
 		"./dist/**/*.svelte",

--- a/package.json
+++ b/package.json
@@ -88,23 +88,31 @@
 			"svelte": "./dist/index.js",
 			"default": "./dist/index.js"
 		},
-		"./styles/*": "./src/lib/styles/*",
-		"./tailwind/*": "./src/lib/tailwind/*",
-		"./themes/*": "./src/lib/themes/*"
+		"./styles/*": "./dist/styles/*",
+		"./themes/*": "./dist/themes/*",
+		"./tailwind/skeleton.cjs": {
+			"default": "./dist/tailwind/skeleton.cjs",
+			"types": "./dist/tailwind/skeleton.d.cts"
+		}
 	},
 	"files": [
 		"./dist/**/*.svelte",
 		"./dist/**/*.js",
 		"./dist/**/*.d.ts",
-		"./src/lib/styles/*",
-		"./src/lib/tailwind/*",
-		"./src/lib/themes/*",
+		"./dist/**/*.cjs",
+		"./dist/**/*.d.cts",
+		"./dist/styles/*",
+		"./dist/tailwind/*",
+		"./dist/themes/*",
 		"!./dist/**/*.test.*"
 	],
 	"typesVersions": {
 		">4.0": {
 			"index": [
 				"./dist/index.d.ts"
+			],
+			"tailwind/skeleton.cjs": [
+				"./dist/tailwind/skeleton.d.cts"
 			]
 		}
 	}


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Rather than copying the `src/lib` dir for `styles`, `themes`, and `tailwind` directly into our package, we'll reference those dirs from the generated `dist`. This change will provide the type declarations for our plugin `tailwind/skeleton.cjs`. Additionally, this should also fix the import type errors that users would get if they tried to import our plugin in a `tailwind.config.ts` file.
