### PR TITLE
Chore/slide toggle bg prop

### DIFF
--- a/.changeset/nervous-cheetahs-smile.md
+++ b/.changeset/nervous-cheetahs-smile.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: added a `background` prop to the slide toggle component

--- a/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
+++ b/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
@@ -21,7 +21,9 @@
 	 * @type {'sm' | 'md' | 'lg'}
 	 */
 	export let size = 'md';
-	/** Provide classes to set the checked state color. */
+	/** Provide classe to set the inactive state background color. */
+	export let background: CssClasses = 'bg-surface-400 dark:bg-surface-700';
+	/** Provide classes to set the active state background color. */
 	export let active: CssClasses = 'bg-surface-900 dark:bg-surface-300';
 	/** Provide classes to set the border styles. */
 	export let border: CssClasses = '';
@@ -59,7 +61,7 @@
 	}
 
 	// Interactive
-	$: cTrackActive = checked ? active : 'bg-surface-400 dark:bg-surface-700 cursor-pointer';
+	$: cTrackActive = checked ? active : `${background} cursor-pointer`;
 	$: cThumbBackground = checked ? 'bg-white/75' : 'bg-white';
 	$: cThumbPos = checked ? 'translate-x-full' : '';
 


### PR DESCRIPTION
## Linked Issue

Closes #1626

## Description

Adds a `background` prop to the slide toggle component.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
