### PR TITLE
chore: cleanup changesets

### DIFF
--- a/.changeset/big-maps-smell.md
+++ b/.changeset/big-maps-smell.md
@@ -1,6 +1,5 @@
 ---
-"skeleton.dev": patch
 "@skeletonlabs/skeleton": patch
 ---
 
-Add typing to the Stepper store, dispatchParent, and docs page.
+chore: Added types to the `Stepper` store and `dispatchParent`

--- a/.changeset/big-paws-melt.md
+++ b/.changeset/big-paws-melt.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: Updated `focusablePopupElements` in Popup to allow tabbing into changed lists in Autocomplete
+bugfix: Updated `focusablePopupElements` in Popup to resolve issues when tabbing into Autocomplete options

--- a/.changeset/big-paws-melt.md
+++ b/.changeset/big-paws-melt.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: updated focusablePopupElements onWindowKeyDown in popup to allow tabbing into changed lists in Autocomplete
+bugfix: Updated `focusablePopupElements` in Popup to allow tabbing into changed lists in Autocomplete

--- a/.changeset/empty-apricots-judge.md
+++ b/.changeset/empty-apricots-judge.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Added numeric rows to Paginator
+feat: The Paginator component can now be displayed as a numeric row of pages

--- a/.changeset/empty-apricots-judge.md
+++ b/.changeset/empty-apricots-judge.md
@@ -1,6 +1,5 @@
 ---
-"skeleton.dev": minor
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: added pagination-control Numeric row
+feat: Added numeric rows to Paginator

--- a/.changeset/empty-students-mix.md
+++ b/.changeset/empty-students-mix.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: Fire Drawer's `backdrop` event only on backdrop interaction
+bugfix: The Drawer's `backdrop` event only fires on backdrop interaction

--- a/.changeset/empty-students-mix.md
+++ b/.changeset/empty-students-mix.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: drawer - fire backdrop event only on backdrop interaction, implemented drawer event on drawer interaction
+bugfix: Fire Drawer's `backdrop` event only on backdrop interaction

--- a/.changeset/famous-pears-jam.md
+++ b/.changeset/famous-pears-jam.md
@@ -1,5 +1,5 @@
 ---
-"@skeletonlabs/skeleton": patch
+"@skeletonlabs/skeleton": minor
 ---
 
-chore: Provide more forwarded events for the App Rail Tile and Anchor
+feat: Added more forwarded events for AppRailTile and AppRailAnchor

--- a/.changeset/famous-pears-jam.md
+++ b/.changeset/famous-pears-jam.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Added more forwarded events for AppRailTile and AppRailAnchor
+feat: Added additional forwarded events for AppRailTile and AppRailAnchor

--- a/.changeset/few-flowers-train.md
+++ b/.changeset/few-flowers-train.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Added `digits` prop to Conic Gradient
+feat: Added `digits` prop to Conic Gradient to limit decimal points

--- a/.changeset/fluffy-gorillas-sneeze.md
+++ b/.changeset/fluffy-gorillas-sneeze.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: `typography-prose.css` is now required to be imported directly
+bugfix: `typography-prose.css` must now be imported directly to enable the default Tailwind Typography plugin styles

--- a/.changeset/fluffy-gorillas-sneeze.md
+++ b/.changeset/fluffy-gorillas-sneeze.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: The `typography-prose.css` stylesheet must now be imported directly. 
+bugfix: `typography-prose.css` is now required to be imported directly

--- a/.changeset/funny-plants-burn.md
+++ b/.changeset/funny-plants-burn.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-docs: Updated autocomplete documentation to demonstrate Firefox tab navigation fix for wrapping elements
+docs: Updated Autocomplete documentation to demonstrate Firefox tab navigation fix for wrapping elements

--- a/.changeset/hip-dancers-march.md
+++ b/.changeset/hip-dancers-march.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-Fix Toast jiggle when last toast remain
+bugfix: Fixed Toast jiggle animation on the last

--- a/.changeset/hip-dancers-march.md
+++ b/.changeset/hip-dancers-march.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: Fixed Toast's jiggle animation
+bugfix: Fixed an undesired jiggle within the animation for Toasts

--- a/.changeset/hip-dancers-march.md
+++ b/.changeset/hip-dancers-march.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: Fixed Toast jiggle animation on the last
+bugfix: Fixed Toast's jiggle animation

