### PR TITLE
added mutationObserver to focusTrap

### DIFF
--- a/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/src/lib/actions/FocusTrap/focusTrap.ts
@@ -1,5 +1,4 @@
 // Action: Focus Trap
-
 export function focusTrap(node: HTMLElement, enabled: boolean) {
 	const elemWhitelist = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 	let elemFirst: HTMLElement;
@@ -21,7 +20,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 		}
 	}
 
-	const onInit = () => {
+	const onScanElements = (fromObserver: boolean) => {
 		if (enabled === false) return;
 		// Gather all focusable elements
 		const focusableElems: HTMLElement[] = Array.from(node.querySelectorAll(elemWhitelist));
@@ -29,28 +28,39 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			// Set first/last focusable elements
 			elemFirst = focusableElems[0];
 			elemLast = focusableElems[focusableElems.length - 1];
-			// Auto-focus first focusable element
-			elemFirst.focus();
+			// Auto-focus first focusable element only when not called from observer
+			if (!fromObserver) elemFirst.focus();
 			// Listen for keydown on first & last element
 			elemFirst.addEventListener('keydown', onFirstElemKeydown);
 			elemLast.addEventListener('keydown', onLastElemKeydown);
 		}
 	};
-	onInit();
+	onScanElements(false);
 
-	function onDestroy(): void {
+	function onCleanUp(): void {
 		if (elemFirst) elemFirst.removeEventListener('keydown', onFirstElemKeydown);
 		if (elemLast) elemLast.removeEventListener('keydown', onLastElemKeydown);
 	}
+
+	// When children of node are changed (added or removed)
+	const onObservationChange = (mutationRecords: MutationRecord[], observer: MutationObserver) => {
+		if (mutationRecords.length) {
+			onCleanUp();
+			onScanElements(true);
+		}
+		return observer;
+	};
+	const observer = new MutationObserver(onObservationChange);
+	observer.observe(node, { childList: true, subtree: true });
 
 	// Lifecycle
 	return {
 		update(newArgs: boolean) {
 			enabled = newArgs;
-			newArgs ? onInit() : onDestroy();
+			newArgs ? onScanElements(false) : onCleanUp();
 		},
 		destroy() {
-			onDestroy();
+			onCleanUp();
 		}
 	};
 }

--- a/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/src/lib/actions/FocusTrap/focusTrap.ts
@@ -61,6 +61,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 		},
 		destroy() {
 			onCleanUp();
+			observer.disconnect();
 		}
 	};
 }


### PR DESCRIPTION
## Fixes

Fixes #1444
Fixes #1423 

## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
I have also tested the focusTrap manually with the following components:
1. DocsSearch
2. Modal
3. Accordion
4. Drawer
5. Drawer with Accordions with anchor links
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?
As described here: https://github.com/skeletonlabs/skeleton/issues/1444#issuecomment-1541461421 and following the second solution, I implemented a MutationObserver to monitor the children of the node and execute the `onScanElements` function.
### Notes
1. Changed function names: (`onInit` -> `onScanElements`, `onDestroy` -> `onCleanUp`) because these functions are also used outside the lifecycle logic and I thought these names describe them better. (I would happily change them back if necessary)
2. The `onScanElements` function now receives a boolean indicating if the call was executed by the observer or at initialization of the `focusTrap`, this boolean is used to prevent the function from focusing on the first element when called by the observer.
In other words: "to not focus on the first element when the children are changed.