### PR TITLE
#1453 Clipboard now uses text/html when copying a node.

### DIFF
--- a/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
+++ b/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
@@ -1,5 +1,5 @@
 declare namespace svelteHTML {
-  interface HTMLAttributes<T> {
-    'on:copyComplete'?: (event: any) => any;
-  }
+	interface HTMLAttributes<T> {
+		'on:copyComplete'?: (event: any) => any;
+	}
 }

--- a/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
+++ b/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
@@ -1,0 +1,5 @@
+declare namespace svelteHTML {
+  interface HTMLAttributes<T> {
+    'on:copyComplete'?: (event: any) => any;
+  }
+}

--- a/src/lib/actions/Clipboard/clipboard.ts
+++ b/src/lib/actions/Clipboard/clipboard.ts
@@ -43,6 +43,9 @@ async function copyToClipboard(data: any, mimeType = 'text/plain') {
 			new ClipboardItem({
 				[mimeType]: new Blob([data], {
 					type: mimeType
+				}),
+				['text/plain']: new Blob([data], {
+					type: 'text/plain'
 				})
 			})
 		]);

--- a/src/lib/actions/Clipboard/clipboard.ts
+++ b/src/lib/actions/Clipboard/clipboard.ts
@@ -1,24 +1,27 @@
 // Action: Clipboard
 
 export function clipboard(node: HTMLElement, args: any) {
+	const fireCopyCompleteEvent = () => {
+		node.dispatchEvent(new CustomEvent('copyComplete'));
+	};
 	const onClick = () => {
 		// Handle `data-clipboard` target based on object key
 		if (typeof args === 'object') {
 			// Element Inner HTML
 			if (Object.prototype.hasOwnProperty.call(args, 'element')) {
 				const element: HTMLElement | null = document.querySelector(`[data-clipboard="${args.element}"]`);
-				copyToClipboard(element?.innerHTML);
+				copyToClipboard(element?.innerHTML, 'text/html').then(fireCopyCompleteEvent);
 				return;
 			}
 			// Form Input Value
 			if (Object.prototype.hasOwnProperty.call(args, 'input')) {
 				const input: HTMLInputElement | null = document.querySelector(`[data-clipboard="${args.input}"]`);
-				copyToClipboard(input?.value);
+				copyToClipboard(input?.value).then(fireCopyCompleteEvent);
 				return;
 			}
 		}
 		// Handle everything else.
-		copyToClipboard(args);
+		copyToClipboard(args).then(fireCopyCompleteEvent);
 	};
 	// Event Listener
 	node.addEventListener('click', onClick);
@@ -34,6 +37,19 @@ export function clipboard(node: HTMLElement, args: any) {
 }
 
 // Shared copy method
-function copyToClipboard(data: any): void {
-	navigator.clipboard.writeText(String(data));
+async function copyToClipboard(data: any, mimeType = 'text/plain') {
+	if (navigator.clipboard.write) {
+		await navigator.clipboard.write([
+			new ClipboardItem({
+				[mimeType]: new Blob([data], {
+					type: mimeType
+				})
+			})
+		]);
+	} else {
+		// fallback since .writeText has wider browser support
+		await new Promise((resolve) => {
+			resolve(navigator.clipboard.writeText(String(data)));
+		});
+	}
 }


### PR DESCRIPTION
Also: an event is fired when copying is ready.

## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

- When copying a html node, mime-type is set to text/html
- An event is fired when copy is done so you can e.g., easily show a toast as feedback to the user.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
