### PR TITLE
Revised GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: 🐞 Bug
-description: File a bug/issue
-title: "<title>"
+description: Report an issue or bug
 labels: [bug]
 body:
 - type: textarea
@@ -11,25 +10,29 @@ body:
     required: false
 - type: textarea
   attributes:
-    label: Reproduction / Steps To Reproduce
-    description: Stackblitz/Link to a repository with steps to reproduce the behavior.
+    label: Expected Behavior
+    description: A description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Describe how to reproduce the issue.
     placeholder: |
-      As you can see in this code example/Stackblitz link/repostitory
       1. Using this component...
       2. With these properties...
       3. Click '...'
       4. See error...
   validations:
     required: false
-- type: markdown
+- type: input
+  id: reproduction
   attributes:
-    value: |
-      Bug Reports with a repository with a full reproduction or a Stackblitz can be anwswered far quicker, so please consider including as much information as possible to let us help you quicker!
+    label: Link to Reproduction / Stackblitz
 - type: textarea
   attributes:
-    label: Anything else?
+    label: More Information
     description: |
-      Links? References? Anything that will give us more context about the issue you are encountering!
-      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      Provide relevant links or additionl information.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,11 +1,7 @@
 name: 📗 Report Docs Issue
-description: See a typo? Outdated or incorrect information? Let us know!
-title: "<title>"
+description: Use this to report a typo or incorrect information.
 labels: [documentation]
 body:
-- type: markdown
-  attributes:
-    value: Sometimes something slips through the cracks, and the documentation is not quite right. Thanks for letting us know!
 - type: input
   id: link
   attributes:
@@ -13,11 +9,4 @@ body:
 - type: textarea
   id: quote
   attributes:
-    label: Describe the Issue
-- type: dropdown
-  id: participate
-  attributes:
-    label: Are you able to create a Pull Request with the fix?
-    options:
-      - 'Yes'
-      - 'No'
+    label: Describe the Issue (screenshots encouraged!)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,11 +1,11 @@
 name: 🛠️ Request New Feature
-description: Let us know what we should add.
+description: Let us know what you would like to see added.
 labels: ['feature request']
 body:
   - type: textarea
     id: description
     attributes:
-      label: Describe what feature you'd like. Pseudo-code, mockups, or screenshots of similar solutions are encouraged!
+      label: Describe the feature in detail (code, mocks, or screenshots encouraged)
   - type: dropdown
     id: category
     attributes:
@@ -19,4 +19,4 @@ body:
   - type: textarea
     id: references
     attributes:
-      label: Any links to similar examples or other references we should review? 
+      label: Provide relevant links or additional information.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,21 @@
-## Before submitting the PR:
-- [ ] Does your PR reference an issue? If not, please [chat to the team on Discord](https://discord.gg/EXqV7W8MtY) or [GitHub](https://github.com/skeletonlabs/skeleton/discussions) before submission.
-- [ ] Did you update and run tests before submission using `npm run test`?
-- [ ] Does your branch follow our [naming convention](https://www.skeleton.dev/docs/contributing)? If not, please amend the branch name using `branch -m new-branch-name`
-- [ ] Did you update documentation related to your new feature or changes?
+## Linked Issue
 
-## What does your PR address?
+Closes #{issueNumber}
 
-Please briefly describe your changes here.
+## Description
 
-### Tips
-- Tap "convert to draft" to indicate this is work in progress.
-- Link to an issue using the verbiage [Fixes #XX](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-- Linked issues will auto-close when the PR is merged.
+...
+
+## Checklist
+
+Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).
+
+- [ ] This PR targets the `dev` branch
+- [ ] Documented all relevant changes
+- [ ] Prefixed branch with: `docs/`, `feat/`, `chore/`, `bugfix/` - [reference](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches)
+- [ ] Prefixed PR title with: `docs:`, `feat:`, `chore:`, `bugfix:`
+- [ ] Added a changeset - run `pnpm changeset`
+- [ ] Code linting is current - run `pnpm format`
+- [ ] All test cases are passing - run `pnpm test`
+
+Make sure to set "draft PR" or "ready for review" as relevant.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,18 +4,19 @@ Closes #{issueNumber}
 
 ## Description
 
-...
+{description}
+
+## Changsets
+
+If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. This automates our changelog.
 
 ## Checklist
 
 Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).
 
-- [ ] This PR targets the `dev` branch
-- [ ] Documented all relevant changes
-- [ ] Prefixed branch with: `docs/`, `feat/`, `chore/`, `bugfix/` - [reference](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches)
-- [ ] Prefixed PR title with: `docs:`, `feat:`, `chore:`, `bugfix:`
-- [ ] Added a changeset - run `pnpm changeset`
-- [ ] Code linting is current - run `pnpm format`
+- [ ] This PR targets the `dev` branch (NEVER `master`)
+- [ ] Documentation reflects all relevant changes
+- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
+- [ ] Ensure code linting is current - run `pnpm format`
 - [ ] All test cases are passing - run `pnpm test`
-
-Make sure to set "draft PR" or "ready for review" as relevant.
+- [ ] Includes a changeset (if relevant; see above)


### PR DESCRIPTION
## Linked Issue

Close #1569

## Description

This PR updates the PR and Issue templates for GitHub.

## Changsets

If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. This automates our changelog.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
