### PR TITLE
Moved classesBase from tab to parent label

### DIFF
--- a/src/lib/components/Tab/Tab.svelte
+++ b/src/lib/components/Tab/Tab.svelte
@@ -30,6 +30,10 @@
 	/** Set the ARIA controls value to define which panel this tab controls. */
 	export let controls = '';
 
+	// Props (regions)
+	/** Provide arbitrary classes to style the tab region. */
+	export let regionTab: CssClasses = '';
+
 	// Context
 	/** Provide classes to style each tab's active styles. */
 	export let active: CssClasses = getContext('active');
@@ -96,6 +100,7 @@
 	$: classesActive = selected ? active : hover;
 	$: classesBase = `${cBase} ${flex} ${padding} ${rounded} ${classesActive} ${$$props.class ?? ''}`;
 	$: classesInterface = `${cInterface} ${spacing}`;
+	$: classesTab = `${regionTab}`;
 
 	// RestProps
 	function prunedRestProps(): any {
@@ -107,7 +112,7 @@
 <label class={classesBase}>
 	<!-- A11y attributes are not allowed on <label> -->
 	<div
-		class="tab"
+		class="tab {classesTab}"
 		data-testid="tab"
 		role="tab"
 		aria-controls={controls}

--- a/src/lib/components/Tab/Tab.svelte
+++ b/src/lib/components/Tab/Tab.svelte
@@ -104,10 +104,10 @@
 	}
 </script>
 
-<label>
+<label class={classesBase}>
 	<!-- A11y attributes are not allowed on <label> -->
 	<div
-		class="tab {classesBase}"
+		class="tab"
 		data-testid="tab"
 		role="tab"
 		aria-controls={controls}


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
issue: #1446 
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?
Fractional width was not applied because the `classesBase` was located on the child `div` instead of the parent `label` in Tab.
so I moved it and tested fractional width on tabs, which is working now.