### PR TITLE
bugfix: fire backdrop event only on backdrop interaction

### DIFF
--- a/.changeset/empty-students-mix.md
+++ b/.changeset/empty-students-mix.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: drawer - fire backdrop event only on backdrop interaction, implemented drawer event on drawer interaction

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -127,12 +127,17 @@
 	}
 
 	// Input Handlers
-	function onBackdropInteraction(event: any): void {
-		if (event.target === elemBackdrop) drawerStore.close();
-		/** @event {{ event }} backdrop - Fires on backdrop interaction.  */
-		dispatch('backdrop', event);
+	function onDrawerInteraction(event: MouseEvent): void {
+		if (event.target === elemBackdrop) {
+			drawerStore.close();
+			/** @event {{ event }} backdrop - Fires on backdrop interaction.  */
+			dispatch('backdrop', event);
+		} else {
+			/** @event {{ event }} drawer - Fires on drawer interaction. */
+			dispatch('drawer', event);
+		}
 	}
-	function onKeydownWindow(event: any): void {
+	function onKeydownWindow(event: KeyboardEvent): void {
 		if (!$drawerStore) return;
 		if (event.code === 'Escape') drawerStore.close();
 	}
@@ -164,8 +169,9 @@
 		bind:this={elemBackdrop}
 		class="drawer-backdrop {classesBackdrop}"
 		data-testid="drawer-backdrop"
-		on:mousedown={onBackdropInteraction}
-		on:touchstart={onBackdropInteraction}
+		on:mousedown={onDrawerInteraction}
+		on:touchstart
+		on:touchend
 		on:keypress
 		transition:fade|local={{ duration }}
 		use:focusTrap={true}


### PR DESCRIPTION
## Linked Issue

Closes #1610

## Description

Changes:
1. `backdrop` event only fires on backdrop interaction (not on drawer interaction).
2. implemented `drawer` event that fires on drawer interaction.
3. changed handle functions param type from `any` to the appropriate event type.
4. forwarded `touchstart` and `touchend`. (backward compatibility).

## Changsets

bugfix: drawer - fire backdrop event only on backdrop interaction, implemented drawer event on drawer interaction

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
