### PR TITLE
chore: AppShell documentation warning that scrolling is not window scoped

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -134,13 +134,6 @@
 				Implement the App Shell in your app's root layout in <code class="code">/src/routes/+layout.svelte</code>. Slot order does not
 				matter.
 			</p>
-			<!-- prettier-ignore -->
-			<aside class="alert alert-message variant-ghost-warning">
-				<p>
-					App Shell does not support window scoped scrolling due to some technical limitations. In order to scroll the content region first needs to be focused a click or mouse over. If you require window scoped scrolling it's recommended that you implement a custom layout instead of using App Shell.
-				</p>
-			</aside>
-			
 		</section>
 		<section class="space-y-4">
 			<div class="flex items-center space-x-2">
@@ -235,6 +228,14 @@ function scrollHandler(event: UIEvent & { currentTarget: EventTarget & HTMLDivEl
 `}
 			/>
 			<CodeBlock language="html" code={`<AppShell ... on:scroll={scrollHandler}>`} />
+		</section>
+		<section class="space-y-4">
+			<h2 class="h2">Accessibility</h2>
+			<p>
+				Please be aware that the App Shell does not support window scoped scrolling. This may affect certain features, such as
+				pull-to-refresh on mobile. In order to scroll the page region you first need to focus the page with either a touch or click. If you
+				require window scoped scrolling we recommend you implement a custom layout in place of the App Shell.
+			</p>
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -134,6 +134,13 @@
 				Implement the App Shell in your app's root layout in <code class="code">/src/routes/+layout.svelte</code>. Slot order does not
 				matter.
 			</p>
+			<!-- prettier-ignore -->
+			<aside class="alert alert-message variant-ghost-warning">
+				<p>
+					App Shell does not support window scoped scrolling due to some technical limitations. In order to scroll the content region first needs to be focused a click or mouse over. If you require window scoped scrolling it's recommended that you implement a custom layout instead of using App Shell.
+				</p>
+			</aside>
+			
 		</section>
 		<section class="space-y-4">
 			<div class="flex items-center space-x-2">


### PR DESCRIPTION
## Description

Add a warning to the AppShell component page to explain that scrolling isn't globally scoped and that the users will need to first focus the content regions before scrolling.

Documentation to address issue #1408 

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
