### PR TITLE
Feat: toast enhancement

### DIFF
--- a/.changeset/lazy-pants-yawn.md
+++ b/.changeset/lazy-pants-yawn.md
@@ -1,0 +1,8 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Toast enhancement
+    1. Added the ability to hide the close button.
+    2. Added the ability to remain visible on hover.
+    3. Added the ability to close toasts programmatically by Id.

--- a/.changeset/lazy-pants-yawn.md
+++ b/.changeset/lazy-pants-yawn.md
@@ -2,7 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Toast enhancement
-    1. Added the ability to hide the close button.
-    2. Added the ability to remain visible on hover.
-    3. Added the ability to close toasts programmatically by Id.
+feat: Toast enhancement - ability to `hide the close button`, ability to `remain visible on hover`, ability to `close toasts programmatically` by Id.

--- a/.changeset/lazy-pants-yawn.md
+++ b/.changeset/lazy-pants-yawn.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Toast enhancement - ability to `hide the close button`, ability to `remain visible on hover`, ability to `close toasts programmatically` by Id.
+feat: Expanded Toast features to allow hiding the dismiss button, allow toast to remain visible on hover, and programatically close each instance.

--- a/cspell.json
+++ b/cspell.json
@@ -125,6 +125,7 @@
 		"Themer",
 		"tickmarks",
 		"Transpiles",
+		"undismissible",
 		"unsub",
 		"Unsubscriber",
 		"Vercel",

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -76,6 +76,14 @@
 		toastStore.close($toastStore[index].id);
 	}
 
+	function onMouseEnter(index: number): void {
+		if ($toastStore[index]?.hoverVisible) toastStore.freeze(index);
+	}
+
+	function onMouseLeave(index: number): void {
+		if ($toastStore[index]?.hoverVisible) toastStore.unfreeze(index);
+	}
+
 	// Reactive
 	$: classesWrapper = `${cWrapper} ${cPosition} ${zIndex} ${$$props.class || ''}`;
 	$: classesSnackbar = `${cSnackbar} ${cAlign} ${padding}`;
