### PR TITLE
Updated GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,15 +8,16 @@ Closes #{issueNumber}
 
 ## Changsets
 
-Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.
+Instructions: Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset` in the monorepo root, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.
 
 ## Checklist
 
-Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).
+Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).
 
 - [ ] This PR targets the `dev` branch (NEVER `master`)
 - [ ] Documentation reflects all relevant changes
 - [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
-- [ ] Ensure code linting is current - run `pnpm format`
+- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
+- [ ] Ensure Prettier linting is current - run `pnpm format`
 - [ ] All test cases are passing - run `pnpm test`
 - [ ] Includes a changeset (if relevant; see above)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Closes #{issueNumber}
 
 ## Changsets
 
-Instructions: Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset` in the monorepo root, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.
+Instructions: Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.
 
 ## Checklist
 


### PR DESCRIPTION
## Linked Issue

Closes #1622

## Description

Various improvements to THIS PR message template.

## Changsets

Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset`, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing/style-guide#feature-branches).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure code linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
