### PR TITLE
Modal Feature: disable close modal on backdrop click

### DIFF
--- a/src/lib/utilities/Modal/Modal.svelte
+++ b/src/lib/utilities/Modal/Modal.svelte
@@ -105,8 +105,10 @@
 		const classList = event.target.classList;
 		if (classList.contains('modal-backdrop') || classList.contains('modal-transition')) {
 			// We return `undefined` to differentiate from the cancel button
-			if ($modalStore[0].response) $modalStore[0].response(undefined);
-			modalStore.close();
+			if ($modalStore[0].disableBackdropClick !== true) {
+				if ($modalStore[0].response) $modalStore[0].response(undefined);
+				modalStore.close();
+			}
 			/** @event {{ event }} backdrop - Fires on backdrop interaction.  */
 			dispatch('backdrop', event);
 		}

--- a/src/lib/utilities/Modal/types.ts
+++ b/src/lib/utilities/Modal/types.ts
@@ -30,6 +30,8 @@ export interface ModalSettings {
 	response?: (r: any) => void;
 	/** Provide arbitrary classes to the backdrop. */
 	backdropClasses?: string;
+	/** Stop closing modal on backdrop click */
+	disableBackdropClick?: boolean;
 	/** Provide arbitrary classes to the modal window. */
 	modalClasses?: string;
 	/** Override the Cancel button label. */


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Modal utility component

Please briefly describe your changes here.

Add new option to modal state `disableBackdropClick: boolean`, if this option is `true` then backdrop clicks won't close current modal.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
