### PR TITLE
Added an explanation for how to preload fonts to potentially avoid flicker on load.

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -198,6 +198,17 @@ body {
                         	`}
 						/>
 					{/each}
+					<!-- 5 -->
+					<h3 class="h3" data-toc-ignore>5. Preload the Font to avoid flickering</h3>
+					<p>To avoid your page flickering during hydration, you should consider preloading your font in your <code class="code">head</code> tag in your <code class="code">app.html</code></p>
+					{#each activeFonts as f}
+						<CodeBlock
+							language="html"
+							code={`
+<link rel="preload" href="%sveltekit.assets%/fonts/${f.file}" as="font" type="font/ttf" crossorigin />
+                        	`}
+						/>
+					{/each}
 				{:else if tabsFontImport === 1}
 					<aside class="alert alert-message variant-ghost-warning">
 						<p><strong>Warning:</strong> please be aware that using remote imports are typically not GDPR compliant.</p>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -199,13 +199,22 @@ body {
 						/>
 					{/each}
 					<!-- 5 -->
-					<h3 class="h3" data-toc-ignore>5. Preload the Font to avoid flickering</h3>
-					<p>To avoid your page flickering during hydration, you should consider preloading your font in your <code class="code">head</code> tag in your <code class="code">app.html</code></p>
+					<h3 class="h3" data-toc-ignore>5. Preloading Fonts.</h3>
+					<p>
+						To avoid your page flickering during hydration, consider preloading fonts within the <code class="code">head</code>
+						tag in <code class="code">app.html</code>
+					</p>
 					{#each activeFonts as f}
 						<CodeBlock
 							language="html"
 							code={`
-<link rel="preload" href="%sveltekit.assets%/fonts/${f.file}" as="font" type="font/ttf" crossorigin />
+<link
+	rel="preload"
+	href="%sveltekit.assets%/fonts/${f.file}"
+	as="font"
+	type="font/ttf"
+	crossorigin
+/>
                         	`}
 						/>
 					{/each}


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

Added an explanation for how to preload fonts to potentially avoid flicker on load.
https://discord.com/channels/1003691521280856084/1109062538517286923
ezpz on Discord noted that it fixes the flicker and it seems like a good place to add the tip to preload the font.