### PR TITLE
feat/paginator-more-options

### DIFF
--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -29,6 +29,10 @@
 	export let buttonTextPrevious: CssClasses = '&larr;';
 	/** Set the text label for the Next button. */
 	export let buttonTextNext: CssClasses = '&rarr;';
+	/** Set the text label for the First button. */
+	export let buttonTextFirst: CssClasses = '&laquo;';
+	/** Set the text label for the Last button. */
+	export let buttonTextLast: CssClasses = '&raquo;';
 
 	// Base Classes
 	const cBase = 'flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4';
@@ -48,6 +52,14 @@
 	}
 	function onNext(): void {
 		settings.offset++;
+		dispatch('page', settings.offset);
+	}
+	function onFirst(): void {
+		settings.offset = 0;
+		dispatch('page', settings.offset);
+	}
+	function onLast(): void {
+		settings.offset = settings.size / settings.limit - 1;
 		dispatch('page', settings.offset);
 	}
 
@@ -72,11 +84,17 @@
 	</span>
 	<!-- Arrows -->
 	<div class="paginator-arrows space-x-2">
+		<button type="button" class="{buttonClasses}" on:click={() => { onFirst() }} disabled={disabled || settings.offset === 0}>
+			{@html buttonTextFirst}
+		</button>
 		<button type="button" class="{buttonClasses}" on:click={() => { onPrev() }} disabled={disabled || settings.offset === 0}>
 			{@html buttonTextPrevious}
 		</button>
 		<button type="button" class="{buttonClasses}" on:click={() => { onNext() }} disabled={disabled || (settings.offset + 1) * settings.limit >= settings.size}>
 			{@html buttonTextNext}
+		</button>
+		<button type="button" class="{buttonClasses}" on:click={() => { onLast() }} disabled={disabled || (settings.offset + 1) * settings.limit >= settings.size}>
+			{@html buttonTextLast}
 		</button>
 	</div>
 </div>

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -11,12 +11,14 @@
 	 * @type {PaginationSettings}
 	 */
 	export let settings: PaginationSettings = { offset: 0, limit: 5, size: 0, amounts: [1, 2, 5, 10] };
-	/** Sets selection and buttons to disabled state on-demand. */
+	/** Sets selection, page input and buttons to disabled state on-demand. */
 	export let disabled = false;
 
 	// Props (styles)
 	/** Provide classes to style the select input. */
 	export let select: CssClasses = 'select min-w-[150px]';
+	/** Provide classes to style the page input. */
+	export let pageInputClasses: CssClasses = 'input min-w-[150px]';
 	/** Provide classes to set flexbox justification. */
 	export let justify: CssClasses = 'justify-between';
 	/** Provide classes to style page info text. */
@@ -45,9 +47,22 @@
 		/** @event {{ length: number }} amount - Fires when the amount selection input changes.  */
 		dispatch('amount', settings.limit);
 	}
