### PR TITLE
fix illegal constructor bug for popup

### DIFF
--- a/src/lib/utilities/Popup/popup.ts
+++ b/src/lib/utilities/Popup/popup.ts
@@ -20,8 +20,8 @@ export function popup(triggerNode: HTMLElement, args: PopupSettings) {
 	let elemArrow: HTMLElement;
 
 	function setDomElements(): void {
-		elemPopup = document.querySelector(`[data-popup="${args.target}"]`) ?? new HTMLElement();
-		elemArrow = elemPopup?.querySelector(`.arrow`) ?? new HTMLElement();
+		elemPopup = document.querySelector(`[data-popup="${args.target}"]`) ?? document.createElement('div');
+		elemArrow = elemPopup?.querySelector(`.arrow`) ?? document.createElement('div');
 	}
 	setDomElements(); // init
 


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

When no element matches the query selector for either the arrow or the `[data-popup]` element, a new HTMLElement is created currently with `new HTMLElement()`. This doesn't work, because HTMLElement is meant to be an interface that element implement. Instead, we can use `document.createElement('div')` to create a new HTMLDivElement
