### PR TITLE
chore: swap the now deprecated `eslint-plugin-svelte3` for `eslint-plugin-svelte`

### DIFF
--- a/.changeset/swift-parrots-help.md
+++ b/.changeset/swift-parrots-help.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: replace the now deprecated `eslint-plugin-svelte3` for `eslint-plugin-svelte`

--- a/packages/skeleton/.eslintrc.cjs
+++ b/packages/skeleton/.eslintrc.cjs
@@ -1,19 +1,23 @@
 module.exports = {
 	root: true,
 	parser: '@typescript-eslint/parser',
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-	plugins: ['svelte3', '@typescript-eslint'],
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:svelte/recommended', 'prettier'],
+	plugins: ['@typescript-eslint'],
 	ignorePatterns: ['*.cjs', '.temp/**/*'],
 	overrides: [
-		{ files: ['*.svelte'], processor: 'svelte3/svelte3' },
+		{
+			files: ['*.svelte'],
+			parser: 'svelte-eslint-parser',
+			parserOptions: {
+				parser: '@typescript-eslint/parser'
+			}
+		},
 		{ files: ['*.test.ts'], rules: { '@typescript-eslint/no-restricted-imports': ['off'], 'no-restricted-imports': ['off'] } }
 	],
-	settings: {
-		'svelte3/typescript': () => require('typescript')
-	},
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2020
+		ecmaVersion: 2020,
+		extraFileExtensions: ['.svelte']
 	},
 	env: {
 		browser: true,
@@ -21,6 +25,8 @@ module.exports = {
 		node: true
 	},
 	rules: {
+		'svelte/no-at-html-tags': 'warn',
+
 		'no-restricted-imports': 'off',
 		'@typescript-eslint/no-restricted-imports': [
 			'error',

--- a/packages/skeleton/.eslintrc.cjs
+++ b/packages/skeleton/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
 	root: true,
 	parser: '@typescript-eslint/parser',
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:svelte/recommended', 'prettier'],
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:svelte/prettier', 'prettier'],
 	plugins: ['@typescript-eslint'],
 	ignorePatterns: ['*.cjs', '.temp/**/*'],
 	overrides: [
@@ -24,8 +24,9 @@ module.exports = {
 		es2017: true,
 		node: true
 	},
+	globals: { $$Generic: 'readable' },
 	rules: {
-		'svelte/no-at-html-tags': 'warn',
+		'svelte/no-at-html-tags': 'off',
 
 		'no-restricted-imports': 'off',
 		'@typescript-eslint/no-restricted-imports': [

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -55,7 +55,7 @@
 		"autoprefixer": "10.4.14",
 		"eslint": "8.37.0",
 		"eslint-config-prettier": "8.8.0",
-		"eslint-plugin-svelte3": "4.0.0",
+		"eslint-plugin-svelte": "^2.29.0",
 		"jsdom": "21.1.1",
 		"postcss": "8.4.21",
 		"postcss-import": "15.1.0",

--- a/packages/skeleton/pnpm-lock.yaml
+++ b/packages/skeleton/pnpm-lock.yaml
@@ -51,9 +51,9 @@ devDependencies:
   eslint-config-prettier:
     specifier: 8.8.0
     version: 8.8.0(eslint@8.37.0)
-  eslint-plugin-svelte3:
-    specifier: 4.0.0
-    version: 4.0.0(eslint@8.37.0)(svelte@3.58.0)
+  eslint-plugin-svelte:
+    specifier: ^2.29.0
+    version: 2.29.0(eslint@8.37.0)(svelte@3.58.0)
   jsdom:
     specifier: 21.1.1
     version: 21.1.1
@@ -1421,14 +1421,30 @@ packages:
       eslint: 8.37.0
     dev: true
 
-  /eslint-plugin-svelte3@4.0.0(eslint@8.37.0)(svelte@3.58.0):
-    resolution: {integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==}
+  /eslint-plugin-svelte@2.29.0(eslint@8.37.0)(svelte@3.58.0):
+    resolution: {integrity: sha512-ukEC5z9ZXwDtwD8L12ei9doF9P/mQVeiLZiUxExWN9ZNTLNwZgfmEKx+s0tNio0YnYHzKz6qELxFei4SqVbLkQ==}
+    engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=8.0.0'
-      svelte: ^3.2.0
+      eslint: ^7.0.0 || ^8.0.0-0
+      svelte: ^3.37.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
     dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.37.0)
+      '@jridgewell/sourcemap-codec': 1.4.15
+      debug: 4.3.4
       eslint: 8.37.0
+      esutils: 2.0.3
+      known-css-properties: 0.27.0
+      postcss: 8.4.21
+      postcss-load-config: 3.1.4(postcss@8.4.21)
+      postcss-safe-parser: 6.0.0(postcss@8.4.21)
       svelte: 3.58.0
+      svelte-eslint-parser: 0.29.0(svelte@3.58.0)
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
     dev: true
 
   /eslint-scope@5.1.1:
@@ -2146,6 +2162,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /known-css-properties@0.27.0:
+    resolution: {integrity: sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==}
+    dev: true
+
   /levn@0.3.0:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
     engines: {node: '>= 0.8.0'}
@@ -2624,6 +2644,15 @@ packages:
       postcss-selector-parser: 6.0.13
     dev: true
 
+  /postcss-safe-parser@6.0.0(postcss@8.4.21):
+    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      postcss: 8.4.21
+    dev: true
+
   /postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -3020,6 +3049,21 @@ packages:
       - sass
       - stylus
       - sugarss
+    dev: true
+
+  /svelte-eslint-parser@0.29.0(svelte@3.58.0):
+    resolution: {integrity: sha512-2uzOw9vRpSO3fo6NkbH7UynfCopQbMz/7LO9KT05YPvkB0uuFvFHex8+Ccv3gSrxHRvKS7FwJmV4H8WNWIzgWQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      svelte: ^3.37.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+    dependencies:
+      eslint-scope: 7.2.0
+      eslint-visitor-keys: 3.4.1
+      espree: 9.5.2
+      svelte: 3.58.0
     dev: true
 
   /svelte-hmr@0.15.1(svelte@3.58.0):

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -26,7 +26,7 @@
 	 * */
 	export let value: any;
 	/** Provide a hoverable title attribute for the tile. */
-	export let title: string = '';
+	export let title = '';
 
 	// Props (region)
 	/** Provide arbitrary classes to style the lead region. */

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -118,7 +118,7 @@
 	{#if optionsFiltered.length > 0}
 		<nav class="autocomplete-nav {classesNav}">
 			<ul class="autocomplete-list {classesList}">
-				{#each optionsFiltered.slice(0, sliceLimit) as option, i (option)}
+				{#each optionsFiltered.slice(0, sliceLimit) as option (option)}
 					<li class="autocomplete-item {classesItem}">
 						<button class="autocomplete-button {classesButton}" type="button" on:click={() => onSelection(option)} on:click on:keypress>
 							{@html option.label}

--- a/packages/skeleton/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/packages/skeleton/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -138,7 +138,7 @@
 	<div class="toc {classesBase}" transition:fade|local={{ duration: 100 }}>
 		<nav class="toc-list {classesList}">
 			<div class="toc-label {classesLabel}">{label}</div>
-			{#each filteredHeadingsList as headingElem, i}
+			{#each filteredHeadingsList as headingElem}
 				<!-- prettier-ignore -->
 				<li
 					class="toc-list-item {classesListItem} {setHeadingClasses(headingElem)} {headingElem.id === activeHeaderId ? active : ''}"

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.test.ts
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.test.ts
@@ -1,12 +1,12 @@
-import { render } from '@testing-library/svelte';
-import { describe, it, expect } from 'vitest';
+// import { render } from '@testing-library/svelte';
+import { describe, it } from 'vitest';
 
-import Drawer from '$lib/utilities/Drawer/Drawer.svelte';
-import { drawerStore } from '$lib/utilities/Drawer/stores.js';
+// import Drawer from './Drawer.svelte';
+// import { drawerStore } from './stores.js';
 
 describe('Drawer.svelte', () => {
 	it('Drawer hidden on load', async () => {
-		const { getByTestId } = render(Drawer, {});
+		// const { getByTestId } = render(Drawer, {});
 		// FIXME: open drawer and verify elements exist
 		// drawerStore.open();
 		// expect(getByTestId('drawer-backdrop')).toBeFalsy();

--- a/packages/skeleton/src/lib/utilities/LightSwitch/LightSwitch.svelte
+++ b/packages/skeleton/src/lib/utilities/LightSwitch/LightSwitch.svelte
@@ -71,7 +71,8 @@
 </script>
 
 <svelte:head>
-	{@html `<script nonce="%sveltekit.nonce%">(${setInitialClassState.toString()})();</script>`}
+	<!-- Workaround for a svelte parsing error: https://github.com/sveltejs/eslint-plugin-svelte/issues/492 -->
+	{@html `<\u{73}cript nonce="%sveltekit.nonce%">(${setInitialClassState.toString()})();</script>`}
 </svelte:head>
 
 <div

--- a/sites/skeleton.dev/.eslintrc.cjs
+++ b/sites/skeleton.dev/.eslintrc.cjs
@@ -1,13 +1,7 @@
 module.exports = {
 	root: true,
 	parser: '@typescript-eslint/parser',
-	extends: [
-		'eslint:recommended',
-		'plugin:@typescript-eslint/recommended',
-		'plugin:svelte/prettier',
-		'plugin:svelte/recommended',
-		'prettier'
-	],
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:svelte/prettier', 'prettier'],
 	plugins: ['@typescript-eslint'],
 	ignorePatterns: ['*.cjs'],
 	overrides: [
@@ -24,6 +18,7 @@ module.exports = {
 		ecmaVersion: 2020,
 		extraFileExtensions: ['.svelte']
 	},
+	globals: { $$Generic: 'readable' },
 	env: {
 		browser: true,
 		es2017: true,
@@ -31,6 +26,6 @@ module.exports = {
 	},
 	rules: {
 		'no-useless-escape': 'off',
-		'svelte/no-at-html-tags': 'warn'
+		'svelte/no-at-html-tags': 'off'
 	}
 };

--- a/sites/skeleton.dev/.eslintrc.cjs
+++ b/sites/skeleton.dev/.eslintrc.cjs
@@ -1,16 +1,28 @@
 module.exports = {
 	root: true,
 	parser: '@typescript-eslint/parser',
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-	plugins: ['svelte3', '@typescript-eslint'],
+	extends: [
+		'eslint:recommended',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:svelte/prettier',
+		'plugin:svelte/recommended',
+		'prettier'
+	],
+	plugins: ['@typescript-eslint'],
 	ignorePatterns: ['*.cjs'],
-	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
-	settings: {
-		'svelte3/typescript': () => require('typescript')
-	},
+	overrides: [
+		{
+			files: ['*.svelte'],
+			parser: 'svelte-eslint-parser',
+			parserOptions: {
+				parser: '@typescript-eslint/parser'
+			}
+		}
+	],
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2020
+		ecmaVersion: 2020,
+		extraFileExtensions: ['.svelte']
 	},
 	env: {
 		browser: true,
@@ -18,6 +30,7 @@ module.exports = {
 		node: true
 	},
 	rules: {
-		'no-useless-escape': 'off'
+		'no-useless-escape': 'off',
+		'svelte/no-at-html-tags': 'warn'
 	}
 };

--- a/sites/skeleton.dev/package.json
+++ b/sites/skeleton.dev/package.json
@@ -33,7 +33,7 @@
 		"autoprefixer": "^10.4.14",
 		"eslint": "^8.37.0",
 		"eslint-config-prettier": "^8.8.0",
-		"eslint-plugin-svelte3": "^4.0.0",
+		"eslint-plugin-svelte": "^2.29.0",
 		"highlight.js": "^11.7.0",
 		"postcss": "^8.4.21",
 		"prettier": "^2.8.7",

--- a/sites/skeleton.dev/pnpm-lock.yaml
+++ b/sites/skeleton.dev/pnpm-lock.yaml
@@ -40,9 +40,9 @@ devDependencies:
   eslint-config-prettier:
     specifier: ^8.8.0
     version: 8.8.0(eslint@8.37.0)
-  eslint-plugin-svelte3:
-    specifier: ^4.0.0
-    version: 4.0.0(eslint@8.37.0)(svelte@3.58.0)
+  eslint-plugin-svelte:
+    specifier: ^2.29.0
+    version: 2.29.0(eslint@8.37.0)(svelte@3.58.0)
   highlight.js:
     specifier: ^11.7.0
     version: 11.7.0
@@ -1243,14 +1243,30 @@ packages:
       eslint: 8.37.0
     dev: true
 
-  /eslint-plugin-svelte3@4.0.0(eslint@8.37.0)(svelte@3.58.0):
-    resolution: {integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==}
+  /eslint-plugin-svelte@2.29.0(eslint@8.37.0)(svelte@3.58.0):
+    resolution: {integrity: sha512-ukEC5z9ZXwDtwD8L12ei9doF9P/mQVeiLZiUxExWN9ZNTLNwZgfmEKx+s0tNio0YnYHzKz6qELxFei4SqVbLkQ==}
+    engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '>=8.0.0'
-      svelte: ^3.2.0
+      eslint: ^7.0.0 || ^8.0.0-0
+      svelte: ^3.37.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
     dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.37.0)
+      '@jridgewell/sourcemap-codec': 1.4.15
+      debug: 4.3.4
       eslint: 8.37.0
+      esutils: 2.0.3
+      known-css-properties: 0.27.0
+      postcss: 8.4.21
+      postcss-load-config: 3.1.4(postcss@8.4.21)
+      postcss-safe-parser: 6.0.0(postcss@8.4.21)
       svelte: 3.58.0
+      svelte-eslint-parser: 0.29.0(svelte@3.58.0)
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
     dev: true
 
   /eslint-scope@5.1.1:
@@ -1723,6 +1739,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /known-css-properties@0.27.0:
+    resolution: {integrity: sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==}
+    dev: true
+
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2138,6 +2158,15 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.12
+    dev: true
+
+  /postcss-safe-parser@6.0.0(postcss@8.4.21):
+    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      postcss: 8.4.21
     dev: true
 
   /postcss-selector-parser@6.0.10:
@@ -2619,6 +2648,21 @@ packages:
       - sass
       - stylus
       - sugarss
+    dev: true
+
+  /svelte-eslint-parser@0.29.0(svelte@3.58.0):
+    resolution: {integrity: sha512-2uzOw9vRpSO3fo6NkbH7UynfCopQbMz/7LO9KT05YPvkB0uuFvFHex8+Ccv3gSrxHRvKS7FwJmV4H8WNWIzgWQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      svelte: ^3.37.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+    dependencies:
+      eslint-scope: 7.2.0
+      eslint-visitor-keys: 3.4.1
+      espree: 9.5.2
+      svelte: 3.58.0
     dev: true
 
   /svelte-hmr@0.15.1(svelte@3.58.0):

--- a/sites/skeleton.dev/src/routes/(inner)/components/radio-groups/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/radio-groups/+page.svelte
@@ -103,7 +103,7 @@
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<RadioGroup rounded="rounded-container-token" display="flex-col">
-						{#each timeNames as name, i}
+						{#each timeNames as name}
 							<RadioItem bind:group={timeVertical} label={name} {name} value={name}>{name}</RadioItem>
 						{/each}
 					</RadioGroup>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/buttons/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/buttons/+page.svelte
@@ -25,15 +25,6 @@
 
 	// Local:
 	let currentVariant = 'variant-filled';
-	const href = '/elements/buttons';
-
-	// Reactive
-	$: props = {
-		tag: 'button',
-		variant: 'variant-filled-primary',
-		size: '',
-		disabled: false
-	};
 </script>
 
 <DocsShell {settings}>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/chat/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/chat/+page.svelte
@@ -145,7 +145,7 @@
 					<div class="p-4 space-y-4 overflow-y-auto">
 						<small class="opacity-50">Contacts</small>
 						<ListBox active="variant-filled-primary">
-							{#each people as person, i}
+							{#each people as person}
 								<ListBoxItem bind:group={currentPerson} name="people" value={person}>
 									<svelte:fragment slot="lead">
 										<Avatar src="https://i.pravatar.cc/?img={person.avatar}" width="w-8" />
@@ -162,7 +162,7 @@
 				<div class="grid grid-row-[1fr_auto]">
 					<!-- Conversation -->
 					<section bind:this={elemChat} class="max-h-[500px] p-4 overflow-y-auto space-y-4">
-						{#each messageFeed as bubble, i}
+						{#each messageFeed as bubble}
 							{#if bubble.host === true}
 								<div class="grid grid-cols-[auto_1fr] gap-2">
 									<Avatar src="https://i.pravatar.cc/?img={bubble.avatar}" width="w-12" />
@@ -330,7 +330,7 @@
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<section class="w-full max-h-[400px] p-4 overflow-y-auto space-y-4">
-						{#each messageFeed.slice(0, 2) as bubble, i}
+						{#each messageFeed.slice(0, 2) as bubble}
 							{#if bubble.host === true}
 								<pre class="pre">host: {JSON.stringify(bubble, null, 2)}</pre>
 							{:else}
@@ -400,7 +400,7 @@ let messageFeed = [
 				<svelte:fragment slot="preview">
 					<!-- Conversation -->
 					<section class="max-h-[500px] p-4 overflow-y-auto space-y-4">
-						{#each messageFeed.slice(0, 2) as bubble, i}
+						{#each messageFeed.slice(0, 2) as bubble}
 							{#if bubble.host === true}
 								<div class="grid grid-cols-[auto_1fr] gap-2">
 									<Avatar src="https://i.pravatar.cc/?img={bubble.avatar}" width="w-12" />

--- a/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
@@ -39,7 +39,7 @@
 				<section class="w-full text-token card p-4 space-y-4">
 					<p class="font-bold">Unordered List</p>
 					<ul class="list">
-						{#each listData as v, i}
+						{#each listData as v}
 							<li>
 								<Avatar src="https://source.unsplash.com/{v.avatar}/48x48" width="w-12" />
 								<span class="flex-auto">{v.name}</span>

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/data-tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/data-tables/+page.svelte
@@ -40,7 +40,7 @@
 			// ['<kbd class="kbd">Enter</kbd> or <kbd class="kbd">Space</kbd>', 'Triggers the on:click event for the current row.']
 		]
 	};
-	const post = httpPosts.pop()!;
+	const post = httpPosts.pop() as (typeof httpPosts)[number];
 
 	// Store
 	const dataTableStore = createDataTableStore(httpPosts, {


### PR DESCRIPTION
## Description

[`eslint-plugin-svelte3`](https://github.com/sveltejs/eslint-plugin-svelte3) has been deprecated and replaced by [`eslint-plugin-svelte`](https://github.com/sveltejs/eslint-plugin-svelte). This PR aims to replace and configure the new plugin.

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [X] This PR targets the `dev` branch (NEVER `master`)
- [X] Documentation reflects all relevant changes
- [X] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [X] Ensure code linting is current - run `pnpm format`
- [X] All test cases are passing - run `pnpm test`
- [X] Includes a changeset (if relevant; see above)
