### PR TITLE
fix: Closing tag on input element

### DIFF
--- a/src/routes/(inner)/actions/clipboard/+page.svelte
+++ b/src/routes/(inner)/actions/clipboard/+page.svelte
@@ -100,7 +100,7 @@
 						language="html"
 						code={`
 <!-- Source -->
-<input type="text" value="(contents)" data-clipboard="exampleInput"></input>\n
+<input type="text" value="(contents)" data-clipboard="exampleInput" />\n
 <!-- Trigger -->
 <button use:clipboard={{ input: 'exampleInput' }}>Copy</button>
 `}


### PR DESCRIPTION
\<input\> is a void element and cannot have children, or a closing tag

## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?
Fixed a bug in documentation page
