### PR TITLE
Added csl for creating a Svelte-kit library project in packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"preinstall": "npx only-allow pnpm",
 		"getall": "node scripts/checkout.cjs && pnpm i",
 		"postinstall": "pnpm -r sync",
-		"csa": "node ./packages/create-skeleton-app/src/index.js --types=typescript --prettier --eslint --playwright=false --vitest=false --codeblocks=true --popups=true --typography=true --forms=true -t=skeleton --skeletontemplate=welcome -p=sites --monorepo --inspector=true",
+		"csa": "node ./packages/create-skeleton-app/src/index.js --types=typescript --prettier --eslint --playwright --vitest=false --codeblocks --popups --typography --forms -t=skeleton --skeletontemplate=welcome -p=sites --monorepo --inspector --library",
 		"templategen": "node ./scripts/template-gen.js"
 	},
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"preinstall": "npx only-allow pnpm",
 		"getall": "node scripts/checkout.cjs && pnpm i",
 		"postinstall": "pnpm -r sync",
-		"csa": "node ./packages/create-skeleton-app/src/index.js --types=typescript --prettier --eslint --playwright=false --vitest=false --codeblocks=true --popups=true --typography=false --forms=false -t=skeleton --skeletontemplate=welcome -p=sites --monorepo",
+		"csa": "node ./packages/create-skeleton-app/src/index.js --types=typescript --prettier --eslint --playwright=false --vitest=false --codeblocks=true --popups=true --typography=true --forms=true -t=skeleton --skeletontemplate=welcome -p=sites --monorepo --inspector=true",
 		"templategen": "node ./scripts/template-gen.js"
 	},
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"preinstall": "npx only-allow pnpm",
 		"getall": "node scripts/checkout.cjs && pnpm i",
 		"postinstall": "pnpm -r sync",
-		"csa": "node ./packages/create-skeleton-app/src/index.js --types=typescript --prettier --eslint --playwright --vitest=false --codeblocks --popups --typography --forms -t=skeleton --skeletontemplate=welcome -p=sites --monorepo --inspector --library",
+		"csa": "node ./packages/create-skeleton-app/src/index.js --types=typescript --prettier --eslint --playwright=false --vitest=false --codeblocks --popups --typography --forms -t=skeleton --skeletontemplate=welcome -p=sites --monorepo --inspector",
+		"csl": "node ./packages/create-skeleton-app/src/index.js --types=typescript --library --prettier --eslint --playwright --vitest --codeblocks --popups --typography --forms -t=skeleton --skeletontemplate=bare -p=packages --monorepo --inspector",
 		"templategen": "node ./scripts/template-gen.js"
 	},
 	"license": "MIT",


### PR DESCRIPTION
Added option for creating a svelte-kit library type in packages that adds things like svelte-package and publint as well as defaulting to playwright and vitest being true due to the higher likelihood of testing requirements