--- a/.changeset/itchy-mice-judge.md
+++ b/.changeset/itchy-mice-judge.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Added a navigation slot to the Step component, replacing the Back button for the first step only
+feat: Added a navigation slot to the Step component, which can replace the Back button for the first step only

--- a/.changeset/itchy-mice-judge.md
+++ b/.changeset/itchy-mice-judge.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Added a navigation slot to the Step component, this replaces the Back button for the first step only
+feat: Added a navigation slot to the Step component, replacing the Back button for the first step only

--- a/.changeset/nasty-deers-draw.md
+++ b/.changeset/nasty-deers-draw.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: modal backdrop interaction - register interaction on mousedown and close modal on mouseup
+feat: Modals now close on `mouseup` on backdrop clicks

--- a/.changeset/nasty-deers-draw.md
+++ b/.changeset/nasty-deers-draw.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Modals now close on `mouseup` on backdrop clicks
+feat: Modal backdrop clicks now take into account both the `mouseup` and `mousedown` events for better accuracy

--- a/.changeset/nervous-cheetahs-smile.md
+++ b/.changeset/nervous-cheetahs-smile.md
@@ -1,5 +1,5 @@
 ---
-"@skeletonlabs/skeleton": patch
+"@skeletonlabs/skeleton": minor
 ---
 
-chore: added a `background` prop to the slide toggle component
+feat: Added a `background` prop to the SlideToggle component

--- a/.changeset/ninety-eagles-yawn.md
+++ b/.changeset/ninety-eagles-yawn.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-Add additional safeguard to scrollToHeading
+chore: Added additional type safeguard to `scrollToHeading`

--- a/.changeset/ninety-eagles-yawn.md
+++ b/.changeset/ninety-eagles-yawn.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-chore: Added additional type safeguard to `scrollToHeading`
+chore: Added additional type safeguard to the Table of Contents `scrollToHeading`

--- a/.changeset/odd-countries-admire.md
+++ b/.changeset/odd-countries-admire.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: Replaced unicode arrows with template SVGs for the Paginator component
+bugfix: Replaced unicode arrows with SVGs for the Paginator component

--- a/.changeset/odd-countries-admire.md
+++ b/.changeset/odd-countries-admire.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: replaced unicode arrows with template SVGs in paginator
+bugfix: Replaced unicode arrows with template SVGs for the Paginator component

--- a/.changeset/pink-vans-rule.md
+++ b/.changeset/pink-vans-rule.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: added `.js` extension to all relative imports
+bugfix: All relative import paths now fully specify the `.js` extension to adhere to Node's ESM algorithm

--- a/.changeset/purple-mice-fly.md
+++ b/.changeset/purple-mice-fly.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-Added missing .dark .bg-variant-hover-token
+feat: Added missing `.dark .bg-variant-hover-token`

--- a/.changeset/purple-mice-fly.md
+++ b/.changeset/purple-mice-fly.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Added a missing dark mode modifier for each background hover design token.
+feat: Added a missing dark mode modifier for each background hover design token

--- a/.changeset/purple-mice-fly.md
+++ b/.changeset/purple-mice-fly.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Added missing `.dark .bg-variant-hover-token`
+feat: Added a missing dark mode modifier for each background hover design token.

--- a/.changeset/slimy-knives-tie.md
+++ b/.changeset/slimy-knives-tie.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: ListBoxItem is now compared by value rather than by reference
+bugfix: ListBoxItem now supports the use of objects for the `value` property

--- a/.changeset/slimy-knives-tie.md
+++ b/.changeset/slimy-knives-tie.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: checking listBoxItem value equality deeply instead of by reference.
+bugfix: ListBoxItem is now compared by value rather than by reference

--- a/.changeset/smooth-rockets-know.md
+++ b/.changeset/smooth-rockets-know.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: updated `typesVersions` map to fix auto imports paths
+bugfix: Updated `typesVersions` map to fix auto imports paths

--- a/.changeset/swift-parrots-help.md
+++ b/.changeset/swift-parrots-help.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-chore: replace the now deprecated `eslint-plugin-svelte3` for `eslint-plugin-svelte`
+chore: Replaced the now deprecated `eslint-plugin-svelte3` for `eslint-plugin-svelte`


### PR DESCRIPTION
## Description

Cleaned up the changeset messages.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
