### PR TITLE
update focusable elements onWindowKeyDown

### DIFF
--- a/.changeset/big-paws-melt.md
+++ b/.changeset/big-paws-melt.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: updated focusablePopupElements onWindowKeyDown in popup to allow tabbing into changed lists in Autocomplete

--- a/packages/skeleton/src/lib/utilities/Popup/popup.ts
+++ b/packages/skeleton/src/lib/utilities/Popup/popup.ts
@@ -163,6 +163,8 @@ export function popup(triggerNode: HTMLElement, args: PopupSettings) {
 			close();
 			return;
 		}
+		// Update focusable elements (important for Autocomplete)
+		focusablePopupElements = Array.from(elemPopup?.querySelectorAll(focusableAllowedList));
 		// On Tab or ArrowDown key
 		const triggerMenuFocused: boolean = popupState.open && document.activeElement === triggerNode;
 		if (


### PR DESCRIPTION
## Linked Issue

Closes #1586 

## Description

The popup focusable elements were not updated when the input changed in Autocomplete causing the index to be stuck in the input if the list changed and the first element is not existing anymore.

updated the `focusablePopupElements` in `onWindowKeyDown`.

## Changsets

bugfix: updated focusablePopupElements onWindowKeyDown in popup to allow tabbing into changed lists in Autocomplete

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)