### PR TITLE
Fix: Toast position incorrect type

### DIFF
--- a/src/lib/utilities/Toast/Toast.svelte
+++ b/src/lib/utilities/Toast/Toast.svelte
@@ -10,7 +10,9 @@
 	import { toastStore } from './stores';
 
 	// Props
-	/** Set the toast position. */
+	/** Set the toast position. 
+	 * @type {'t' | 'b' | 'l' | 'r' | 'tl' | 'tr' | 'bl' | 'br'}
+	 */
 	export let position: 't' | 'b' | 'l' | 'r' | 'tl' | 'tr' | 'bl' | 'br' = 'b';
 	/** Maximum toasts that can show at once. */
 	export let max = 3;

--- a/src/lib/utilities/Toast/Toast.svelte
+++ b/src/lib/utilities/Toast/Toast.svelte
@@ -10,7 +10,7 @@
 	import { toastStore } from './stores';
 
 	// Props
-	/** Set the toast position. 
+	/** Set the toast position.
 	 * @type {'t' | 'b' | 'l' | 'r' | 'tl' | 'tr' | 'bl' | 'br'}
 	 */
 	export let position: 't' | 'b' | 'l' | 'r' | 'tl' | 'tr' | 'bl' | 'br' = 'b';

--- a/src/lib/utilities/Toast/Toast.svelte
+++ b/src/lib/utilities/Toast/Toast.svelte
@@ -10,10 +10,8 @@
 	import { toastStore } from './stores';
 
 	// Props
-	/** Set the toast position.
-	 * @type {'t' | 'b' | 'l' | 'r' | 'tl' | 'tr' | 'bl' | 'br'}
-	 */
-	export let position = 'b';
+	/** Set the toast position. */
+	export let position: 't' | 'b' | 'l' | 'r' | 'tl' | 'tr' | 'bl' | 'br' = 'b';
 	/** Maximum toasts that can show at once. */
 	export let max = 3;
 	/** The duration of the fly in/out animation. */


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?: **Was not required**

## What does your PR address?

Fixes #1403. The type of ``position`` in the ``Toast.svelte`` component was only defined through a JSDoc comment leading to TypeScript inferring the type as ``string``. Moved this to a TypeScript type instead, so that the type is now inferred correctly leading to intellisense/autocomplete working. See issue for more details. 
