### PR TITLE
bugfix: changed `typesVersions` map to point to `index.d.ts`

### DIFF
--- a/.changeset/smooth-rockets-know.md
+++ b/.changeset/smooth-rockets-know.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: updated `typesVersions` map to fix auto imports paths

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -85,13 +85,13 @@
 			},
 			"./styles/*": "./dist/styles/*",
 			"./themes/*": "./dist/themes/*",
-			"./tailwind/skeleton.cjs": "./dist/tailwind/skeleton.cjs"
+			"./tailwind/skeleton.cjs": {
+				"types": "./dist/tailwind/skeleton.cts",
+				"default": "./dist/tailwind/skeleton.cjs"
+			}
 		},
 		"typesVersions": {
 			">4.0": {
-				"index": [
-					"./dist/index.d.ts"
-				],
 				"tailwind/skeleton.cjs": [
 					"./dist/tailwind/skeleton.d.cts"
 				]
@@ -117,12 +117,5 @@
 		"./dist/tailwind/*",
 		"./dist/themes/*",
 		"!./dist/**/*.test.*"
-	],
-	"typesVersions": {
-		">4.0": {
-			"index": [
-				"./src/lib/index.ts"
-			]
-		}
-	}
+	]
 }

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -92,6 +92,9 @@
 		},
 		"typesVersions": {
 			">4.0": {
+				"index.d.ts": [
+					"./dist/index.d.ts"
+				],
 				"tailwind/skeleton.cjs": [
 					"./dist/tailwind/skeleton.d.cts"
 				]


### PR DESCRIPTION
## Linked Issue

Closes #1581 

## Description

Replaces `index` for `index.d.ts` from `typesVersions` map in `package.json`. Even though SvelteKit's [packaging docs](https://kit.svelte.dev/docs/packaging#typescript) states:
> Note that if you opt into typesVersions you have to declare all type imports through it, including the root import (which is defined as `"index": [..]`). 

I think this may actually be a typo in the SvelteKit docs.

Fortunately, this change won't negatively effect any users that may already be importing their components with the `@skeletonlabs/skeleton/index` path since it was never a valid import path in the first place. If they imported anything from this path, the app would just error.

I also added the type declaration path for our plugin as well since that was missing.

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
