### PR TITLE
Feat/conic gradient digits prop

### DIFF
--- a/.changeset/few-flowers-train.md
+++ b/.changeset/few-flowers-train.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Added `digits` prop to Conic Gradient

--- a/packages/skeleton/src/lib/components/ConicGradient/ConicGradient.svelte
+++ b/packages/skeleton/src/lib/components/ConicGradient/ConicGradient.svelte
@@ -20,7 +20,7 @@
 	export let width: CssClasses = 'w-24';
 	/** Style the legend hover effect. */
 	export let hover: CssClasses = 'bg-primary-hover-token';
-	/** Set the number of digits on the legend values */
+	/** Set the number of digits on the legend values. */
 	export let digits = 0;
 
 	// Props (regions)

--- a/packages/skeleton/src/lib/components/ConicGradient/ConicGradient.svelte
+++ b/packages/skeleton/src/lib/components/ConicGradient/ConicGradient.svelte
@@ -20,6 +20,8 @@
 	export let width: CssClasses = 'w-24';
 	/** Style the legend hover effect. */
 	export let hover: CssClasses = 'bg-primary-hover-token';
+	/** Set the number of digits on the legend values */
+	export let digits = 0;
 
 	// Props (regions)
 	/** Style the caption region above the gradient. */
@@ -62,7 +64,7 @@
 			return {
 				label: v.label,
 				color: setColorValue(v.color),
-				value: v.end - v.start
+				value: (v.end - v.start).toFixed(digits)
 			};
 		});
 	}


### PR DESCRIPTION
## Linked Issue

Closes #1603  

## Description

Adds `digits` prop to Conic Gradient to set the number of digits on the legend values.

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
