### PR TITLE
Fix Toast jiggle when last toast remains

### DIFF
--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -47,7 +47,7 @@
 
 	// Base Classes
 	const cWrapper = 'flex fixed top-0 left-0 right-0 bottom-0 pointer-events-none';
-	const cSnackbar = 'flex flex-col space-y-2';
+	const cSnackbar = 'flex flex-col gap-y-2';
 	const cToast = 'flex justify-between items-center pointer-events-auto';
 	const cToastActions = 'flex items-center space-x-2';
 


### PR DESCRIPTION
## Before submitting the PR:
- [x] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub]
- [x] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`

## What does your PR address?
Slight jiggle when there is one remaining toast and it moving back into the initial slot.
https://github.com/skeletonlabs/skeleton/assets/12503538/6a1232a1-eeaf-4773-a766-a2cc47134ce0

Please briefly describe your changes here.
Swapped to using CSS gap instead of the older Tailwind spacing helper class
