### PR TITLE
Fixed typo on the themes page

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -100,7 +100,7 @@ body {
 		`}
 		/>
 		<p>
-			Likewise, if you wish to implement a custom the font family for a preset theme, you can modify the <em>base</em> and
+			Likewise, if you wish to implement a custom font family for a preset theme, you can modify the <em>base</em> and
 			<em>heading</em>
 			properties as shown below.
 		</p>


### PR DESCRIPTION
## Linked Issue

Closes #1620

## Description

Fixed a minor typo on the themes page related to font family overrides.

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