@@ -109,7 +117,13 @@
 		<!-- List -->
 		<div class="snackbar {classesSnackbar}">
 			{#each filteredToasts as t, i (t)}
-				<div animate:flip={{ duration }} in:receive={{ key: t.id }} out:send={{ key: t.id }}>
+				<div
+					animate:flip={{ duration }}
+					in:receive={{ key: t.id }}
+					out:send={{ key: t.id }}
+					on:mouseenter={() => onMouseEnter(i)}
+					on:mouseleave={() => onMouseLeave(i)}
+				>
 					<!-- Toast -->
 					<div
 						class="toast {classesToast} {t.background ?? background} {t.classes ?? ''}"

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -140,7 +140,7 @@
 						<div class="text-base">{@html t.message}</div>
 						<div class="toast-actions {cToastActions}">
 							{#if t.action}<button class={buttonAction} on:click={() => onAction(i)}>{@html t.action.label}</button>{/if}
-							{#if !t.undismissible}<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>{/if}
+							{#if !t.hideDismiss}<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>{/if}
 						</div>
 					</div>
 				</div>

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -77,14 +77,14 @@
 	}
 
 	function onMouseEnter(index: number): void {
-		if ($toastStore[index]?.hoverVisible) {
+		if ($toastStore[index]?.hoverable) {
 			toastStore.freeze(index);
 			classesSnackbar += ' scale-[105%]';
 		}
 	}
 
 	function onMouseLeave(index: number): void {
-		if ($toastStore[index]?.hoverVisible) {
+		if ($toastStore[index]?.hoverable) {
 			toastStore.unfreeze(index);
 			classesSnackbar = classesSnackbar.replace(' scale-[105%]', '');
 		}
@@ -140,7 +140,7 @@
 						<div class="text-base">{@html t.message}</div>
 						<div class="toast-actions {cToastActions}">
 							{#if t.action}<button class={buttonAction} on:click={() => onAction(i)}>{@html t.action.label}</button>{/if}
-							{#if !t.hideDismiss}<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>{/if}
+							{#if !t.undismissible}<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>{/if}
 						</div>
 					</div>
 				</div>

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -120,7 +120,7 @@
 						<div class="text-base">{@html t.message}</div>
 						<div class="toast-actions {cToastActions}">
 							{#if t.action}<button class={buttonAction} on:click={() => onAction(i)}>{@html t.action.label}</button>{/if}
-							<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>
+							{#if !t.hideDismiss}<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>{/if}
 						</div>
 					</div>
 				</div>

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -77,11 +77,17 @@
 	}
 
 	function onMouseEnter(index: number): void {
-		if ($toastStore[index]?.hoverVisible) toastStore.freeze(index);
+		if ($toastStore[index]?.hoverVisible) {
+			toastStore.freeze(index);
+			classesSnackbar += ' scale-[105%]';
+		}
 	}
 
 	function onMouseLeave(index: number): void {
-		if ($toastStore[index]?.hoverVisible) toastStore.unfreeze(index);
+		if ($toastStore[index]?.hoverVisible) {
+			toastStore.unfreeze(index);
+			classesSnackbar = classesSnackbar.replace(' scale-[105%]', '');
+		}
 	}
 
 	// Reactive

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -138,10 +138,12 @@
 						data-testid="toast"
 					>
 						<div class="text-base">{@html t.message}</div>
-						<div class="toast-actions {cToastActions}">
-							{#if t.action}<button class={buttonAction} on:click={() => onAction(i)}>{@html t.action.label}</button>{/if}
-							{#if !t.hideDismiss}<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>{/if}
-						</div>
+						{#if t.action || !t.hideDismiss}
+							<div class="toast-actions {cToastActions}">
+								{#if t.action}<button class={buttonAction} on:click={() => onAction(i)}>{@html t.action.label}</button>{/if}
+								{#if !t.hideDismiss}<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>{/if}
+							</div>
+						{/if}
 					</div>
 				</div>
 			{/each}

--- a/packages/skeleton/src/lib/utilities/Toast/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/stores.ts
@@ -31,7 +31,7 @@ function toastService() {
 				// Trigger Callback
 				if (toast && toast.callback) toast.callback({ id, status: 'queued' });
 				// activate autohide when dismiss button is hidden.
-				if (toast.hideDismiss) toast.autohide = true;
+				if (toast.undismissible) toast.autohide = true;
 				// Merge with defaults
 				const tMerged: Toast = { ...toastDefaults, ...toast, id };
 				// Handle auto-hide, if needed

--- a/packages/skeleton/src/lib/utilities/Toast/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/stores.ts
@@ -31,7 +31,7 @@ function toastService() {
 				// Trigger Callback
 				if (toast && toast.callback) toast.callback({ id, status: 'queued' });
 				// activate autohide when dismiss button is hidden.
-				if (toast.undismissible) toast.autohide = true;
+				if (toast.hideDismiss) toast.autohide = true;
 				// Merge with defaults
 				const tMerged: Toast = { ...toastDefaults, ...toast, id };
 				// Handle auto-hide, if needed

--- a/packages/skeleton/src/lib/utilities/Toast/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/stores.ts
@@ -30,6 +30,8 @@ function toastService() {
 				const id: string = randomUUID();
 				// Trigger Callback
 				if (toast && toast.callback) toast.callback({ id, status: 'queued' });
+				// activate autohide when dismiss button is hidden.
+				if (toast.hideDismiss) toast.autohide = true;
 				// Merge with defaults
 				const tMerged: Toast = { ...toastDefaults, ...toast, id };
 				// Handle auto-hide, if needed

--- a/packages/skeleton/src/lib/utilities/Toast/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/stores.ts
@@ -58,6 +58,18 @@ function toastService() {
 				}
 				return tStore;
 			}),
+		/** remain visible on hover */
+		freeze: (index: number) =>
+			update((tStore) => {
+				if (tStore.length > 0) clearTimeout(tStore[index].timeoutId);
+				return tStore;
+			}),
+		/** cancel remain visible on leave */
+		unfreeze: (index: number) =>
+			update((tStore) => {
+				if (tStore.length > 0) tStore[index].timeoutId = handleAutoHide(tStore[index]);
+				return tStore;
+			}),
 		/** Remove all toasts from queue */
 		clear: () => set([])
 	};

--- a/packages/skeleton/src/lib/utilities/Toast/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/stores.ts
@@ -25,9 +25,9 @@ function toastService() {
 	return {
 		subscribe,
 		/** Add a new toast to the queue. */
-		trigger: (toast: ToastSettings) =>
+		trigger: (toast: ToastSettings) => {
+			const id: string = randomUUID();
 			update((tStore) => {
-				const id: string = randomUUID();
 				// Trigger Callback
 				if (toast && toast.callback) toast.callback({ id, status: 'queued' });
 				// activate autohide when dismiss button is hidden.
@@ -40,8 +40,10 @@ function toastService() {
 				tStore.push(tMerged);
 				// Return
 				return tStore;
-			}),
-		/** Remove first toast in queue */
+			});
+			return id;
+		},
+		/** Remove toast in queue*/
 		close: (id: string) =>
 			update((tStore) => {
 				if (tStore.length > 0) {

--- a/packages/skeleton/src/lib/utilities/Toast/types.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/types.ts
@@ -18,6 +18,8 @@ export interface ToastSettings {
 	};
 	/** Hide dismiss button */
 	hideDismiss?: boolean;
+	/** Remain visible on Hover */
+	hoverVisible?: boolean;
 	/** Provide arbitrary CSS classes to style the toast. */
 	classes?: string;
 	/** Callback function that fires on trigger and close. */

--- a/packages/skeleton/src/lib/utilities/Toast/types.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/types.ts
@@ -17,9 +17,9 @@ export interface ToastSettings {
 		response: () => void;
 	};
 	/** Hide dismiss button */
-	hideDismiss?: boolean;
+	undismissible?: boolean;
 	/** Remain visible on Hover */
-	hoverVisible?: boolean;
+	hoverable?: boolean;
 	/** Provide arbitrary CSS classes to style the toast. */
 	classes?: string;
 	/** Callback function that fires on trigger and close. */

--- a/packages/skeleton/src/lib/utilities/Toast/types.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/types.ts
@@ -17,7 +17,7 @@ export interface ToastSettings {
 		response: () => void;
 	};
 	/** Hide dismiss button */
-	undismissible?: boolean;
+	hideDismiss?: boolean;
 	/** Remain visible on Hover */
 	hoverable?: boolean;
 	/** Provide arbitrary CSS classes to style the toast. */

--- a/packages/skeleton/src/lib/utilities/Toast/types.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/types.ts
@@ -16,6 +16,8 @@ export interface ToastSettings {
 		/** The function triggered when the button is pressed. */
 		response: () => void;
 	};
+	/** Hide dismiss button */
+	hideDismiss?: boolean;
 	/** Provide arbitrary CSS classes to style the toast. */
 	classes?: string;
 	/** Callback function that fires on trigger and close. */

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -74,6 +74,15 @@
 		toastStore.trigger(t);
 	}
 
+	function toastHiddenDismiss(): void {
+		const t: ToastSettings = {
+			message: 'The dismiss button is hidden.',
+			hideDismiss: true,
+			timeout: 10000
+		};
+		toastStore.trigger(t);
+	}
+
 	function toastBackground(background: string): void {
 		const t: ToastSettings = {
 			message: `The background was set as <u>${background}</u>.`,
@@ -211,6 +220,31 @@ const t: ToastSettings = {
 toastStore.trigger(t);
 `}
 					/>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- dismiss hidden -->
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<div class="flex gap-4">
+						<button class="btn variant-filled" on:click={toastHiddenDismiss}>Hidden dismiss</button>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+const t: ToastSettings = {
+	message: 'The dismiss button is hidden.',
+	hideDismiss: true,
+	timeout: 10000
+};
+toastStore.trigger(t);
+`}
+					/>
+					<p>
+						Note: setting the <code class="code">hideDismiss</code> will auto set the <code class="code">autohide</code> property so users don't
+						have the toast staying on the screen infinitely
+					</p>
 				</svelte:fragment>
 			</DocsPreview>
 			<!-- Clear -->

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -19,6 +19,9 @@
 		components: [{ sveld: sveldToast }]
 	};
 
+	// Local
+	let toastId = '';
+
 	// Triggers Toasts ---
 
 	function toastDemo(): void {
@@ -90,6 +93,18 @@
 			hoverVisible: true
 		};
 		toastStore.trigger(t);
+	}
+
+	function toastCloseProgrammatically(): void {
+		const t: ToastSettings = {
+			message: 'Programmatically closable toast',
+			autohide: false
+		};
+		toastId = toastStore.trigger(t);
+	}
+
+	function closeToast(): void {
+		toastStore.close(toastId);
 	}
 
 	function toastBackground(background: string): void {
@@ -275,10 +290,29 @@ const t: ToastSettings = {
 toastStore.trigger(t);
 `}
 					/>
-					<p>
-						Note: setting the <code class="code">hideDismiss</code> will auto set the <code class="code">autohide</code> property so users don't
-						have the toast staying on the screen infinitely
-					</p>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- close programmatically -->
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<div class="flex gap-4">
+						<button class="btn variant-filled" on:click={toastCloseProgrammatically}>Programmatically closable toast</button>
+						<button class="btn variant-filled-error" on:click={closeToast}>Close toast</button>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+const t: ToastSettings = {
+	message: 'Programmatically closable toast',
+};
+toastId = toastStore.trigger(t);
+
+// close toast
+toastStore.close(toastId);
+`}
+					/>
 				</svelte:fragment>
 			</DocsPreview>
 			<!-- Clear -->

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -206,7 +206,9 @@ toastStore.trigger(t);
 					/>
 				</svelte:fragment>
 			</DocsPreview>
-			<!-- Fixed -->
+			<h3 class="h3">Timing</h3>
+			<p>Use the following setting to adjust the toast timing.</p>
+			<!-- No Timeout -->
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="flex gap-4">
@@ -246,11 +248,16 @@ toastStore.trigger(t);
 					/>
 				</svelte:fragment>
 			</DocsPreview>
+			<h3 class="h3">Dismiss</h3>
+			<p>
+				Use the <code class="code">hideDismiss</code> option to disable the dismiss button. When using this setting
+				<code class="code">autohide</code> option enabled by default.
+			</p>
 			<!-- Hidden dismiss -->
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="flex gap-4">
-						<button class="btn variant-filled" on:click={toastHiddenDismiss}>Hidden dismiss</button>
+						<button class="btn variant-filled" on:click={toastHiddenDismiss}>Hide Dismiss</button>
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
@@ -265,11 +272,10 @@ const t: ToastSettings = {
 toastStore.trigger(t);
 `}
 					/>
-					<p>
-						When using the <code class="code">hideDismiss</code> option <code class="code">autohide</code> is required and enabled by default.
-					</p>
 				</svelte:fragment>
 			</DocsPreview>
+			<h3 class="h3">Hover State</h3>
+			<p>Use the <code class="code">hoverable</code> option to keep the toast visible while hovering with a mouse cursor.</p>
 			<!-- remain visible on hover -->
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
@@ -295,10 +301,12 @@ toastStore.trigger(t);
 			<h3 class="h3">Clear</h3>
 			<p>Use <code class="code">toastStore.clear()</code> to clear the entire toast store queue.</p>
 			<CodeBlock language="ts" code={`toastStore.clear();`} />
+		</section>
+		<!-- Programatic -->
+		<section class="space-y-4">
 			<!-- Programatic -->
-			<h3 class="h3">Programatic</h3>
-			<p>Create a reference ID for your toast so that you may programatically close the toast on demand.</p>
-
+			<h2 class="h2">Programatic</h2>
+			<p>Create a reference for your toast so that you may programatically close it on demand.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="flex gap-4">

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -80,7 +80,7 @@
 	function toastHiddenDismiss(): void {
 		const t: ToastSettings = {
 			message: 'The dismiss button is hidden.',
-			undismissible: true,
+			hideDismiss: true,
 			timeout: 10000
 		};
 		toastStore.trigger(t);
@@ -259,14 +259,14 @@ toastStore.trigger(t);
 						code={`
 const t: ToastSettings = {
 	message: 'The dismiss button is hidden.',
-	undismissible: true,
+	hideDismiss: true,
 	timeout: 10000
 };
 toastStore.trigger(t);
 `}
 					/>
 					<p>
-						When using the <code class="code">dismissable</code> option <code class="code">autohide</code> is required and enabled by default.
+						When using the <code class="code">hideDismiss</code> option <code class="code">autohide</code> is required and enabled by default.
 					</p>
 				</svelte:fragment>
 			</DocsPreview>

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -83,6 +83,15 @@
 		toastStore.trigger(t);
 	}
 
+	function toastRemainVisibleOnHover(): void {
+		const t: ToastSettings = {
+			message: 'remain visible on hover.',
+			timeout: 5000,
+			hoverVisible: true
+		};
+		toastStore.trigger(t);
+	}
+
 	function toastBackground(background: string): void {
 		const t: ToastSettings = {
 			message: `The background was set as <u>${background}</u>.`,
@@ -222,7 +231,7 @@ toastStore.trigger(t);
 					/>
 				</svelte:fragment>
 			</DocsPreview>
-			<!-- dismiss hidden -->
+			<!-- Hidden dismiss -->
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="flex gap-4">
@@ -237,6 +246,31 @@ const t: ToastSettings = {
 	message: 'The dismiss button is hidden.',
 	hideDismiss: true,
 	timeout: 10000
+};
+toastStore.trigger(t);
+`}
+					/>
+					<p>
+						Note: setting the <code class="code">hideDismiss</code> will auto set the <code class="code">autohide</code> property so users don't
+						have the toast staying on the screen infinitely
+					</p>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- remain visible on hover -->
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<div class="flex gap-4">
+						<button class="btn variant-filled" on:click={toastRemainVisibleOnHover}>remain visible on hover</button>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+const t: ToastSettings = {
+	message: 'remain visible on hover.',
+	timeout: 5000,
+	hoverVisible: true
 };
 toastStore.trigger(t);
 `}

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -80,7 +80,7 @@
 	function toastHiddenDismiss(): void {
 		const t: ToastSettings = {
 			message: 'The dismiss button is hidden.',
-			hideDismiss: true,
+			undismissible: true,
 			timeout: 10000
 		};
 		toastStore.trigger(t);
@@ -90,7 +90,7 @@
 		const t: ToastSettings = {
 			message: 'remain visible on hover.',
 			timeout: 5000,
-			hoverVisible: true
+			hoverable: true
 		};
 		toastStore.trigger(t);
 	}
@@ -259,15 +259,14 @@ toastStore.trigger(t);
 						code={`
 const t: ToastSettings = {
 	message: 'The dismiss button is hidden.',
-	hideDismiss: true,
+	undismissible: true,
 	timeout: 10000
 };
 toastStore.trigger(t);
 `}
 					/>
 					<p>
-						Note: setting the <code class="code">hideDismiss</code> will auto set the <code class="code">autohide</code> property so users don't
-						have the toast staying on the screen infinitely
+						When using the <code class="code">dismissable</code> option <code class="code">autohide</code> is required and enabled by default.
 					</p>
 				</svelte:fragment>
 			</DocsPreview>
@@ -275,7 +274,7 @@ toastStore.trigger(t);
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="flex gap-4">
-						<button class="btn variant-filled" on:click={toastRemainVisibleOnHover}>remain visible on hover</button>
+						<button class="btn variant-filled" on:click={toastRemainVisibleOnHover}>Visible on Hover</button>
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
@@ -285,19 +284,26 @@ toastStore.trigger(t);
 const t: ToastSettings = {
 	message: 'remain visible on hover.',
 	timeout: 5000,
-	hoverVisible: true
+	hoverable: true
 };
 toastStore.trigger(t);
 `}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
-			<!-- close programmatically -->
+			<!-- Clear -->
+			<h3 class="h3">Clear</h3>
+			<p>Use <code class="code">toastStore.clear()</code> to clear the entire toast store queue.</p>
+			<CodeBlock language="ts" code={`toastStore.clear();`} />
+			<!-- Programatic -->
+			<h3 class="h3">Programatic</h3>
+			<p>Create a reference ID for your toast so that you may programatically close the toast on demand.</p>
+
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="flex gap-4">
-						<button class="btn variant-filled" on:click={toastCloseProgrammatically}>Programmatically closable toast</button>
-						<button class="btn variant-filled-error" on:click={closeToast}>Close toast</button>
+						<button class="btn variant-filled" on:click={toastCloseProgrammatically}>Show</button>
+						<button class="btn variant-filled-error" on:click={closeToast}>Close</button>
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
@@ -315,10 +321,6 @@ toastStore.close(toastId);
 					/>
 				</svelte:fragment>
 			</DocsPreview>
-			<!-- Clear -->
-			<h3 class="h3">Clear</h3>
-			<p>Use <code class="code">toastStore.clear()</code> to clear the entire toast store queue.</p>
-			<CodeBlock language="ts" code={`toastStore.clear();`} />
 		</section>
 		<!-- Styling -->
 		<section class="space-y-4">


### PR DESCRIPTION
## Linked Issue

Closes #1311

## Description

### Done
1. ability to hide the x button using the prop `hideDismiss`.
2. ability to remain visible if hovering using the prop `hoverVisible`.
3. ability to close toast programmatically using the toastId.
### Notes
1. I was worried that the user could activate `hideDismiss` and the toast will stay on screen infinitely. so I have set autohide to true automatically when `hideDismiss` is set and wrote a note in the docs about it.
2. Should I add some hover effect when `hoverVisible` is set so the user knows that hovering the toast will keep it open?
3. remaining visible when hovering is simpler when we just delete the timeout and recreate it after, but the time spent on the toast is not calculated, so should I track the time and kind of continue it after `mouseLeave` or is it ok to just reset the timer?
4. to close the toast programmatically I am returning the ID from the store `trigger` function, I don't think this change should be a breaking change, but I just wanted to make sure.

## Changsets

feat: Toast enhancement - ability to `hide the close button`, ability to `remain visible on hover`, ability to `close toasts programmatically` by Id.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
