### PR TITLE
fix: modal store needs to be imported directly

### DIFF
--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@skeletonlabs/skeleton",
-	"version": "1.5.1",
+	"version": "1.6.1",
 	"description": "A SvelteKit component library.",
 	"author": "endigo9740 <chris@skeletonlabs.dev>",
 	"scripts": {

--- a/packages/skeleton/src/lib/components/Table/Table.svelte
+++ b/packages/skeleton/src/lib/components/Table/Table.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
-	import { tableA11y } from '../..';
+	import { tableA11y } from '../../utilities/DataTable/actions';
 
 	// Types
 	import type { CssClasses, TableSource } from '../..';

--- a/packages/skeleton/src/lib/utilities/CodeBlock/CodeBlock.svelte
+++ b/packages/skeleton/src/lib/utilities/CodeBlock/CodeBlock.svelte
@@ -8,7 +8,7 @@
 	import type { CssClasses } from '../..';
 
 	import { storeHighlightJs } from './stores';
-	import { clipboard } from '../..';
+	import { clipboard } from '../../actions/Clipboard/clipboard';
 
 	// Props
 	/** Sets a language alias for Highlight.js syntax highlighting. */

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -10,7 +10,7 @@
 	import type { CssClasses } from '../..';
 
 	// Actions
-	import { focusTrap } from '../..';
+	import { focusTrap } from '../../actions/FocusTrap/focusTrap';
 
 	// Drawer Utils
 	import type { DrawerSettings } from './types';

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -8,7 +8,8 @@
 	// Types
 	import type { CssClasses } from '../..';
 
-	import { focusTrap, modalStore } from '../..';
+	import { modalStore } from './stores';
+	import { focusTrap } from '../../actions/FocusTrap/focusTrap';
 	import type { ModalComponent, ModalSettings } from './types';
 
 	// Props


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

Modal store was being imported from our `index.ts` rather than directly from where it's declared. This was causing runtime type errors as a result.