### PR TITLE
fix: remove the publish script from `packages/skeleton/package.json`

### DIFF
--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -7,7 +7,6 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"package": "node ./scripts/pre-build.js && pnpm build:jss && svelte-kit sync && svelte-package && node ./scripts/post-build.js",
-		"publish": "npm publish",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?
This script is the reason why we would see the npm error about publishing duplicate packages. When executing, this would run `npm publish` twice.