### PR TITLE
Trap focus no longer loses focus when clicking on non-tabbable elements

### DIFF
--- a/.changeset/clean-chicken-deliver.md
+++ b/.changeset/clean-chicken-deliver.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Add a new strict mode feature to the focus trap action

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -1,11 +1,9 @@
 // Action: Focus Trap
 export function focusTrap(node: HTMLElement, enabled: boolean) {
-	const elemWhitelist = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 	let firstFocusableChild: HTMLElement;
 	let lastFocusableChild: HTMLElement;
 
 	function keydownHandler(event: KeyboardEvent) {
-
 		// We do not care for any keys other than tab so we return early, also return if focustrap is disabled
 		// Note: All code after this statement is with 'Tab is pressed' context in mind.
 		if (event.key !== 'Tab' || !enabled) return;
@@ -14,7 +12,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 		if (event.shiftKey && document.activeElement === firstFocusableChild) {
 			event.preventDefault();
 			lastFocusableChild.focus();
-		} 
+		}
 
 		// If the currently active element is the lastFocusableChild, focus the first child
 		else if (!event.shiftKey && document.activeElement === lastFocusableChild) {
@@ -30,18 +28,10 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	}
 	document.addEventListener('keydown', keydownHandler);
 
-	// Get first and last focusable (and therefor tabbable) child from element
-	function getFirstAndLastFocusableChild(element: HTMLElement) {
-		const focusableChilds: HTMLElement[] = Array.from(element.querySelectorAll(elemWhitelist));
-		const first = focusableChilds.at(0);
-		const last = focusableChilds.at(-1);
-		return { first, last };
-	}
-
-	function determineFocusableChilds(fromObserver: boolean)  {
+	function determineFocusableChilds(fromObserver: boolean) {
 		if (!enabled) return;
 		// Gather all focusable elements
-		const focusableElems: HTMLElement[] = Array.from(node.querySelectorAll(elemWhitelist));
+		const focusableElems: HTMLElement[] = Array.from(node.querySelectorAll(focusableElementSelector));
 		if (focusableElems.length) {
 			// Get first and last focusable child from the node
 			const { first, last } = getFirstAndLastFocusableChild(node);
@@ -51,9 +41,8 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			// Auto-focus first focusable element only when not called from observer
 			if (!fromObserver) firstFocusableChild.focus();
 		}
-	};
+	}
 	determineFocusableChilds(false);
-	
 
 	// When children of node are changed (added or removed)
 	const onObservationChange = (mutationRecords: MutationRecord[], observer: MutationObserver) => {
@@ -67,11 +56,21 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	return {
 		update(newArgs: boolean) {
 			enabled = newArgs;
-			if (newArgs) determineFocusableChilds(false)
+			if (newArgs) determineFocusableChilds(false);
 		},
 		destroy() {
 			document.removeEventListener('keydown', keydownHandler);
 			observer.disconnect();
 		}
 	};
+}
+
+const focusableElementSelector = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
+
+// Get first and last focusable (and therefor tabbable) child from element
+function getFirstAndLastFocusableChild(element: HTMLElement) {
+	const focusableChilds: HTMLElement[] = Array.from(element.querySelectorAll(focusableElementSelector));
+	const first = focusableChilds.at(0);
+	const last = focusableChilds.at(-1);
+	return { first, last };
 }

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -64,7 +64,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 const focusableElementSelector = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 
 // Get first and last focusable child from element
-function getFirstAndLastFocusableChild(element: HTMLElement): { first: HTMLElement | undefined, last: HTMLElement | undefined } {
+function getFirstAndLastFocusableChild(element: HTMLElement): { first: HTMLElement | undefined; last: HTMLElement | undefined } {
 	const focusableChilds: HTMLElement[] = Array.from(element.querySelectorAll(focusableElementSelector));
 	const first = focusableChilds.at(0);
 	const last = focusableChilds.at(-1);

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -73,5 +73,7 @@ function getFirstAndLastFocusableChild(element: HTMLElement): { first: HTMLEleme
 
 // Return wether a element has the data-strict-focus attribute
 function isFocusStrict(element: HTMLElement): boolean {
-	return element.dataset.strictFocus !== undefined;
+	const strictFocus = element.dataset.strictFocus;
+	if (strictFocus === '' || strictFocus?.toLocaleLowerCase() === 'true') return true;
+	return false;
 }

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -17,7 +17,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			event.preventDefault();
 			firstFocusableChild.focus();
 		}
-		// If strictFocus is enabled and the activeElement is currently outside our node focus the first child
+		// If strictFocus is enabled and the activeElement is currently outside our node: focus the first child
 		else if (isFocusStrict(node) && !node.contains(document.activeElement)) {
 			event.preventDefault();
 			firstFocusableChild.focus();
@@ -60,11 +60,11 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	};
 }
 
-// Selector to match any focusable (and thus tabbable) elements
+// Selector that matches any focusable (and thus tabbable) elements
 const focusableElementSelector = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 
 // Get first and last focusable child from element
-function getFirstAndLastFocusableChild(element: HTMLElement) {
+function getFirstAndLastFocusableChild(element: HTMLElement): { first: HTMLElement | undefined, last: HTMLElement | undefined } {
 	const focusableChilds: HTMLElement[] = Array.from(element.querySelectorAll(focusableElementSelector));
 	const first = focusableChilds.at(0);
 	const last = focusableChilds.at(-1);

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -17,8 +17,8 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			event.preventDefault();
 			firstFocusableChild.focus();
 		}
-		// If the activeElement is currently outside our node focus the first child
-		else if (!node.contains(document.activeElement)) {
+		// If strictFocus is enabled and the activeElement is currently outside our node focus the first child
+		else if (isFocusStrict(node) && !node.contains(document.activeElement)) {
 			event.preventDefault();
 			firstFocusableChild.focus();
 		}
@@ -69,4 +69,9 @@ function getFirstAndLastFocusableChild(element: HTMLElement) {
 	const first = focusableChilds.at(0);
 	const last = focusableChilds.at(-1);
 	return { first, last };
+}
+
+// Return wether a element has the data-strict-focus attribute
+function isFocusStrict(element: HTMLElement): boolean {
+	return element.dataset.strictFocus !== undefined;
 }

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -4,18 +4,17 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	let firstFocusableChild: HTMLElement;
 	let lastFocusableChild: HTMLElement;
 
-	// Selector that matches any focusable (and thus tabbable) elements
 	const focusableElementSelector = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 
-	// Get first and last focusable child from element
-	function getFirstAndLastFocusableChild(element: HTMLElement): { first: HTMLElement | undefined; last: HTMLElement | undefined } {
+	type FirstAndLastFocusableChildren = { first?: HTMLElement; last?: HTMLElement };
+
+	function getFirstAndLastFocusableChild(element: HTMLElement): FirstAndLastFocusableChildren {
 		const focusableChilds: HTMLElement[] = Array.from(element.querySelectorAll(focusableElementSelector));
 		const first = focusableChilds.at(0);
 		const last = focusableChilds.at(-1);
 		return { first, last };
 	}
 
-	// Return wether an element has the data-focus-strict attribute
 	function isFocusStrict(element: HTMLElement): boolean {
 		const strictFocus = element.dataset.focusStrict;
 		return strictFocus === '' || strictFocus === 'true';

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -15,27 +15,22 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 		return { first, last };
 	}
 
-	// Return wether a element has the data-focus-strict attribute
+	// Return wether an element has the data-focus-strict attribute
 	function isFocusStrict(element: HTMLElement): boolean {
 		const strictFocus = element.dataset.focusStrict;
-		if (strictFocus === '' || strictFocus?.toLocaleLowerCase() === 'true') return true;
-		return false;
+		return strictFocus === '' || strictFocus === 'true';
 	}
 
 	function keydownHandler(event: KeyboardEvent) {
-		// Note: All code after this statement is with 'Tab is pressed' context in mind
 		if (event.key !== 'Tab' || !enabled) return;
-		// If the user holds shift and the currently active element is the firstFocusableChild: focus the last child
 		if (event.shiftKey && document.activeElement === firstFocusableChild) {
 			event.preventDefault();
 			lastFocusableChild.focus();
 		}
-		// If the currently active element is the lastFocusableChild: focus the first child
 		else if (!event.shiftKey && document.activeElement === lastFocusableChild) {
 			event.preventDefault();
 			firstFocusableChild.focus();
 		}
-		// If strictFocus is enabled and the activeElement is currently outside our node: focus the first child
 		else if (isFocusStrict(node) && !node.contains(document.activeElement)) {
 			event.preventDefault();
 			firstFocusableChild.focus();
@@ -43,19 +38,14 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	}
 	function determineFocusableChildren(fromObserver: boolean) {
 		if (!enabled) return;
-		// Get first and last focusable child from the node
 		const { first, last } = getFirstAndLastFocusableChild(node);
-		// If there is not first (and thus last node, we return early)
 		if (!first || !last) return;
-		// Set the new found first and last focusable childs to the variables
 		firstFocusableChild = first;
 		lastFocusableChild = last;
-		// Auto-focus first focusable element only when not called from observer
 		if (!fromObserver) firstFocusableChild.focus();
 	}
 	determineFocusableChildren(false);
 
-	// When children of node are changed (added or removed)
 	const onObservationChange = (mutationRecords: MutationRecord[], observer: MutationObserver) => {
 		if (mutationRecords.length) determineFocusableChildren(true);
 		return observer;

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -1,7 +1,26 @@
 // Action: Focus Trap
+// DEPRECATED: replace the 'enabled: boolean' argument with '{enabled: boolean, strict?: boolean}' in v2.
 export function focusTrap(node: HTMLElement, enabled: boolean) {
 	let firstFocusableChild: HTMLElement;
 	let lastFocusableChild: HTMLElement;
+
+	// Selector that matches any focusable (and thus tabbable) elements
+	const focusableElementSelector = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
+
+	// Get first and last focusable child from element
+	function getFirstAndLastFocusableChild(element: HTMLElement): { first: HTMLElement | undefined; last: HTMLElement | undefined } {
+		const focusableChilds: HTMLElement[] = Array.from(element.querySelectorAll(focusableElementSelector));
+		const first = focusableChilds.at(0);
+		const last = focusableChilds.at(-1);
+		return { first, last };
+	}
+
+	// Return wether a element has the data-focus-strict attribute
+	function isFocusStrict(element: HTMLElement): boolean {
+		const strictFocus = element.dataset.focusStrict;
+		if (strictFocus === '' || strictFocus?.toLocaleLowerCase() === 'true') return true;
+		return false;
+	}
 
 	function keydownHandler(event: KeyboardEvent) {
 		// Note: All code after this statement is with 'Tab is pressed' context in mind
@@ -22,8 +41,6 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			firstFocusableChild.focus();
 		}
 	}
-	document.addEventListener('keydown', keydownHandler);
-
 	function determineFocusableChilds(fromObserver: boolean) {
 		if (!enabled) return;
 		// Get first and last focusable child from the node
@@ -46,6 +63,8 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	const observer = new MutationObserver(onObservationChange);
 	observer.observe(node, { childList: true, subtree: true });
 
+	// Event Listener
+	document.addEventListener('keydown', keydownHandler);
 	// Lifecycle
 	return {
 		update(newArgs: boolean) {
@@ -57,22 +76,4 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			observer.disconnect();
 		}
 	};
-}
-
-// Selector that matches any focusable (and thus tabbable) elements
-const focusableElementSelector = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
-
-// Get first and last focusable child from element
-function getFirstAndLastFocusableChild(element: HTMLElement): { first: HTMLElement | undefined; last: HTMLElement | undefined } {
-	const focusableChilds: HTMLElement[] = Array.from(element.querySelectorAll(focusableElementSelector));
-	const first = focusableChilds.at(0);
-	const last = focusableChilds.at(-1);
-	return { first, last };
-}
-
-// Return wether a element has the data-strict-focus attribute
-function isFocusStrict(element: HTMLElement): boolean {
-	const strictFocus = element.dataset.strictFocus;
-	if (strictFocus === '' || strictFocus?.toLocaleLowerCase() === 'true') return true;
-	return false;
 }

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -7,19 +7,16 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 		// We do not care for any keys other than tab so we return early, also return if focustrap is disabled
 		// Note: All code after this statement is with 'Tab is pressed' context in mind.
 		if (event.key !== 'Tab' || !enabled) return;
-
 		// If the user holds shift and the currently active element is the firstFocusableChild, focus the last child
 		if (event.shiftKey && document.activeElement === firstFocusableChild) {
 			event.preventDefault();
 			lastFocusableChild.focus();
 		}
-
 		// If the currently active element is the lastFocusableChild, focus the first child
 		else if (!event.shiftKey && document.activeElement === lastFocusableChild) {
 			event.preventDefault();
 			firstFocusableChild.focus();
 		}
-
 		// If the activeElement is currently outside our node focus the first child
 		else if (!node.contains(document.activeElement)) {
 			event.preventDefault();
@@ -30,17 +27,16 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 
 	function determineFocusableChilds(fromObserver: boolean) {
 		if (!enabled) return;
-		// Gather all focusable elements
-		const focusableElems: HTMLElement[] = Array.from(node.querySelectorAll(focusableElementSelector));
-		if (focusableElems.length) {
-			// Get first and last focusable child from the node
-			const { first, last } = getFirstAndLastFocusableChild(node);
-			if (!first || !last) return;
-			firstFocusableChild = first;
-			lastFocusableChild = last;
-			// Auto-focus first focusable element only when not called from observer
-			if (!fromObserver) firstFocusableChild.focus();
-		}
+		// Get first and last focusable child from the node
+		const { first, last } = getFirstAndLastFocusableChild(node);
+		// If there is not first (and thus last node, we return early)
+		if (!first || !last) return;
+		// Set the new found first and last focusable childs to the variables
+		firstFocusableChild = first;
+		lastFocusableChild = last;
+		// Auto-focus first focusable element only when not called from observer
+		if (!fromObserver) firstFocusableChild.focus();
+
 	}
 	determineFocusableChilds(false);
 
@@ -65,9 +61,10 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	};
 }
 
+// Selector to match any focusable (and thus tabbable) elements
 const focusableElementSelector = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 
-// Get first and last focusable (and therefor tabbable) child from element
+// Get first and last focusable child from element
 function getFirstAndLastFocusableChild(element: HTMLElement) {
 	const focusableChilds: HTMLElement[] = Array.from(element.querySelectorAll(focusableElementSelector));
 	const first = focusableChilds.at(0);

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -1,4 +1,7 @@
 // Action: Focus Trap
+
+import { hasFocusStrict, registerToStrictlyStack, removeFromStrictlyStack } from './shared.js';
+
 // DEPRECATED: replace the 'enabled: boolean' argument with '{enabled: boolean, strict?: boolean}' in v2.
 export function focusTrap(node: HTMLElement, enabled: boolean) {
 	let firstFocusableChild: HTMLElement;
@@ -50,6 +53,9 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	const observer = new MutationObserver(onObservationChange);
 	observer.observe(node, { childList: true, subtree: true });
 
+	// Register element
+	if (hasFocusStrict(node)) registerToStrictlyStack(node);
+
 	// Event Listener
 	document.addEventListener('keydown', keydownHandler);
 	// Lifecycle
@@ -59,6 +65,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			if (newArgs) determineFocusableChildren(false);
 		},
 		destroy() {
+			if (hasFocusStrict(node)) removeFromStrictlyStack(node);
 			document.removeEventListener('keydown', keydownHandler);
 			observer.disconnect();
 		}

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -4,15 +4,14 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	let lastFocusableChild: HTMLElement;
 
 	function keydownHandler(event: KeyboardEvent) {
-		// We do not care for any keys other than tab so we return early, also return if focustrap is disabled
-		// Note: All code after this statement is with 'Tab is pressed' context in mind.
+		// Note: All code after this statement is with 'Tab is pressed' context in mind
 		if (event.key !== 'Tab' || !enabled) return;
-		// If the user holds shift and the currently active element is the firstFocusableChild, focus the last child
+		// If the user holds shift and the currently active element is the firstFocusableChild: focus the last child
 		if (event.shiftKey && document.activeElement === firstFocusableChild) {
 			event.preventDefault();
 			lastFocusableChild.focus();
 		}
-		// If the currently active element is the lastFocusableChild, focus the first child
+		// If the currently active element is the lastFocusableChild: focus the first child
 		else if (!event.shiftKey && document.activeElement === lastFocusableChild) {
 			event.preventDefault();
 			firstFocusableChild.focus();

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -26,12 +26,10 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 		if (event.shiftKey && document.activeElement === firstFocusableChild) {
 			event.preventDefault();
 			lastFocusableChild.focus();
-		}
-		else if (!event.shiftKey && document.activeElement === lastFocusableChild) {
+		} else if (!event.shiftKey && document.activeElement === lastFocusableChild) {
 			event.preventDefault();
 			firstFocusableChild.focus();
-		}
-		else if (isFocusStrict(node) && !node.contains(document.activeElement)) {
+		} else if (isFocusStrict(node) && !node.contains(document.activeElement)) {
 			event.preventDefault();
 			firstFocusableChild.focus();
 		}

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -41,7 +41,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 			firstFocusableChild.focus();
 		}
 	}
-	function determineFocusableChilds(fromObserver: boolean) {
+	function determineFocusableChildren(fromObserver: boolean) {
 		if (!enabled) return;
 		// Get first and last focusable child from the node
 		const { first, last } = getFirstAndLastFocusableChild(node);
@@ -53,11 +53,11 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 		// Auto-focus first focusable element only when not called from observer
 		if (!fromObserver) firstFocusableChild.focus();
 	}
-	determineFocusableChilds(false);
+	determineFocusableChildren(false);
 
 	// When children of node are changed (added or removed)
 	const onObservationChange = (mutationRecords: MutationRecord[], observer: MutationObserver) => {
-		if (mutationRecords.length) determineFocusableChilds(true);
+		if (mutationRecords.length) determineFocusableChildren(true);
 		return observer;
 	};
 	const observer = new MutationObserver(onObservationChange);
@@ -69,7 +69,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 	return {
 		update(newArgs: boolean) {
 			enabled = newArgs;
-			if (newArgs) determineFocusableChilds(false);
+			if (newArgs) determineFocusableChildren(false);
 		},
 		destroy() {
 			document.removeEventListener('keydown', keydownHandler);

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -36,7 +36,6 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 		lastFocusableChild = last;
 		// Auto-focus first focusable element only when not called from observer
 		if (!fromObserver) firstFocusableChild.focus();
-
 	}
 	determineFocusableChilds(false);
 

--- a/packages/skeleton/src/lib/actions/FocusTrap/shared.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/shared.ts
@@ -1,0 +1,27 @@
+const strictlyElementStack: HTMLElement[] = [];
+
+export function shouldFocusStrictly(element: HTMLElement): boolean {
+	const focusStrict = hasFocusStrict(element);
+	// If the element is focused strictly but not at the top of the stack we return false since we only prioritize elements at the top of the stack
+	if (focusStrict && strictlyElementStack.at(-1) !== element) return false;
+	return focusStrict;
+}
+
+export function registerToStrictlyStack(element: HTMLElement) {
+	// Only allow elements that have the data-focus-strict atrtribute set and don't already exist in the stack
+	if (hasFocusStrict(element) && !strictlyElementStack.includes(element)) strictlyElementStack.push(element);
+}
+
+export function removeFromStrictlyStack(element: HTMLElement) {
+	const index = strictlyElementStack.indexOf(element);
+	if (index > -1) {
+		strictlyElementStack.splice(index, 1);
+	}
+}
+
+// Returns wether a element has the data-focus-strict attribute set to true or false
+export function hasFocusStrict(element: HTMLElement) {
+	const strictFocusAttribute = element.dataset.focusStrict;
+	const focusIsStrict = strictFocusAttribute === '' || strictFocusAttribute === 'true';
+	return focusIsStrict;
+}

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -26,7 +26,7 @@
 	 * */
 	export let value: any;
 	/** Provide a hoverable title attribute for the tile. */
-	export let title: string = '';
+	export let title = '';
 
 	// Props (region)
 	/** Provide arbitrary classes to style the lead region. */

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -175,6 +175,7 @@
 		on:keypress
 		transition:fade|local={{ duration }}
 		use:focusTrap={true}
+		data-strict-focus
 	>
 		<!-- Drawer -->
 		<div

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -175,7 +175,7 @@
 		on:keypress
 		transition:fade|local={{ duration }}
 		use:focusTrap={true}
-		data-strict-focus
+		data-focus-strict
 	>
 		<!-- Drawer -->
 		<div

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -200,6 +200,7 @@
 			on:touchend
 			transition:fade={{ duration }}
 			use:focusTrap={true}
+			data-strict-focus
 		>
 			<!-- Transition Layer -->
 			<div class="modal-transition {classesTransitionLayer}" transition:fly={{ duration, opacity: flyOpacity, x: flyX, y: flyY }}>

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -200,7 +200,7 @@
 			on:touchend
 			transition:fade={{ duration }}
 			use:focusTrap={true}
-			data-strict-focus
+			data-focus-strict
 		>
 			<!-- Transition Layer -->
 			<div class="modal-transition {classesTransitionLayer}" transition:fly={{ duration, opacity: flyOpacity, x: flyX, y: flyY }}>

--- a/sites/skeleton.dev/src/routes/(inner)/actions/focus-trap/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/actions/focus-trap/+page.svelte
@@ -24,7 +24,7 @@
 	<svelte:fragment slot="sandbox">
 		<DocsPreview>
 			<svelte:fragment slot="preview">
-				<form class="w-full card p-4 text-token space-y-4" use:focusTrap={isFocused}>
+				<form class="w-full card p-4 text-token space-y-4" use:focusTrap={isFocused} data-focus-strict>
 					<label class="label">
 						<span>Name</span>
 						<input class="input" type="text" placeholder="Enter name..." />
@@ -73,17 +73,19 @@
 			</p>
 		</section>
 		<section class="space-y-4">
-			<h2 class="h2">Focusing Overlays</h2>
+			<h2 class="h2">Strict Mode</h2>
+			<p>
+				Add the <code class="code">data-focus-strict</code> attribute to the same element the focus trap action is applied to. When enabled,
+				users will not be able to tab outside the target region. This is beneficial for elements that require full focus, such as overlays.
+			</p>
+			<CodeBlock class="w-full" language="html" code={`<div use:focusTrap={true} data-focus-strict>...</div>`} />
+		</section>
+		<section class="space-y-4">
+			<h2 class="h2">Skeleton Overlays</h2>
 			<p>
 				Skeleton automatically enables this action for overlays such as <a class="anchor" href="/utilities/modals">modals</a> and
 				<a class="anchor" href="/utilities/drawers">drawers</a> to aid accessibility.
 			</p>
 		</section>
-		<h2 class="h2">Strict Mode</h2>
-		<!-- prettier-ignore -->
-		<p>
-			Add the <code class="code">data-focus-strict</code> attribute to the same element the focus trap action is applied to. When this is enabled, users will not be able to tab out of the target element. This is beneficial when creating custom overlays or modals. This is applied automatically for you when using Skeleton's drawer and modal features.
-		</p>
-		<CodeBlock class="w-full" language="html" code={`<div use:focusTrap={true} data-focus-strict>...</div>`} />
 	</svelte:fragment>
 </DocsShell>

--- a/sites/skeleton.dev/src/routes/(inner)/actions/focus-trap/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/actions/focus-trap/+page.svelte
@@ -17,6 +17,8 @@
 
 	// Local
 	let isFocused = false;
+	let isStrict = false;
+	$: shouldFocusStrictly = isStrict && isFocused
 </script>
 
 <DocsShell {settings}>
@@ -24,7 +26,7 @@
 	<svelte:fragment slot="sandbox">
 		<DocsPreview>
 			<svelte:fragment slot="preview">
-				<form class="w-full card p-4 text-token space-y-4" use:focusTrap={isFocused} data-focus-strict>
+				<form class="w-full card p-4 text-token space-y-4" use:focusTrap={isFocused} data-focus-strict={isStrict}>
 					<label class="label">
 						<span>Name</span>
 						<input class="input" type="text" placeholder="Enter name..." />
@@ -39,8 +41,9 @@
 				</form>
 			</svelte:fragment>
 			<svelte:fragment slot="footer">
-				<div class="text-center">
+				<div class="flex justify-evenly">
 					<SlideToggle name="trap-focus" bind:checked={isFocused}>Enable Focus Trap</SlideToggle>
+					<SlideToggle disabled={!isFocused} name="trap-focus-strictly" bind:checked={shouldFocusStrictly}>Enable Strict Focus</SlideToggle>
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">

--- a/sites/skeleton.dev/src/routes/(inner)/actions/focus-trap/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/actions/focus-trap/+page.svelte
@@ -79,5 +79,11 @@
 				<a class="anchor" href="/utilities/drawers">drawers</a> to aid accessibility.
 			</p>
 		</section>
+		<h2 class="h2">Strict Mode</h2>
+		<!-- prettier-ignore -->
+		<p>
+			Add the <code class="code">data-focus-strict</code> attribute to the same element the focus trap action is applied to. When this is enabled, users will not be able to tab out of the target element. This is beneficial when creating custom overlays or modals. This is applied automatically for you when using Skeleton's drawer and modal features.
+		</p>
+		<CodeBlock class="w-full" language="html" code={`<div use:focusTrap={true} data-focus-strict>...</div>`} />
 	</svelte:fragment>
 </DocsShell>

--- a/sites/skeleton.dev/src/routes/(inner)/actions/focus-trap/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/actions/focus-trap/+page.svelte
@@ -18,7 +18,7 @@
 	// Local
 	let isFocused = false;
 	let isStrict = false;
-	$: shouldFocusStrictly = isStrict && isFocused
+	$: shouldFocusStrictly = isStrict && isFocused;
 </script>
 
 <DocsShell {settings}>


### PR DESCRIPTION
## Linked Issue

Fixed #1613

## Description

Instead of adding event listeners to each child, I added 1 keydown listener to the dom, this prevents adding and removing listeners every time the targeted node has changes (observed by the MutationObserver). The main reason I did this is to add 1 more check after ``Shift + Tab`` and ``Tab`` have been checked: Now when both tab scenario's were falsy focusTrap will do 1 additional check to check wether the currently active element is not inside the targeted node, if not it will focus the first child inside the targeted node again. This utilizes ``document.activeElement`` which will return the current active element (like the name suggests). This way when a user clicks on an element that is not tabbable and hits tab after, it will first check if that element is part of our focusableChilds list, if not it will prevent the user from tabbing (``e.preventDefault()``) and instead focus the firstFocusableChild (determined by the MutationObserver).

Edit (Important note):
After discussing with @endigo9740 and @Mahmoud-zino we've decided to make the behaviour I implemented optional by user, this ensures modals can be focused without escape and forms can be escaped if the users wishes to. Because that would introduce a breaking change we've decided to, for the time being, allow a ``data-focus-strict`` attribute to be set on the node focus trap is applied to, it will look like:
```html
<div use:focusTrap={true} data-focus-strict>
```
The focus trap action will respect this prop and focus strictly (no escape) if the attribute is set. This will be removed when Skeleton Version 2 hits and instead will be part of a parameter passed on to the focusTrap action. So it will convert from:
```ts
export function focusTrap(node: HTMLElement, enabled: boolean);
```
to:
```ts
export function focusTrap(node: HTMLElement, {enabled: boolean, strict?: boolean});
```
Read the discussion: https://discord.com/channels/1003691521280856084/1003699523522142399/1113897699687796848

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
