### PR TITLE
InputChip reset behaviour fix

### DIFF
--- a/src/lib/components/InputChip/InputChip.svelte
+++ b/src/lib/components/InputChip/InputChip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte/internal';
+	import { createEventDispatcher, onMount } from 'svelte/internal';
 	import { fly, scale } from 'svelte/transition';
 	import { flip } from 'svelte/animate';
 
@@ -65,6 +65,27 @@
 	let inputValid = true;
 	let chipValues: Array<{ val: (typeof value)[0]; id: number }> = value.map((val) => {
 		return { val: val, id: Math.random() };
+	});
+
+	function resetFormHandler() {
+		value = [];
+	}
+
+	onMount(() => {
+		const inputElement: HTMLInputElement | null = document.querySelector('.phantom-input') as HTMLInputElement | null;
+
+		// Verify input element AND external form are present
+		if (!inputElement || !inputElement.form) return;
+
+		const externalForm: HTMLFormElement = inputElement.form;
+
+		// Attach reset event listener to external form
+		externalForm.addEventListener('reset', resetFormHandler);
+
+		// Return onDestroy handler that will remove the event listener from the external form
+		return () => { 
+			externalForm.removeEventListener('reset', resetFormHandler);
+		}
 	});
 
 	function onInputHandler(): void {
@@ -137,6 +158,9 @@
 		return { id: Math.random(), val: val };
 	});
 </script>
+
+<!-- Hidden input used to select external form -->
+<input class="hidden phantom-input"/>
 
 <div class="input-chip {classesBase}" class:opacity-50={$$restProps.disabled}>
 	<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->

--- a/src/routes/test/+page.server.ts
+++ b/src/routes/test/+page.server.ts
@@ -1,0 +1,8 @@
+import type { Actions } from "@sveltejs/kit";
+
+export const actions: Actions = {
+    default: async () => {
+        console.log("action reached");
+        return { success: true }
+    }
+};

--- a/src/routes/test/+page.svelte
+++ b/src/routes/test/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { enhance } from "$app/forms";
+	import { InputChip } from "@skeletonlabs/skeleton";
+</script>
+
+<form method="post" use:enhance>
+    <InputChip name="test" required />
+    <button>Submit</button>
+</form>


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Fixes #1407 

Created phantom input to select parental form when present, attaches and detaches event listener accordingly, resets chip value on reset event.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
