### PR TITLE
Doc updates resulting from monorepo migration

### DIFF
--- a/.changeset/rotten-apes-own.md
+++ b/.changeset/rotten-apes-own.md
@@ -1,5 +1,0 @@
----
-"skeleton.dev": patch
----
-
-Doc updates resulting from monorepo migration

--- a/.changeset/rotten-apes-own.md
+++ b/.changeset/rotten-apes-own.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+Doc updates resulting from monorepo migration

--- a/cspell.json
+++ b/cspell.json
@@ -1,7 +1,19 @@
 {
 	"language": "en",
-	"ignorePaths": ["src/lib/tailwind/generated/**", "static/**", "pnpm-lock.yaml", "package-lock.json", "yarn.lock", "package/**"],
-	"dictionaries": ["html", "typescript", "softwareTerms", "companies"],
+	"ignorePaths": [
+		"src/lib/tailwind/generated/**",
+		"static/**",
+		"pnpm-lock.yaml",
+		"package-lock.json",
+		"yarn.lock",
+		"package/**"
+	],
+	"dictionaries": [
+		"html",
+		"typescript",
+		"softwareTerms",
+		"companies"
+	],
 	"allowCompoundWords": true,
 	"words": [
 		"Abril",
@@ -14,6 +26,7 @@
 		"bluenight",
 		"callout",
 		"carbonads",
+		"checkjs",
 		"Chicunamictlán",
 		"Codepen",
 		"colindex",
@@ -55,6 +68,7 @@
 		"iste",
 		"Javis",
 		"JSDocced",
+		"kleur",
 		"labelledby",
 		"laborum",
 		"Lightswitch",
@@ -94,6 +108,7 @@
 		"Scrollbars",
 		"seafoam",
 		"Segoe",
+		"skel",
 		"skeletonlabs",
 		"slnt",
 		"stylesheet",
@@ -113,8 +128,8 @@
 		"unsub",
 		"Unsubscriber",
 		"Vercel",
-		"Vitest",
 		"vite",
+		"Vitest",
 		"wght",
 		"Wonka",
 		"xmark",

--- a/sites/skeleton.dev/src/lib/links.ts
+++ b/sites/skeleton.dev/src/lib/links.ts
@@ -118,8 +118,8 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 					label: 'Modals',
 					keywords: 'overlay, dialog, notification, alert, confirm, prompt, multiple, form, list, embed, video'
 				},
-				{ href: '/utilities/toasts', label: 'Toasts', keywords: 'overlay, snack, snackbar, bar, action, alert, notification' },
-				{ href: '/utilities/popups', label: 'Popups', keywords: 'menu, tooltip, overlay, dropdown, combobox, drop, down, select' }
+				{ href: '/utilities/popups', label: 'Popups', keywords: 'menu, tooltip, overlay, dropdown, combobox, drop, down, select' },
+				{ href: '/utilities/toasts', label: 'Toasts', keywords: 'overlay, snack, snackbar, bar, action, alert, notification' }
 				// DELISTED UNTIL FURTHER NOTICE
 				// { href: '/utilities/data-tables', label: 'Data Tables', keywords: 'search, sort, page, pagination, async', badge: 'Experimental' }
 			]

--- a/sites/skeleton.dev/src/routes/(inner)/docs/contributing/requirements/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/contributing/requirements/+page.svelte
@@ -105,7 +105,8 @@
 		<!-- prettier-ignore -->
 		<ol class="list-decimal list-inside space-y-2">
 			<li>Install <a class="anchor" href="https://pnpm.io/" target="_blank" rel="noreferrer">pnpm</a> globally using <code class="code">npm install -g pnpm</code>. Confirm via <code class="code">pnpm --version</code> in your terminal.</li>
-			<li>Run <code class="code">git clone https://github.com/skeletonlabs/skeleton.git</code> to clone the monorepo project.</li>
+			<li>Go to our <a href="https://github.com/skeletonlabs/skeleton" class="anchor" >repo</a> and press the Fork button in the top right.</li>
+			<li>Click the Code button in Github to clone down a copy of your fork to your local machine</li>
 			<li>Run <code class="code">cd skeleton</code> to move into the cloned monorepo project.</li>
 			<li>Delete your <code class="code">node_modules</code> directory, then run <code class="code">pnpm i</code> to install depedencies for all projects.</li>
 			<li>Run <code class="code">cd sites/skeleton.dev</code> to move into the Skeleton documentation project.</li>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
