### PR TITLE
added anchor lead slot, added tile title

### DIFF
--- a/packages/skeleton/src/lib/components/AppRail/AppRail.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRail.svelte
@@ -37,11 +37,14 @@
 	export let active: CssClasses = 'bg-primary-active-token';
 	/** Tile: Provide classes to set the tile vertical spacing. */
 	export let spacing: CssClasses = 'space-y-1';
+	/** Adds a tooltip with the title text */
+	export let title: string = '';
 
 	// Context
 	setContext('active', active);
 	setContext('hover', hover);
 	setContext('spacing', spacing);
+	setContext('title', title);
 
 	// Base Classes
 	const cBase = 'grid grid-rows-[auto_1fr_auto] overflow-y-auto';

--- a/packages/skeleton/src/lib/components/AppRail/AppRail.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRail.svelte
@@ -37,14 +37,11 @@
 	export let active: CssClasses = 'bg-primary-active-token';
 	/** Tile: Provide classes to set the tile vertical spacing. */
 	export let spacing: CssClasses = 'space-y-1';
-	/** Adds a tooltip with the title text */
-	export let title: string = '';
 
 	// Context
 	setContext('active', active);
 	setContext('hover', hover);
 	setContext('spacing', spacing);
-	setContext('title', title);
 
 	// Base Classes
 	const cBase = 'grid grid-rows-[auto_1fr_auto] overflow-y-auto';

--- a/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
@@ -15,7 +15,7 @@
 
 	// Props (region)
 	/** Provide arbitrary classes to style the lead region. */
-	export let regionLead: CssClasses = '';
+	export let regionLead: CssClasses = 'flex justify-center items-center';
 	/** Provide arbitrary classes to style the label region. */
 	export let regionLabel: CssClasses = '';
 

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -25,6 +25,8 @@
 	 * @type {any}
 	 * */
 	export let value: any;
+	/** Provides a tooltip for the tile */
+	export let title: string = '';
 
 	// Props (region)
 	/** Provide arbitrary classes to style the lead region. */
@@ -36,7 +38,6 @@
 	export let hover: CssClasses = getContext('hover');
 	export let active: CssClasses = getContext('active');
 	export let spacing: CssClasses = getContext('spacing');
-	export let title: string = getContext('title');
 
 	// Classes
 	const cBase = 'cursor-pointer';

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -25,7 +25,7 @@
 	 * @type {any}
 	 * */
 	export let value: any;
-	/** Provides a tooltip for the tile */
+	/** Provide a hoverable title attribute for the tile. */
 	export let title: string = '';
 
 	// Props (region)

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -36,6 +36,7 @@
 	export let hover: CssClasses = getContext('hover');
 	export let active: CssClasses = getContext('active');
 	export let spacing: CssClasses = getContext('spacing');
+	export let title: string = getContext('title');
 
 	// Classes
 	const cBase = 'cursor-pointer';
@@ -62,7 +63,7 @@
 	}
 </script>
 
-<label class="app-rail-tile {classesBase}" data-testid="app-rail-tile">
+<label class="app-rail-tile {classesBase}" data-testid="app-rail-tile" {title}>
 	<!-- A11y attributes are not allowed on <label> -->
 	<div class="app-rail-wrapper {classesWrapper}" on:keydown on:keyup on:keypress>
 		<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.test.ts
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.test.ts
@@ -27,16 +27,4 @@ describe('AppRailTile.svelte', () => {
 		});
 		expect(getByTestId('app-rail-tile')).toBeTruthy();
 	});
-
-	it('Overrides tag when href is passed', async () => {
-		const { getByTestId } = render(AppRailTile, {
-			props: {
-				href: '/about',
-				group: 'testGroup',
-				name: 'test tile',
-				value: 'some value'
-			}
-		});
-		expect(getByTestId('app-rail-tile').querySelector('a')).toBeTruthy();
-	});
 });

--- a/sites/skeleton.dev/src/routes/(inner)/components/app-rail/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-rail/+page.svelte
@@ -48,15 +48,15 @@
 							</AppRailAnchor>
 						</svelte:fragment>
 						<!-- Default -->
-						<AppRailTile bind:group={currentTile} name="tile-1" value={0}>
+						<AppRailTile bind:group={currentTile} name="tile-1" value={0} title="tile-1">
 							<svelte:fragment slot="lead"><i class="fa-solid fa-image text-2xl" /></svelte:fragment>
 							<span>Tile 1</span>
 						</AppRailTile>
