### PR TITLE
Docs: remove shorthand props

### DIFF
--- a/.changeset/wild-tools-ring.md
+++ b/.changeset/wild-tools-ring.md
@@ -1,5 +1,0 @@
----
-"skeleton.dev": patch
----
-
-docs: removed shorthand prop definitions

--- a/.changeset/wild-tools-ring.md
+++ b/.changeset/wild-tools-ring.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+docs: removed shorthand prop defintions

--- a/.changeset/wild-tools-ring.md
+++ b/.changeset/wild-tools-ring.md
@@ -2,4 +2,4 @@
 "skeleton.dev": patch
 ---
 
-docs: removed shorthand prop defintions
+docs: removed shorthand prop definitions

--- a/sites/skeleton.dev/src/routes/(inner)/components/avatars/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/avatars/+page.svelte
@@ -22,7 +22,7 @@
 
 	// Local
 	const imgPlaceholder = 'https://source.unsplash.com/YOErFW8AfkI/128x128';
-	const borderStyles = 'border-4 	border-surface-300-600-token hover:!border-primary-500';
+	const borderStyles = 'border-4 border-surface-300-600-token hover:!border-primary-500';
 
 	const roundedMapping = {
 		0: 'rounded-none',

--- a/sites/skeleton.dev/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -68,7 +68,7 @@
 			<h2 class="h2">Binding Method</h2>
 			<p>Use a <code class="code">FileList</code> to bind the file data.</p>
 			<CodeBlock language="ts" code={`let files: FileList;`} />
-			<CodeBlock language="html" code={`<FileButton ... bind:files />`} />
+			<CodeBlock language="html" code={`<FileButton ... bind:files={files} />`} />
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">On Change Event</h2>

--- a/sites/skeleton.dev/src/routes/(inner)/components/file-dropzone/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/file-dropzone/+page.svelte
@@ -85,7 +85,7 @@
 			<h2 class="h2">Binding Method</h2>
 			<p>Use a <code class="code">FileList</code> to bind the file data.</p>
 			<CodeBlock language="ts" code={`let files: FileList;`} />
-			<CodeBlock language="html" code={`<FileDropzone ... bind:files />`} />
+			<CodeBlock language="html" code={`<FileDropzone ... bind:files={files} />`} />
 		</div>
 		<div class="space-y-4">
 			<h2 class="h2">On Change Event</h2>

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -35,7 +35,7 @@
 			</svelte:fragment>
 			<svelte:fragment slot="source">
 				<CodeBlock language="ts" code={`let value: number = 50; // %`} />
-				<CodeBlock language="html" code={`<ProgressRadial {value}>{value}%</ProgressRadial>`} />
+				<CodeBlock language="html" code={`<ProgressRadial value={value}>{value}%</ProgressRadial>`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>


### PR DESCRIPTION
## Linked Issue

Closes #1571 

## Description

removed shorthand prop definitions.

## Changsets

docs: removed shorthand prop definitions.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
