### PR TITLE
Fixed Lightswitch initial state always dark (#1341)

### DIFF
--- a/src/lib/utilities/LightSwitch/LightSwitch.svelte
+++ b/src/lib/utilities/LightSwitch/LightSwitch.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { modeCurrent, setModeUserPrefers, setModeCurrent, setInitialClassState } from './lightswitch';
+	import { onMount } from 'svelte';
+	import { modeCurrent, setModeUserPrefers, setModeCurrent, setInitialClassState, getModeOsPrefers } from './lightswitch';
 
 	// Types
 	import type { CssClasses } from '$lib';
@@ -49,6 +50,14 @@
 			event.currentTarget.click();
 		}
 	}
+
+	// Lifecycle
+	onMount(() => {
+		// Sync lightswitch with the theme
+		if (!('modeCurrent' in localStorage)) {
+			setModeCurrent(getModeOsPrefers());
+		}
+	});
 
 	// State
 	$: trackBg = $modeCurrent === true ? bgLight : bgDark;


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? 
Fixes #1341
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?
Lightswitch Initial State is always dark because when `modeCurrent` is not set in the local storage it will be treated as false and therefore dark.

I have updated the lightswitch to check `onMount` if the `modeCurrent` is **not** set in the local storage, then It will be set to the `modeOsPrefers` causing it to sync with the theme.