-						<AppRailTile bind:group={currentTile} name="tile-2" value={1}>
+						<AppRailTile bind:group={currentTile} name="tile-2" value={1} title="tile-2">
 							<svelte:fragment slot="lead"><i class="fa-solid fa-image text-2xl" /></svelte:fragment>
 							<span>Tile 2</span>
 						</AppRailTile>
-						<AppRailTile bind:group={currentTile} name="tile-3" value={2}>
+						<AppRailTile bind:group={currentTile} name="tile-3" value={2} title="tile-3">
 							<svelte:fragment slot="lead"><i class="fa-solid fa-image text-2xl" /></svelte:fragment>
 							<span>Tile 3</span>
 						</AppRailTile>
@@ -82,15 +82,15 @@
 		<AppRailAnchor href="/" >(icon)</AppRailAnchor>
 	</svelte:fragment>
 	<!-- --- -->
-	<AppRailTile bind:group={currentTile} name="tile-1" value={0}>
+	<AppRailTile bind:group={currentTile} name="tile-1" value={0} title="tile-1">
 		<svelte:fragment slot="lead">(icon)</svelte:fragment>
 		<span>Tile 1</span>
 	</AppRailTile>
-	<AppRailTile bind:group={currentTile} name="tile-2" value={1}>
+	<AppRailTile bind:group={currentTile} name="tile-2" value={1} title="tile-2">
 		<svelte:fragment slot="lead">(icon)</svelte:fragment>
 		<span>Tile 2</span>
 	</AppRailTile>
-	<AppRailTile bind:group={currentTile} name="tile-3" value={2}>
+	<AppRailTile bind:group={currentTile} name="tile-3" value={2} title="tile-3">
 		<svelte:fragment slot="lead">(icon)</svelte:fragment>
 		<span>Tile 3</span>
 	</AppRailTile>
@@ -119,7 +119,7 @@
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="bg-surface-100-800-token overflow-hidden w-24">
-						<AppRailTile bind:group={currentTile} name="tile-4" value={4} hover="hover:bg-primary-hover-token">
+						<AppRailTile bind:group={currentTile} name="tile-4" value={4} hover="hover:bg-primary-hover-token" title="tile-1">
 							<svelte:fragment slot="lead"><i class="fa-solid fa-image text-2xl" /></svelte:fragment>
 							<span>Tile</span>
 						</AppRailTile>
@@ -131,7 +131,7 @@
 					<CodeBlock
 						language="html"
 						code={`
-<AppRailTile bind:group={currentTile} name="tile-1" value={0}>
+<AppRailTile bind:group={currentTile} name="tile-1" value={0} title="tile-1>
 	<svelte:fragment slot="lead">(icon)</svelte:fragment>
 	<span>Tile 1</span>
 </AppRailTile>
@@ -154,12 +154,26 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<AppRailAnchor href="/" target="_blank" title="Account">(icon)</AppRailAnchor>`} />
+					<CodeBlock
+						language="html"
+						code={`
+<AppRailAnchor href="/" target="_blank" title="Account">
+	<svelte:fragment slot="lead">(icon)</svelte:fragment>
+	<span>Anchor</span>
+</AppRailAnchor>`}
+					/>
 					<p>
 						Unlike <code class="code">AppRailTile</code> you must explicitly set the active state via the <code class="code">selected</code>
 						property.
 					</p>
-					<CodeBlock language="html" code={`<AppRailAnchor ... selected={true}>(icon)</AppRailAnchor>`} />
+					<CodeBlock
+						language="html"
+						code={`
+<AppRailAnchor ... selected={true}>
+	<svelte:fragment slot="lead">(icon)</svelte:fragment>
+	<span>Anchor</span>
+</AppRailAnchor>`}
+					/>
 				</svelte:fragment>
 			</DocsPreview>
 		</section>


### PR DESCRIPTION
## Linked Issue

Closes #1549

## Description

- added slot lead to the docs example
- centered the icon content of AppRailAnchor.
- added title to AppRail and AppRailTile (this could required changeset but I will wait for you to decide)
- updated docs to use the title also in AppRailTile
- deleted an outdated test that was covering `Overrides tag when href is passed` which is now replaced by AppRailAnchor.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
