### PR TITLE
Support filters in Firefox

### DIFF
--- a/src/lib/actions/Filters/filter.test.ts
+++ b/src/lib/actions/Filters/filter.test.ts
@@ -27,8 +27,8 @@ describe('Actions: Filter', () => {
 		render(NoirLight);
 		render(Noir);
 		const elements: HTMLCollection = document.getElementsByClassName('filter');
-		for (let i = 0; i < elements.length; ++i) {
-			const el: any = elements[i];
+		for (const element of elements) {
+			const el: any = element;
 			expect(el.getAttribute('class').includes('filter'));
 		}
 	});

--- a/src/lib/actions/Filters/filter.ts
+++ b/src/lib/actions/Filters/filter.ts
@@ -1,9 +1,6 @@
 // Action: Filter
 
 export function filter(node: HTMLElement, filterName: string) {
-	// Return if Firefox browser
-	const isFirefox: boolean = navigator.userAgent.indexOf('Firefox') > -1;
-	if (isFirefox) return;
 	// Return if no filterName provided
 	if (filterName === undefined) return;
 

--- a/src/lib/actions/Filters/svg-filters/Apollo.svelte
+++ b/src/lib/actions/Filters/svg-filters/Apollo.svelte
@@ -1,5 +1,5 @@
 <!-- Apollo: `filter: url(#Apollo)` -->
-<svg id="svg-filter-apollo" class="hidden">
+<svg id="svg-filter-apollo" class="filter absolute -left-full w-0 h-0">
 	<filter id="Apollo" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 		<feColorMatrix
 			values="0.8 0.6 -0.4 0.1 0,

--- a/src/lib/actions/Filters/svg-filters/BlueNight.svelte
+++ b/src/lib/actions/Filters/svg-filters/BlueNight.svelte
@@ -1,5 +1,5 @@
 <!-- BlueNight: `filter: url(#BlueNight)` -->
-<svg id="svg-filter-bluenight" class="hidden">
+<svg id="svg-filter-bluenight" class="filter absolute -left-full w-0 h-0">
 	<filter id="BlueNight" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 		<feColorMatrix
 			type="matrix"

--- a/src/lib/actions/Filters/svg-filters/Emerald.svelte
+++ b/src/lib/actions/Filters/svg-filters/Emerald.svelte
@@ -1,5 +1,5 @@
 <!-- Emerald: `filter: url(#Emerald)` -->
-<svg id="svg-filter-emerald" class="hidden">
+<svg id="svg-filter-emerald" class="filter absolute -left-full w-0 h-0">
 	<filter id="Emerald" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 		<!-- RGB, RGB, RGB, Opacity -->
 		<feColorMatrix

--- a/src/lib/actions/Filters/svg-filters/GreenFall.svelte
+++ b/src/lib/actions/Filters/svg-filters/GreenFall.svelte
@@ -1,5 +1,5 @@
 <!-- GreenFall: `filter: url(#GreenFall)` -->
-<svg id="svg-filter-greenfall" class="filter hidden">
+<svg id="svg-filter-greenfall" class="filter absolute -left-full w-0 h-0">
 	<filter
 		id="GreenFall"
 		x="-20%"

--- a/src/lib/actions/Filters/svg-filters/Noir.svelte
+++ b/src/lib/actions/Filters/svg-filters/Noir.svelte
@@ -1,5 +1,5 @@
 <!-- Noir: `filter: url(#Noir)` -->
-<svg id="svg-filter-noir" class="hidden">
+<svg id="svg-filter-noir" class="filter absolute -left-full w-0 h-0">
 	<filter
 		id="Noir"
 		x="-20%"
@@ -12,19 +12,6 @@
 	>
 		<feColorMatrix type="saturate" values="0" x="0%" y="0%" width="100%" height="100%" in="SourceGraphic" result="colormatrix1" />
 		<feBlend mode="lighten" x="0%" y="0%" width="100%" height="100%" in="colormatrix1" in2="colormatrix1" result="blend" />
-		<feDiffuseLighting
-			surfaceScale="7.7"
-			diffuseConstant="7.3"
-			lighting-color="#707070"
-			x="0%"
-			y="0%"
-			width="100%"
-			height="100%"
-			in="blend"
-			result="diffuseLighting"
-		>
-			<fePointLight x="200" y="157" z="200" />
-		</feDiffuseLighting>
 		<feBlend mode="multiply" x="0%" y="0%" width="100%" height="100%" in="colormatrix1" in2="diffuseLighting" result="blend1" />
 	</filter>
 </svg>

--- a/src/lib/actions/Filters/svg-filters/NoirLight.svelte
+++ b/src/lib/actions/Filters/svg-filters/NoirLight.svelte
@@ -1,5 +1,5 @@
 <!-- NoirLight: `filter: url(#NoirLight)` -->
-<svg id="svg-filter-noirlight" class="hidden">
+<svg id="svg-filter-noirlight" class="filter absolute -left-full w-0 h-0">
 	<filter
 		id="NoirLight"
 		x="-20%"

--- a/src/lib/actions/Filters/svg-filters/Rustic.svelte
+++ b/src/lib/actions/Filters/svg-filters/Rustic.svelte
@@ -1,5 +1,5 @@
 <!-- Rustic: `filter: url(#Rustic)` -->
-<svg id="svg-filter-rustic" class="hidden">
+<svg id="svg-filter-rustic" class="filter absolute -left-full w-0 h-0">
 	<filter id="Rustic" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 		<feColorMatrix
 			type="matrix"

--- a/src/lib/actions/Filters/svg-filters/Summer84.svelte
+++ b/src/lib/actions/Filters/svg-filters/Summer84.svelte
@@ -1,5 +1,5 @@
 <!-- Summer84: `filter: url(#Summer84)` -->
-<svg id="svg-filter-summer84" class="hidden">
+<svg id="svg-filter-summer84" class="filter absolute -left-full w-0 h-0">
 	<filter id="Summer84" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 		<feColorMatrix
 			type="matrix"

--- a/src/lib/actions/Filters/svg-filters/XPro.svelte
+++ b/src/lib/actions/Filters/svg-filters/XPro.svelte
@@ -1,5 +1,5 @@
 <!-- XPro: `filter: url(#XPro)` -->
-<svg id="svg-filter-xpro" class="hidden">
+<svg id="svg-filter-xpro" class="filter absolute -left-full w-0 h-0">
 	<filter id="XPro" filterUnits="objectBoundingBox" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 		<feColorMatrix
 			type="matrix"

--- a/src/routes/(inner)/actions/filters/+page.svelte
+++ b/src/routes/(inner)/actions/filters/+page.svelte
@@ -177,9 +177,7 @@ only utilize theme on this doc page.
 			<h2 class="h2">Browser Support</h2>
 			<!-- prettier-ignore -->
 			<p>
-				Please be aware that <strong>SVG filters</strong> have limited support in Safari, while Firefox is not supported at all. We're aware that <a class="anchor" href="https://developer.mozilla.org/en-US/docs/Web/CSS/filter#browser_compatibility" target="_blank" rel="noreferrer">MDN</a> and
-				<a class="anchor" href="https://caniuse.com/css-filters" target="_blank" rel="noreferrer">caniuse.com</a> both list this as fully supported in Firefox, but in practice the <code class="code">filter: url()</code> effects <u>do not appear</u>. Given this, we've opted to
-				excluded support for Firefox for the time being. If support changes, we will gladly revert this.
+				Please be aware that <strong>SVG filters</strong> have limited support in Safari.
 			</p>
 			<div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
 				<div class="card p-2 !bg-green-500 text-black">
@@ -190,13 +188,13 @@ only utilize theme on this doc page.
 					<h4 class="h4">Edge</h4>
 					<span>Full</span>
 				</div>
+				<div class="card p-2 !bg-green-500 text-black">
+					<h4 class="h4">Firefox</h4>
+					<span>Full</span>
+				</div>
 				<div class="card p-2 !bg-yellow-500 text-black">
 					<h4 class="h4">Safari</h4>
 					<span>Partial</span>
-				</div>
-				<div class="card p-2 !bg-red-500 text-black">
-					<h4 class="h4">Firefox</h4>
-					<span>Excluded</span>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
When a DOM element is marked as `hidden` Firefox will ignore it more
readily than other browsers, which lead to our filters not working in
Firefox. By removing the `hidden` class we are able to render filters in
Firefox.

Since the class was added to avoid rendering the DOM element, they now
create white space that we have to remove via utility classes.

The noir filter used a diffuse lighting effect that did not provide any
visual difference except visual glitches in both Firefox and Chrome. I
simply removed the effect. The filter looks indistinguishable.

## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

This PR ensures that filters work as expected in Firefox as discussed here: https://github.com/skeletonlabs/skeleton/discussions/1426
