### PR TITLE
chore: `baseBranch` for changesets should point to `dev` instead

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
 	"fixed": [],
 	"linked": [],
 	"access": "public",
-	"baseBranch": "master",
+	"baseBranch": "dev",
 	"updateInternalDependencies": "patch",
 	"ignore": []
 }


### PR DESCRIPTION
## Before submitting the PR:
- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
- [ ] Did you update and run tests before submission using `npm run test`?
- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
- [ ] Did you update documentation related to your new feature or changes?

## What does your PR address?

Small config change for changesets. `baseBranch` is used by changesets to determine what packages have been recently changed. This should've been pointing to `dev`. 