### PR TITLE
Default to transparent tap highlight color

### DIFF
--- a/src/lib/styles/partials/core.css
+++ b/src/lib/styles/partials/core.css
@@ -21,7 +21,7 @@
 	/* Mobile tap highlight */
 	/* https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-tap-highlight-color */
 	html {
-		-webkit-tap-highlight-color: rgba(128, 128, 128, 0.5);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	/* === Scrollbars === */


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Change webkit tap highlight color to transparent to get rid of boxes briefly appearing around elements on Android Chrome and make default behavior more consistent across environments. Fixes https://github.com/skeletonlabs/skeleton/issues/1462.