### PR TITLE
docs(AppRail): fix page state example

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/app-rail/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-rail/+page.svelte
@@ -174,8 +174,8 @@
 				language="html"
 				code={`
 <AppRail>
-	<AppRailTile href="/" selected={$page.url.pathname === '/'}>(icon)</AppRailTile>
-	<AppRailTile href="/about" selected={$page.url.pathname === '/about'}>(icon)</AppRailTile>
+	<AppRailAnchor href="/" selected={$page.url.pathname === '/'}>(icon)</AppRailAnchor>
+	<AppRailAnchor href="/about" selected={$page.url.pathname === '/about'}>(icon)</AppRailAnchor>
 </AppRail>
 `}
 			/>


### PR DESCRIPTION
use the new `AppRailAnchor`

## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`? (N/A)
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [x] Did you update documentation related to your new feature or changes?

## What does your PR address?

As I posted on Discord, the page state example for `AppRail` should use the new `AppRailAnchor` instead of `AppRailTile`.

### Tips
- Tap "convert to draft" to indicate this is work in progress.
- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- Linked issues will auto-close when the PR is merged.
