### PR TITLE
Add nav slot to Step component

### DIFF
--- a/.changeset/itchy-mice-judge.md
+++ b/.changeset/itchy-mice-judge.md
@@ -1,5 +1,5 @@
 ---
-"@skeletonlabs/skeleton": patch
+"@skeletonlabs/skeleton": minor
 ---
 
-Added a navigation slot to the Step component, this replaces the Back button for the first step only
+feat: Added a navigation slot to the Step component, this replaces the Back button for the first step only

--- a/.changeset/itchy-mice-judge.md
+++ b/.changeset/itchy-mice-judge.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+Added a navigation slot to the Step component, this replaces the Back button for the first step only

--- a/packages/skeleton/src/lib/components/Stepper/Step.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Step.svelte
@@ -1,5 +1,11 @@
 <!-- Reference: https://dribbble.com/shots/16221169-Figma-Material-Ui-components-Steppers-and-sliders -->
 <script lang="ts">
+	// Slots:
+	/**
+	 * @slot {{}} header - Overrides the header text label.
+	 * @slot {{}} navigation - Overrides the Back button position for the first step only.
+	 */
+
 	import { getContext, onDestroy } from 'svelte';
 	import type { Writable } from 'svelte/store';
 	import { fade } from 'svelte/transition';
@@ -92,10 +98,19 @@
 		<!-- Navigation -->
 		{#if $state.total > 1}
 			<div class="step-navigation {classesNavigation}" transition:fade|local={{ duration: 100 }}>
-				<button type={buttonBackType} class="btn {buttonBack}" on:click={onBack} disabled={$state.current === 0}
-					>{@html buttonBackLabel}</button
-				>
+				{#if stepIndex === 0 && $$slots.navigation}
+					<!-- Slot: Navigation -->
+					<div class="step-navigation-slot">
+						<slot name="navigation" />
+					</div>
+				{:else}
+					<!-- Button: Back -->
+					<button type={buttonBackType} class="btn {buttonBack}" on:click={onBack} disabled={$state.current === 0}>
+						{@html buttonBackLabel}
+					</button>
+				{/if}
 				{#if stepIndex < $state.total - 1}
+					<!-- Button: Next -->
 					<button type={buttonNextType} class="btn {buttonNext}" on:click={onNext} disabled={locked}>
 						{#if locked}
 							<svg class="w-3 aspect-square" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
@@ -107,6 +122,7 @@
 						<span>{@html buttonNextLabel}</span>
 					</button>
 				{:else}
+					<!-- Button: Complete -->
 					<button type={buttonCompleteType} class="btn {buttonComplete}" on:click={onComplete} disabled={locked}>
 						{@html buttonCompleteLabel}
 					</button>

--- a/sites/skeleton.dev/src/routes/(inner)/components/steppers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/steppers/+page.svelte
@@ -63,6 +63,7 @@
 						<Step>
 							<svelte:fragment slot="header">Get Started!</svelte:fragment>
 							<p>This example Stepper will teach you how to use this component. Tap <u>next</u> to proceed to the next step.</p>
+							<!-- <svelte:fragment slot="navigation"><button class="btn variant-ghost-error">Abort</button></svelte:fragment> -->
 						</Step>
 						<Step>
 							<svelte:fragment slot="header">Going Back.</svelte:fragment>
@@ -188,6 +189,25 @@
 			<p>
 				This can be overwritten per each Step as well, which updates the <em>default</em> and <em>header</em> slot placeholder text.
 			</p>
+		</section>
+		<!-- Navigation Slot -->
+		<section class="space-y-4">
+			<h2 class="h2">Navigation Slot</h2>
+			<!-- prettier-ignore -->
+			<p>
+				You may override the contents of the disabled Back button in the <u>first step</u> by supplying a <code class="code">navigation</code> slot. Use this to supply a message or implement a custom action. This is not supported for step two and forward.
+			</p>
+			<CodeBlock
+				language="html"
+				code={`
+<Step>
+	<p>(content)</p>
+	<svelte:fragment slot="navigation">
+		<button class="btn variant-ghost-error" on:click={triggerAbort}>Abort</button>
+	</svelte:fragment>
+</Step>
+			`}
+			/>
 		</section>
 	</svelte:fragment>
 </DocsShell>


### PR DESCRIPTION
## Linked Issue

Closes #1476

## Description

Adds support for a `navigation` slot, which replaces the disabled Back button in the first step only.

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