+	function onChangePage(event: Event): void {
+		const target = event.target as HTMLInputElement;
+		if (isNaN(target.valueAsNumber) || target.valueAsNumber < 0) {
+			settings.offset = 0;
+		} else if (target.valueAsNumber >= settings.size / settings.limit) {
+			settings.offset = settings.size / settings.limit - 1;
+		} else {
+			settings.offset = target.valueAsNumber;
+		}
+		target.valueAsNumber = settings.offset;
+
+		/** @event {{ offset: number }} page Fires when the next/back buttons are pressed or the page input value changed. */
+		dispatch('page', settings.offset);
+	}
 	function onPrev(): void {
 		settings.offset--;
-		/** @event {{ offset: number }} page Fires when the next/back buttons are pressed. */
 		dispatch('page', settings.offset);
 	}
 	function onNext(): void {
@@ -67,6 +82,7 @@
 	$: classesBase = `${cBase} ${justify} ${$$props.class ?? ''}`;
 	$: classesLabel = `${cLabel}`;
 	$: classesSelect = `${select}`;
+	$: classesPageInput = `${pageInputClasses}`;
 	$: classesPageText = `${cPageText} ${text}`;
 </script>
 
@@ -82,6 +98,10 @@
 	<span class="paginator-details {classesPageText}">
 		{settings.offset * settings.limit + 1} - {Math.min(settings.offset * settings.limit + settings.limit, settings.size)} <span class="opacity-50 px-2">/</span> <strong>{settings.size}</strong>
 	</span>
+	<!-- Page Input -->
+	<label class="paginator-label {classesLabel}">
+		<input type="number" max="{settings.size / settings.limit - 1}" min="0" value={settings.offset} on:change={(event) => { onChangePage(event) }} class="paginator-input {classesPageInput}" {disabled} aria-label="Page Input" />
+	</label>
 	<!-- Arrows -->
 	<div class="paginator-arrows space-x-2">
 		<button type="button" class="{buttonClasses}" on:click={() => { onFirst() }} disabled={disabled || settings.offset === 0}>

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -11,14 +11,12 @@
 	 * @type {PaginationSettings}
 	 */
 	export let settings: PaginationSettings = { offset: 0, limit: 5, size: 0, amounts: [1, 2, 5, 10] };
-	/** Sets selection, page input and buttons to disabled state on-demand. */
+	/** Sets selection and buttons to disabled state on-demand. */
 	export let disabled = false;
 
 	// Props (styles)
 	/** Provide classes to style the select input. */
 	export let select: CssClasses = 'select min-w-[150px]';
-	/** Provide classes to style the page input. */
-	export let pageInputClasses: CssClasses = 'input min-w-[150px]';
 	/** Provide classes to set flexbox justification. */
 	export let justify: CssClasses = 'justify-between';
 	/** Provide classes to style page info text. */
@@ -47,22 +45,9 @@
 		/** @event {{ length: number }} amount - Fires when the amount selection input changes.  */
 		dispatch('amount', settings.limit);
 	}
-	function onChangePage(event: Event): void {
-		const target = event.target as HTMLInputElement;
-		if (isNaN(target.valueAsNumber) || target.valueAsNumber < 0) {
-			settings.offset = 0;
-		} else if (target.valueAsNumber >= settings.size / settings.limit) {
-			settings.offset = settings.size / settings.limit - 1;
-		} else {
-			settings.offset = target.valueAsNumber;
-		}
-		target.valueAsNumber = settings.offset;
-
-		/** @event {{ offset: number }} page Fires when the next/back buttons are pressed or the page input value changed. */
-		dispatch('page', settings.offset);
-	}
 	function onPrev(): void {
 		settings.offset--;
+		/** @event {{ offset: number }} page Fires when the next/back buttons are pressed. */
 		dispatch('page', settings.offset);
 	}
 	function onNext(): void {
@@ -82,7 +67,6 @@
 	$: classesBase = `${cBase} ${justify} ${$$props.class ?? ''}`;
 	$: classesLabel = `${cLabel}`;
 	$: classesSelect = `${select}`;
-	$: classesPageInput = `${pageInputClasses}`;
 	$: classesPageText = `${cPageText} ${text}`;
 </script>
 
@@ -98,10 +82,6 @@
 	<span class="paginator-details {classesPageText}">
 		{settings.offset * settings.limit + 1} - {Math.min(settings.offset * settings.limit + settings.limit, settings.size)} <span class="opacity-50 px-2">/</span> <strong>{settings.size}</strong>
 	</span>
-	<!-- Page Input -->
-	<label class="paginator-label {classesLabel}">
-		<input type="number" max="{settings.size / settings.limit - 1}" min="0" value={settings.offset} on:change={(event) => { onChangePage(event) }} class="paginator-input {classesPageInput}" {disabled} aria-label="Page Input" />
-	</label>
 	<!-- Arrows -->
 	<div class="paginator-arrows space-x-2">
 		<button type="button" class="{buttonClasses}" on:click={() => { onFirst() }} disabled={disabled || settings.offset === 0}>


### PR DESCRIPTION
closes #1514 

## Before submitting the PR:
- [x] Does your PR reference an issue?
- [x] Did you update and run tests before submission using `npm run test`?
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)?
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?
1. Added First and Last buttons in the paginator to navigate to the first or last page.
2. Added page input to navigate to a specific page.

### Notes
1. I didn't bind the input value to handle invalid values without affecting the `settings.offset`.
2. I am unsure if the input needs an indicator like "page" written beside it or using an input group.
3. the page input is of type number so we can handle the input easily, however, the input number adds its own spin box which is redundant because we have the next, and previous buttons. I left it like this to hear your opinion about it and change it if necessary.

Please tell me if I can change or improve anything.