@@ -7,7 +7,11 @@
 <!-- Header -->
 <section class="space-y-4">
 	<h2 class="h2">Tailwind CSS</h2>
-	<p>	Skeleton features tight integration with <a class="anchor" href="https://tailwindcss.com/" target="_blank" rel="noreferrer">Tailwind CSS</a>.</p>
+	<p>
+		Skeleton features tight integration with <a class="anchor" href="https://tailwindcss.com/" target="_blank" rel="noreferrer"
+			>Tailwind CSS</a
+		>.
+	</p>
 	<TabGroup regionPanel="space-y-4">
 		<!-- Tabs -->
 		<Tab bind:group={$storeOnboardMethod} name="cli" value="cli">Skeleton CLI</Tab>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
@@ -7,11 +7,7 @@
 <!-- Header -->
 <section class="space-y-4">
 	<h2 class="h2">Tailwind CSS</h2>
-	<p>
-		Skeleton features tight integration with <a class="anchor" href="https://tailwindcss.com/" target="_blank" rel="noreferrer"
-			>Tailwind CSS</a
-		>.
-	</p>
+	<p>	Skeleton features tight integration with <a class="anchor" href="https://tailwindcss.com/" target="_blank" rel="noreferrer">Tailwind CSS</a>.</p>
 	<TabGroup regionPanel="space-y-4">
 		<!-- Tabs -->
 		<Tab bind:group={$storeOnboardMethod} name="cli" value="cli">Skeleton CLI</Tab>
@@ -22,7 +18,7 @@
 				<div class="card variant-glass p-4">
 					<!-- prettier-ignore -->
 					<p>
-						The CLI uses <a class="anchor" href="https://github.com/svelte-add/tailwindcss" target="_blank" rel="noreferrer">Svelte-Add</a> to install and configure Tailwind within your project.
+						The CLI will automatically install and configure Tailwind and PostCSS within your project.
 					</p>
 				</div>
 			{:else if $storeOnboardMethod === 'manual'}
@@ -64,7 +60,7 @@ module.exports = {
 		...require('@skeletonlabs/skeleton/tailwind/skeleton.cjs')()
 	]
 }
-			`}
+`}
 				/>
 				<aside class="alert variant-ghost-warning">
 					<i class="fa-solid fa-triangle-exclamation text-2xl" />

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/lightswitches/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/lightswitches/+page.svelte
@@ -78,8 +78,9 @@
 						</p>
 						<h2 class="h2">Set Initial Classes</h2>
 						<p>
-							Import and add the following to your component. This will set the <code class="code">.dark</code> class on the root HTML element
-							in a highly performant manner.
+							Import and add the following to your component. This will set the <code class="code">.dark</code> class on the root HTML
+							element in a highly performant manner. Please note that the CLI installer inserts <code class="code">class="dark"</code>
+							statically in the <code class="code">html</code> element of app.html and you should remove it when going this route.
 						</p>
 						<CodeBlock language="ts" code={`import { setInitialClassState } from '@skeletonlabs/skeleton';`} />
 						<CodeBlock language="html" code={snippetSetInitClass} />
@@ -188,7 +189,7 @@
 						<h2 class="h2">Reference</h2>
 						<aside class="alert alert-message variant-ghost">
 							<!-- prettier-ignore -->
-							<p>View the Skeleton <a class="anchor" href="https://github.com/skeletonlabs/skeleton/tree/master/src/lib/utilities/LightSwitch" target="_blank" rel="noreferrer">Lightswitch component source code</a> for a detailed reference. </p>
+							<p>View the Skeleton <a class="anchor" href="https://github.com/skeletonlabs/skeleton/tree/master/packages/skeleton/src/lib/utilities/LightSwitch" target="_blank" rel="noreferrer">Lightswitch component source code</a> for a detailed reference. </p>
 						</aside>
 					{/if}
 				</svelte:fragment>


### PR DESCRIPTION
Updated a broken link, popups ordering in links.ts, removing add-svelte from CLI instructions (they remain in manual), making a note about .dark being inserted into app.html by CLI