### PR TITLE
bugfix: checking listBoxItem value equality deeply instead of by reference

### DIFF
--- a/.changeset/slimy-knives-tie.md
+++ b/.changeset/slimy-knives-tie.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: checking listBoxItem value equality deeply instead of by reference.

--- a/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
@@ -33,6 +33,27 @@
 	let checked: boolean;
 	let elemInput: HTMLElement;
 
+	// Functionality
+	function areDeeplyEqual(param1: unknown, param2: unknown) {
+		// check strict equality
+		if (param1 === param2) return true;
+		// check if props are not objects
+		if (!(param1 instanceof Object) || !(param2 instanceof Object)) return false;
+
+		// object keys
+		const keys1 = Object.keys(param1);
+		const keys2 = Object.keys(param2);
+		// check if number of keys are the same
+		if (keys1.length !== keys2.length) return false;
+		// Iterate over the keys and compare the values recursively
+		for (const key of keys1) {
+			const value1 = (param1 as Record<string, unknown>)[key];
+			const value2 = (param2 as Record<string, unknown>)[key];
+			if (!areDeeplyEqual(value1, value2)) return false;
+		}
+		return true;
+	}
+
 	// Svelte Checkbox Bugfix
 	// GitHub: https://github.com/sveltejs/svelte/issues/2308
 	// REPL: https://svelte.dev/repl/de117399559f4e7e9e14e2fc9ab243cc?version=3.12.1
@@ -65,7 +86,7 @@
 	}
 
 	// Reactive
-	$: selected = multiple ? group.includes(value) : group === value;
+	$: selected = multiple ? group.some((groupVal: unknown) => areDeeplyEqual(value, groupVal)) : areDeeplyEqual(group, value);
 	$: classesActive = selected ? active : hover;
 	$: classesBase = `${cBase} ${rounded} ${padding} ${classesActive} ${$$props.class ?? ''}`;
 	$: classesLabel = `${cLabel}`;


### PR DESCRIPTION
## Linked Issue

Closes #1485 

## Description

Checking the value of listBoxItem deeply will also work if the value is received from another source (different object reference).

I made sure this works with primitive types and with multiple options.

## Changsets

bugfix: checking listBoxItem value equality deeply instead of by reference.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
