### PR TITLE
feat: add kbd navigation to tabs

### DIFF
--- a/src/lib/components/Tab/Tab.svelte
+++ b/src/lib/components/Tab/Tab.svelte
@@ -28,7 +28,7 @@
 
 	// Props (a11y)
 	/** Set the ARIA controls value to define which panel this tab controls. */
-	export let controls: string = '';
+	export let controls = '';
 
 	// Context
 	/** Provide classes to style each tab's active styles. */
@@ -56,6 +56,38 @@
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();
 			elemInput.click();
+		} else if (event.code === 'ArrowRight') {
+			const tabList = elemInput.closest('.tab-list');
+			if (!tabList) return;
+			const tabs = Array.from(tabList.querySelectorAll('.tab'));
+
+			const currTab = elemInput.closest('.tab');
+			if (!currTab) return;
+
+			const currIndex = tabs.indexOf(currTab);
+			const nextIndex = currIndex + 1 >= tabs.length ? 0 : currIndex + 1;
+			const nextTab = tabs[nextIndex];
+			const nextTabInput = nextTab?.querySelector('input');
+			if (nextTab && nextTabInput) {
+				nextTabInput.click();
+				(nextTab as HTMLElement).focus();
+			}
+		} else if (event.code === 'ArrowLeft') {
+			const tabList = elemInput.closest('.tab-list');
+			if (!tabList) return;
+			const tabs = Array.from(tabList.querySelectorAll('.tab'));
+
+			const currTab = elemInput.closest('.tab');
+			if (!currTab) return;
+
+			const currIndex = tabs.indexOf(currTab);
+			const nextIndex = currIndex - 1 < 0 ? tabs.length - 1 : currIndex - 1;
+			const nextTab = tabs[nextIndex];
+			const nextTabInput = nextTab?.querySelector('input');
+			if (nextTab && nextTabInput) {
+				nextTabInput.click();
+				(nextTab as HTMLElement).focus();
+			}
 		}
 	}
 
@@ -80,7 +112,7 @@
 		role="tab"
 		aria-controls={controls}
 		aria-selected={selected}
-		tabindex="0"
+		tabindex={selected ? 0 : -1}
 		on:keydown={onKeyDown}
 		on:keydown
 		on:keyup

--- a/src/lib/components/Tab/TabGroup.svelte
+++ b/src/lib/components/Tab/TabGroup.svelte
@@ -37,9 +37,9 @@
 
 	// Props (a11y)
 	/** Provide the ID of the element that labels the tab list. */
-	export let labelledby: string = '';
+	export let labelledby = '';
 	/** Matches the tab aria-control value, pairs with the panel. */
-	export let panel: string = '';
+	export let panel = '';
 
 	// Context
 	setContext('active', active);
@@ -67,6 +67,8 @@
 	</div>
 	<!-- Tab Panel -->
 	{#if $$slots.panel}
-		<div class="tab-panel {classesPanel}" role="tabpanel" aria-labelledby={panel}><slot name="panel" /></div>
+		<div class="tab-panel {classesPanel}" role="tabpanel" aria-labelledby={panel} tabindex="0">
+			<slot name="panel" />
+		</div>
 	{/if}
 </div>


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [X] Did you update and run tests before submission using `npm run test`?
- [X] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

This PR adds keyboard navigation to the TabGroup and Tab components, following the patterns described in [WAI-ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).

Summarizing:
- Pressing the `left` and `right` arrow keys when the selected tab is focused will focus the tab sibilings
- Pressing `tab` when a tab is focused will focus the tab panel instead of another tab
- Pressing `shift+tab` from the tab panel will focus the selected tab
