### PR TITLE
Feat: modal backdrop interaction

### DIFF
--- a/.changeset/nasty-deers-draw.md
+++ b/.changeset/nasty-deers-draw.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: modal backdrop interaction - register interaction on clickDown and close modal on clickUp
+feat: modal backdrop interaction - register interaction on mousedown and close modal on mouseup

--- a/.changeset/nasty-deers-draw.md
+++ b/.changeset/nasty-deers-draw.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: modal backdrop interaction - register interaction on clickDown and close modal on clickUp

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -100,14 +100,14 @@
 	});
 
 	// Event Handlers ---
-	function onBackdropInteractionBegin(event: MouseEvent | TouchEvent): void {
+	function onBackdropInteractionBegin(event: MouseEvent): void {
 		if (!(event.target instanceof Element)) return;
 		const classList = event.target.classList;
 		if (classList.contains('modal-backdrop') || classList.contains('modal-transition')) {
 			registeredInteractionWithBackdrop = true;
 		}
 	}
-	function onBackdropInteractionEnd(event: MouseEvent | TouchEvent): void {
+	function onBackdropInteractionEnd(event: MouseEvent): void {
 		if (!(event.target instanceof Element)) return;
 		const classList = event.target.classList;
 		if ((classList.contains('modal-backdrop') || classList.contains('modal-transition')) && registeredInteractionWithBackdrop) {
@@ -195,9 +195,9 @@
 			class="modal-backdrop {classesBackdrop}"
 			data-testid="modal-backdrop"
 			on:mousedown|preventDefault={onBackdropInteractionBegin}
-			on:touchstart|preventDefault={onBackdropInteractionBegin}
 			on:mouseup|preventDefault={onBackdropInteractionEnd}
-			on:touchend|preventDefault={onBackdropInteractionEnd}
+			on:touchstart|preventDefault
+			on:touchend|preventDefault
 			transition:fade={{ duration }}
 			use:focusTrap={true}
 		>

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -84,6 +84,7 @@
 		buttonTextSubmit
 	};
 	let currentComponent: ModalComponent | undefined;
+	let registeredInteractionWithBackdrop = false;
 
 	// Modal Store Subscription
 	modalStore.subscribe((modals: ModalSettings[]) => {
@@ -99,17 +100,24 @@
 	});
 
 	// Event Handlers ---
-
-	function onBackdropInteraction(event: MouseEvent | TouchEvent): void {
+	function onBackdropInteractionBegin(event: MouseEvent | TouchEvent): void {
 		if (!(event.target instanceof Element)) return;
 		const classList = event.target.classList;
 		if (classList.contains('modal-backdrop') || classList.contains('modal-transition')) {
+			registeredInteractionWithBackdrop = true;
+		}
+	}
+	function onBackdropInteractionEnd(event: MouseEvent | TouchEvent): void {
+		if (!(event.target instanceof Element)) return;
+		const classList = event.target.classList;
+		if ((classList.contains('modal-backdrop') || classList.contains('modal-transition')) && registeredInteractionWithBackdrop) {
 			// We return `undefined` to differentiate from the cancel button
 			if ($modalStore[0].response) $modalStore[0].response(undefined);
 			modalStore.close();
 			/** @event {{ event }} backdrop - Fires on backdrop interaction.  */
 			dispatch('backdrop', event);
 		}
+		registeredInteractionWithBackdrop = false;
 	}
 
 	function onClose(): void {
@@ -186,8 +194,10 @@
 		<div
 			class="modal-backdrop {classesBackdrop}"
 			data-testid="modal-backdrop"
-			on:mousedown={onBackdropInteraction}
-			on:touchstart={onBackdropInteraction}
+			on:mousedown|preventDefault={onBackdropInteractionBegin}
+			on:touchstart|preventDefault={onBackdropInteractionBegin}
+			on:mouseup|preventDefault={onBackdropInteractionEnd}
+			on:touchend|preventDefault={onBackdropInteractionEnd}
 			transition:fade={{ duration }}
 			use:focusTrap={true}
 		>

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -194,10 +194,10 @@
 		<div
 			class="modal-backdrop {classesBackdrop}"
 			data-testid="modal-backdrop"
-			on:mousedown|preventDefault={onBackdropInteractionBegin}
-			on:mouseup|preventDefault={onBackdropInteractionEnd}
-			on:touchstart|preventDefault
-			on:touchend|preventDefault
+			on:mousedown={onBackdropInteractionBegin}
+			on:mouseup={onBackdropInteractionEnd}
+			on:touchstart
+			on:touchend
 			transition:fade={{ duration }}
 			use:focusTrap={true}
 		>


### PR DESCRIPTION
## Linked Issue

Closes #1544 
Closes #1539 

## Description

- Instead of closing modal `on:mouseDown`, we do the following:
    1. register mouseDown if it was on the backdrop
    2. close modal if the the mouseDown was already registered and the mouseUp was fired on the backdrop.
- using `preventDefault` to prevent double firing the events.
- forwarding touchstart and touchend events instead of handling them.


## Changsets

feat: modal backdrop interaction - register interaction on mousedown and close modal on mouseup

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
