### PR TITLE
bugfix: add `.js` extension to all relative imports

### DIFF
--- a/.changeset/pink-vans-rule.md
+++ b/.changeset/pink-vans-rule.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: added `.js` extension to all relative imports

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -117,12 +117,5 @@
 		"./dist/tailwind/*",
 		"./dist/themes/*",
 		"!./dist/**/*.test.*"
-	],
-	"typesVersions": {
-		">4.0": {
-			"index": [
-				"./src/lib/index.ts"
-			]
-		}
-	}
+	]
 }

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -117,5 +117,12 @@
 		"./dist/tailwind/*",
 		"./dist/themes/*",
 		"!./dist/**/*.test.*"
-	]
+	],
+	"typesVersions": {
+		">4.0": {
+			"index": [
+				"./src/lib/index.ts"
+			]
+		}
+	}
 }

--- a/packages/skeleton/src/lib/actions/Filters/filter.test.ts
+++ b/packages/skeleton/src/lib/actions/Filters/filter.test.ts
@@ -2,7 +2,7 @@ import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 
 // Action
-import { filter } from '$lib/actions/Filters/filter';
+import { filter } from '$lib/actions/Filters/filter.js';
 
 // SVG Filters
 import Emerald from '$lib/actions/Filters/svg-filters/Emerald.svelte';

--- a/packages/skeleton/src/lib/components/Accordion/Accordion.svelte
+++ b/packages/skeleton/src/lib/components/Accordion/Accordion.svelte
@@ -6,7 +6,7 @@
 	import { setContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/** Set the auto-collapse mode. */

--- a/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
+++ b/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
@@ -18,7 +18,7 @@
 	const dispatch = createEventDispatcher();
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props (state)
 	/** Set open by default on load. */

--- a/packages/skeleton/src/lib/components/AppBar/AppBar.svelte
+++ b/packages/skeleton/src/lib/components/AppBar/AppBar.svelte
@@ -6,7 +6,7 @@
 	 */
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props (base)
 	/** Provide classes to set background color. */

--- a/packages/skeleton/src/lib/components/AppRail/AppRail.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRail.svelte
@@ -8,7 +8,7 @@
 	import { setContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props (rail)
 	/** Rail: Provide classes to set the background color. */

--- a/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
@@ -7,7 +7,7 @@
 	import { getContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/** Enables the active state styles when set true. */

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -7,7 +7,7 @@
 	import { getContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/AppShell/AppShell.svelte
+++ b/packages/skeleton/src/lib/components/AppShell/AppShell.svelte
@@ -9,7 +9,7 @@
 	 */
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props (regions)
 	/** Apply arbitrary classes to the entire `#page` region. */

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -4,7 +4,7 @@
 	// import {slide} from 'svelte/transition';
 
 	// Types
-	import type { AutocompleteOption } from './types';
+	import type { AutocompleteOption } from './types.js';
 
 	// Custom Dispatcher
 	const dispatch = createEventDispatcher();

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.test.ts
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { AutocompleteOption } from './types';
+import type { AutocompleteOption } from './types.js';
 import Autocomplete from './Autocomplete.svelte';
 import { render } from '@testing-library/svelte';
 

--- a/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
+++ b/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 	import type { Action } from 'svelte/action';
 
 	// Props (initials)

--- a/packages/skeleton/src/lib/components/ConicGradient/ConicGradient.svelte
+++ b/packages/skeleton/src/lib/components/ConicGradient/ConicGradient.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { afterUpdate } from 'svelte';
-	import { tailwindDefaultColors } from './settings';
+	import { tailwindDefaultColors } from './settings.js';
 
 	// Types
-	import type { CssClasses } from '../..';
-	import type { ConicStop } from './types';
+	import type { CssClasses } from '../../index.js';
+	import type { ConicStop } from './types.js';
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/FileButton/FileButton.svelte
+++ b/packages/skeleton/src/lib/components/FileButton/FileButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	//Props
 	/**

--- a/packages/skeleton/src/lib/components/FileDropzone/FileDropzone.svelte
+++ b/packages/skeleton/src/lib/components/FileDropzone/FileDropzone.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -4,7 +4,7 @@
 	import { flip } from 'svelte/animate';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Event Dispatcher
 	const dispatch = createEventDispatcher();

--- a/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
@@ -2,7 +2,7 @@
 	import { setContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/** Enable selection of multiple items. */

--- a/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
@@ -8,7 +8,7 @@
 	import { getContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/** Set the radio group binding value. */

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	// Types
-	import type { CssClasses, PaginationSettings } from '../..';
+	import type { CssClasses, PaginationSettings } from '../../index.js';
 
 	const dispatch = createEventDispatcher();
 

--- a/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte
+++ b/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
+++ b/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
@@ -3,7 +3,7 @@
 	import { afterUpdate } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/Radio/RadioGroup.svelte
+++ b/packages/skeleton/src/lib/components/Radio/RadioGroup.svelte
@@ -2,7 +2,7 @@
 	import { setContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props (Group)
 	/** Provide display classes. Set `flex` to stretch full width. */

--- a/packages/skeleton/src/lib/components/Radio/RadioItem.svelte
+++ b/packages/skeleton/src/lib/components/Radio/RadioItem.svelte
@@ -2,7 +2,7 @@
 	import { getContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/RangeSlider/RangeSlider.svelte
+++ b/packages/skeleton/src/lib/components/RangeSlider/RangeSlider.svelte
@@ -5,7 +5,7 @@
 	import { afterUpdate } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
+++ b/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
@@ -2,7 +2,7 @@
 	import { createEventDispatcher } from 'svelte/internal';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Event Handler
 	const dispatch = createEventDispatcher();

--- a/packages/skeleton/src/lib/components/Stepper/Step.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Step.svelte
@@ -5,7 +5,7 @@
 	import { fade } from 'svelte/transition';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	export let locked = false;

--- a/packages/skeleton/src/lib/components/Stepper/Stepper.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Stepper.svelte
@@ -4,7 +4,7 @@
 	import { fade } from 'svelte/transition';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Event Dispatcher
 	const dispatchParent = createEventDispatcher();

--- a/packages/skeleton/src/lib/components/Tab/Tab.svelte
+++ b/packages/skeleton/src/lib/components/Tab/Tab.svelte
@@ -7,7 +7,7 @@
 	import { getContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/Tab/TabGroup.svelte
+++ b/packages/skeleton/src/lib/components/Tab/TabGroup.svelte
@@ -7,7 +7,7 @@
 	import { setContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props (Group)
 	/** Provide classes to set the tab list flex justification. */

--- a/packages/skeleton/src/lib/components/Table/Table.svelte
+++ b/packages/skeleton/src/lib/components/Table/Table.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
-	import { tableA11y } from '../../utilities/DataTable/actions';
+	import { tableA11y } from '../../utilities/DataTable/actions.js';
 
 	// Types
-	import type { CssClasses, TableSource } from '../..';
+	import type { CssClasses, TableSource } from '../../index.js';
 
 	const dispatch = createEventDispatcher();
 

--- a/packages/skeleton/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/packages/skeleton/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -3,7 +3,7 @@
 	import { fade } from 'svelte/transition';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Props (settings)
 	/** Query selector for the scrollable page element. */

--- a/packages/skeleton/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/packages/skeleton/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -42,6 +42,8 @@
 
 	// Local
 	let elemScrollParent: HTMLElement | null;
+	// this has a type error that shouldn't exist
+	// eslint-disable-next-line
 	let allowedHeadingsList: NodeListOf<HTMLElement> | undefined;
 	let filteredHeadingsList: HTMLElement[] = [];
 	let activeHeaderId: string;

--- a/packages/skeleton/src/lib/index.ts
+++ b/packages/skeleton/src/lib/index.ts
@@ -2,25 +2,25 @@
 
 // Types ---
 
-export type { AutocompleteOption } from './components/Autocomplete/types';
-export type { ConicStop } from './components/ConicGradient/types';
-export type { DrawerSettings } from './utilities/Drawer/types';
-export type { ModalSettings, ModalComponent } from './utilities/Modal/types';
-export type { ToastSettings } from './utilities/Toast/types';
-export type { TableSource } from './components/Table/types';
-export type { PaginationSettings } from './components/Paginator/types';
-export type { PopupSettings } from './utilities/Popup/types';
+export type { AutocompleteOption } from './components/Autocomplete/types.js';
+export type { ConicStop } from './components/ConicGradient/types.js';
+export type { DrawerSettings } from './utilities/Drawer/types.js';
+export type { ModalSettings, ModalComponent } from './utilities/Modal/types.js';
+export type { ToastSettings } from './utilities/Toast/types.js';
+export type { TableSource } from './components/Table/types.js';
+export type { PaginationSettings } from './components/Paginator/types.js';
+export type { PopupSettings } from './utilities/Popup/types.js';
 
 // This type alias is to identify CSS classes within component props, which enables Tailwind IntelliSense
 export type CssClasses = string;
 
 // Stores ---
 
-export { storeHighlightJs } from './utilities/CodeBlock/stores';
-export { storePopup } from './utilities/Popup/popup';
-export { drawerStore } from './utilities/Drawer/stores';
-export { modalStore } from './utilities/Modal/stores';
-export { toastStore } from './utilities/Toast/stores';
+export { storeHighlightJs } from './utilities/CodeBlock/stores.js';
+export { storePopup } from './utilities/Popup/popup.js';
+export { drawerStore } from './utilities/Drawer/stores.js';
+export { modalStore } from './utilities/Modal/stores.js';
+export { toastStore } from './utilities/Toast/stores.js';
 
 // Utilities ---
 
@@ -35,7 +35,7 @@ export {
 	// Svelte Actions
 	tableInteraction,
 	tableA11y
-} from './utilities/DataTable/DataTable';
+} from './utilities/DataTable/DataTable.js';
 // Lightswitch
 export {
 	// Stores
@@ -50,19 +50,19 @@ export {
 	setModeCurrent,
 	setInitialClassState,
 	autoModeWatcher
-} from './utilities/LightSwitch/lightswitch';
+} from './utilities/LightSwitch/lightswitch.js';
 // Local Storage Store
-export { localStorageStore } from './utilities/LocalStorageStore/LocalStorageStore';
+export { localStorageStore } from './utilities/LocalStorageStore/LocalStorageStore.js';
 // Component Utilities
-export { tableSourceMapper, tableSourceValues, tableMapperValues } from './components/Table/utils';
+export { tableSourceMapper, tableSourceValues, tableMapperValues } from './components/Table/utils.js';
 
 // Svelte Actions ---
 
-export { clipboard } from './actions/Clipboard/clipboard';
-export { filter } from './actions/Filters/filter';
-export { focusTrap } from './actions/FocusTrap/focusTrap';
+export { clipboard } from './actions/Clipboard/clipboard.js';
+export { filter } from './actions/Filters/filter.js';
+export { focusTrap } from './actions/FocusTrap/focusTrap.js';
 // Utility Actions
-export { popup } from './utilities/Popup/popup';
+export { popup } from './utilities/Popup/popup.js';
 
 // Svelte Components ---
 

--- a/packages/skeleton/src/lib/utilities/CodeBlock/CodeBlock.svelte
+++ b/packages/skeleton/src/lib/utilities/CodeBlock/CodeBlock.svelte
@@ -5,10 +5,10 @@
 	const dispatch = createEventDispatcher();
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
-	import { storeHighlightJs } from './stores';
-	import { clipboard } from '../../actions/Clipboard/clipboard';
+	import { storeHighlightJs } from './stores.js';
+	import { clipboard } from '../../actions/Clipboard/clipboard.js';
 
 	// Props
 	/** Sets a language alias for Highlight.js syntax highlighting. */

--- a/packages/skeleton/src/lib/utilities/DataTable/DataTable.ts
+++ b/packages/skeleton/src/lib/utilities/DataTable/DataTable.ts
@@ -2,12 +2,12 @@
 // A set of utility features for local template-driven data tables.
 
 import { writable } from 'svelte/store';
-import type { DataTableModel, DataTableOptions } from './types';
+import type { DataTableModel, DataTableOptions } from './types.js';
 
 // Exports
 
-export * from './types';
-export * from './actions';
+export * from './types.js';
+export * from './actions.js';
 
 /** Creates the writeable store for the data table */
 export function createDataTableStore<T extends Record<PropertyKey, any>>(source: T[], options: DataTableOptions<T> = {}) {

--- a/packages/skeleton/src/lib/utilities/DataTable/types.ts
+++ b/packages/skeleton/src/lib/utilities/DataTable/types.ts
@@ -1,6 +1,6 @@
 // Data Table Types
 
-import type { PaginationSettings } from '../..';
+import type { PaginationSettings } from '../../index.js';
 
 export interface DataTableModel<T extends Record<PropertyKey, unknown>> {
 	/** The original source data. */

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -7,14 +7,14 @@
 	const dispatch = createEventDispatcher();
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Actions
-	import { focusTrap } from '../../actions/FocusTrap/focusTrap';
+	import { focusTrap } from '../../actions/FocusTrap/focusTrap.js';
 
 	// Drawer Utils
-	import type { DrawerSettings } from './types';
-	import { drawerStore } from './stores';
+	import type { DrawerSettings } from './types.js';
+	import { drawerStore } from './stores.js';
 
 	// Props
 	/** Set the anchor position.

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.test.ts
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.test.ts
@@ -2,7 +2,7 @@ import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 
 import Drawer from '$lib/utilities/Drawer/Drawer.svelte';
-import { drawerStore } from '$lib/utilities/Drawer/stores';
+import { drawerStore } from '$lib/utilities/Drawer/stores.js';
 
 describe('Drawer.svelte', () => {
 	it('Drawer hidden on load', async () => {

--- a/packages/skeleton/src/lib/utilities/Drawer/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Drawer/stores.ts
@@ -1,7 +1,7 @@
 // Drawer Stores
 
 import { writable } from 'svelte/store';
-import type { DrawerSettings } from './types';
+import type { DrawerSettings } from './types.js';
 
 function drawerService() {
 	const { subscribe, set, update } = writable<DrawerSettings>({});

--- a/packages/skeleton/src/lib/utilities/LightSwitch/LightSwitch.svelte
+++ b/packages/skeleton/src/lib/utilities/LightSwitch/LightSwitch.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { modeCurrent, setModeUserPrefers, setModeCurrent, setInitialClassState, getModeOsPrefers } from './lightswitch';
+	import { modeCurrent, setModeUserPrefers, setModeCurrent, setInitialClassState, getModeOsPrefers } from './lightswitch.js';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 	type OnKeyDownEvent = KeyboardEvent & { currentTarget: EventTarget & HTMLDivElement };
 
 	// Props

--- a/packages/skeleton/src/lib/utilities/LightSwitch/lightswitch.ts
+++ b/packages/skeleton/src/lib/utilities/LightSwitch/lightswitch.ts
@@ -2,7 +2,7 @@
 
 import { get } from 'svelte/store';
 // DO NOT replace this ⬇ import, it has to be imported directly
-import { localStorageStore } from '../LocalStorageStore/LocalStorageStore';
+import { localStorageStore } from '../LocalStorageStore/LocalStorageStore.js';
 
 // Stores ---
 // TRUE: light, FALSE: dark

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -6,11 +6,11 @@
 	const dispatch = createEventDispatcher();
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
-	import { modalStore } from './stores';
-	import { focusTrap } from '../../actions/FocusTrap/focusTrap';
-	import type { ModalComponent, ModalSettings } from './types';
+	import { modalStore } from './stores.js';
+	import { focusTrap } from '../../actions/FocusTrap/focusTrap.js';
+	import type { ModalComponent, ModalSettings } from './types.js';
 
 	// Props
 	/** Set the modal position within the backdrop container */

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.test.ts
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.test.ts
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 
-import { modalStore } from '$lib/utilities/Modal/stores';
-import type { ModalSettings } from '$lib/utilities/Modal/types';
+import { modalStore } from '$lib/utilities/Modal/stores.js';
+import type { ModalSettings } from '$lib/utilities/Modal/types.js';
 
 import Modal from '$lib/utilities/Modal/Modal.svelte';
 

--- a/packages/skeleton/src/lib/utilities/Modal/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Modal/stores.ts
@@ -1,7 +1,7 @@
 // Modal Store Queue
 
 import { writable } from 'svelte/store';
-import type { ModalSettings } from './types';
+import type { ModalSettings } from './types.js';
 
 function modalService() {
 	const { subscribe, set, update } = writable<ModalSettings[]>([]);

--- a/packages/skeleton/src/lib/utilities/Popup/popup.ts
+++ b/packages/skeleton/src/lib/utilities/Popup/popup.ts
@@ -1,5 +1,5 @@
 import { get, writable, type Writable } from 'svelte/store';
-import type { PopupSettings } from './types';
+import type { PopupSettings } from './types.js';
 
 // Use a store to pass the Floating UI import references
 export const storePopup: Writable<any> = writable(undefined);

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -4,10 +4,10 @@
 	import { flip } from 'svelte/animate';
 
 	// Types
-	import type { CssClasses } from '../..';
+	import type { CssClasses } from '../../index.js';
 
 	// Stores
-	import { toastStore } from './stores';
+	import { toastStore } from './stores.js';
 
 	// Props
 	/** Set the toast position.

--- a/packages/skeleton/src/lib/utilities/Toast/Toats.test.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/Toats.test.ts
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 
-import { toastStore } from '$lib/utilities/Toast/stores';
-import type { ToastSettings } from './types';
+import { toastStore } from '$lib/utilities/Toast/stores.js';
+import type { ToastSettings } from './types.js';
 import Toast from '$lib/utilities/Toast/Toast.svelte';
 
 // Toast Payload

--- a/packages/skeleton/src/lib/utilities/Toast/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/stores.ts
@@ -1,7 +1,7 @@
 // Toast Store Queue
 
 import { writable } from 'svelte/store';
-import type { ToastSettings, Toast } from './types';
+import type { ToastSettings, Toast } from './types.js';
 
 const toastDefaults: ToastSettings = { message: 'Missing Toast Message', autohide: true, timeout: 5000 };
 

--- a/packages/skeleton/tsconfig.json
+++ b/packages/skeleton/tsconfig.json
@@ -8,6 +8,7 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"moduleResolution": "nodenext"
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #1501 

## Description

Added `.js` extension to all relative imports. We'll now be adhering to Node's ESM algorithm as specified [here](https://kit.svelte.dev/docs/packaging#caveats) in SvelteKit's packaging docs.

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
