### PR TITLE
Doc/fix blog article styles

### DIFF
--- a/.changeset/good-dingos-attend.md
+++ b/.changeset/good-dingos-attend.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Resolved a bug preventing the prose stylesheet from being imported

--- a/packages/skeleton/src/lib/styles/partials/typography-prose.css
+++ b/packages/skeleton/src/lib/styles/partials/typography-prose.css
@@ -3,49 +3,47 @@
 /* Provides default styling for the Tailwind Typography plugin via element modifiers. */
 /* https://tailwindcss.com/docs/typography-plugin */
 
-@layer base {
-	.prose {
-		@apply text-base font-token text-token;
-		/* Element Modifiers */
-		/* https://tailwindcss.com/docs/typography-plugin#element-modifiers */
-		@apply prose-headings:text-token;
-		/* @apply prose-lead:{utility}; */
-		@apply prose-h1:font-heading-token prose-h1:text-3xl prose-h1:md:text-5xl;
-		@apply prose-h2:font-heading-token prose-h1:text-2xl prose-h1:md:text-4xl;
-		@apply prose-h3:font-heading-token prose-h1:text-xl prose-h1:md:text-2xl;
-		@apply prose-h4:font-heading-token prose-h1:text-lg prose-h1:md:text-xl;
-		@apply prose-p:text-base;
-		/* @apply prose-a:{utility}; */
-		@apply prose-a:text-primary-700 prose-a:dark:text-primary-500 prose-a:hover:brightness-110 prose-a:underline;
-		@apply prose-blockquote:text-token prose-blockquote:text-base prose-blockquote:!border-secondary-500;
-		/* @apply prose-figure:{utility}; */
-		@apply prose-figcaption:text-token prose-figcaption:!text-sm prose-figcaption:italic prose-figcaption:text-center mt-3;
-		@apply prose-strong:text-token;
-		@apply prose-em:text-token;
-		/* @apply prose-ol:{utility}; */
-		/* @apply prose-ul:{utility}; */
-		@apply prose-li:text-base;
-		/* @apply prose-table:{utility}; */
-		/* @apply prose-thead:{utility}; */
-		/* @apply prose-tr:{utility}; */
-		/* @apply prose-th:{utility}; */
-		/* @apply prose-td:{utility}; */
-		/* @apply prose-img:{utility}; */
-		/* @apply prose-video:{utility}; */
-		/* @apply prose-hr:{utility}; */
+.prose {
+	@apply text-base font-token text-token;
+	/* Element Modifiers */
+	/* https://tailwindcss.com/docs/typography-plugin#element-modifiers */
+	@apply prose-headings:text-token;
+	/* @apply prose-lead:{utility}; */
+	@apply prose-h1:font-heading-token prose-h1:text-3xl prose-h1:md:text-5xl;
+	@apply prose-h2:font-heading-token prose-h1:text-2xl prose-h1:md:text-4xl;
+	@apply prose-h3:font-heading-token prose-h1:text-xl prose-h1:md:text-2xl;
+	@apply prose-h4:font-heading-token prose-h1:text-lg prose-h1:md:text-xl;
+	@apply prose-p:text-base;
+	/* @apply prose-a:{utility}; */
+	@apply prose-a:text-primary-700 prose-a:dark:text-primary-500 prose-a:hover:brightness-110 prose-a:underline;
+	@apply prose-blockquote:text-token prose-blockquote:text-base prose-blockquote:!border-secondary-500;
+	/* @apply prose-figure:{utility}; */
+	@apply prose-figcaption:text-token prose-figcaption:!text-sm prose-figcaption:italic prose-figcaption:text-center mt-3;
+	@apply prose-strong:text-token;
+	@apply prose-em:text-token;
+	/* @apply prose-ol:{utility}; */
+	/* @apply prose-ul:{utility}; */
+	@apply prose-li:text-base;
+	/* @apply prose-table:{utility}; */
+	/* @apply prose-thead:{utility}; */
+	/* @apply prose-tr:{utility}; */
+	/* @apply prose-th:{utility}; */
+	/* @apply prose-td:{utility}; */
+	/* @apply prose-img:{utility}; */
+	/* @apply prose-video:{utility}; */
+	/* @apply prose-hr:{utility}; */
 
-		/* The following have special use cases and must be handled seperately */
-		/* @apply prose-code:{utility}; */
-		/* @apply prose-pre:{utility}; */
-	}
+	/* The following have special use cases and must be handled seperately */
+	/* @apply prose-code:{utility}; */
+	/* @apply prose-pre:{utility}; */
+}
 
-	/* NOTE: keep these in sync with typography.css */
-	.prose pre:not(.code-block pre) {
-		@apply font-mono text-base bg-neutral-900/90 text-white p-4 whitespace-pre-wrap overflow-x-auto rounded-container-token;
-	}
-	.prose code:is(:not(pre *)) {
-		@apply font-mono text-xs text-primary-700 dark:text-primary-400 whitespace-nowrap;
-		@apply bg-primary-500/30 dark:bg-primary-500/20;
-		@apply py-0.5 px-1 rounded;
-	}
+/* NOTE: keep these in sync with typography.css */
+.prose pre:not(.code-block pre) {
+	@apply font-mono text-base bg-neutral-900/90 text-white p-4 whitespace-pre-wrap overflow-x-auto rounded-container-token;
+}
+.prose code:is(:not(pre *)) {
+	@apply font-mono text-xs text-primary-700 dark:text-primary-400 whitespace-nowrap;
+	@apply bg-primary-500/30 dark:bg-primary-500/20;
+	@apply py-0.5 px-1 rounded;
 }

--- a/sites/skeleton.dev/src/lib/styles/blog.css
+++ b/sites/skeleton.dev/src/lib/styles/blog.css
@@ -1,5 +1,55 @@
 /* Ghost Blog Styles */
 
+/* === Tailwind Typography (prose) === */
+
+/* Provides default styling for the Tailwind Typography plugin via element modifiers. */
+/* https://tailwindcss.com/docs/typography-plugin */
+
+.prose {
+	@apply text-base font-token text-token;
+	/* Element Modifiers */
+	/* https://tailwindcss.com/docs/typography-plugin#element-modifiers */
+	@apply prose-headings:text-token;
+	/* @apply prose-lead:{utility}; */
+	@apply prose-h1:font-heading-token prose-h1:text-3xl prose-h1:md:text-5xl;
+	@apply prose-h2:font-heading-token prose-h1:text-2xl prose-h1:md:text-4xl;
+	@apply prose-h3:font-heading-token prose-h1:text-xl prose-h1:md:text-2xl;
+	@apply prose-h4:font-heading-token prose-h1:text-lg prose-h1:md:text-xl;
+	@apply prose-p:text-base;
+	/* @apply prose-a:{utility}; */
+	@apply prose-a:text-primary-700 prose-a:dark:text-primary-500 prose-a:hover:brightness-110 prose-a:underline;
+	@apply prose-blockquote:text-token prose-blockquote:text-base prose-blockquote:!border-secondary-500;
+	/* @apply prose-figure:{utility}; */
+	@apply prose-figcaption:text-token prose-figcaption:!text-sm prose-figcaption:italic prose-figcaption:text-center mt-3;
+	@apply prose-strong:text-token;
+	@apply prose-em:text-token;
+	/* @apply prose-ol:{utility}; */
+	/* @apply prose-ul:{utility}; */
+	@apply prose-li:text-base;
+	/* @apply prose-table:{utility}; */
+	/* @apply prose-thead:{utility}; */
+	/* @apply prose-tr:{utility}; */
+	/* @apply prose-th:{utility}; */
+	/* @apply prose-td:{utility}; */
+	/* @apply prose-img:{utility}; */
+	/* @apply prose-video:{utility}; */
+	/* @apply prose-hr:{utility}; */
+
+	/* The following have special use cases and must be handled seperately */
+	/* @apply prose-code:{utility}; */
+	/* @apply prose-pre:{utility}; */
+}
+
+/* NOTE: keep these in sync with typography.css */
+.prose pre:not(.code-block pre) {
+	@apply font-mono text-base bg-neutral-900/90 text-white p-4 whitespace-pre-wrap overflow-x-auto rounded-container-token;
+}
+.prose code:is(:not(pre *)) {
+	@apply font-mono text-xs text-primary-700 dark:text-primary-400 whitespace-nowrap;
+	@apply bg-primary-500/30 dark:bg-primary-500/20;
+	@apply py-0.5 px-1 rounded;
+}
+
 /* === Embeds === */
 
 /* YouTube */

--- a/sites/skeleton.dev/src/routes/+layout.svelte
+++ b/sites/skeleton.dev/src/routes/+layout.svelte
@@ -42,6 +42,7 @@
 	// import '@skeletonlabs/skeleton/styles/all.css';
 	import '@skeletonlabs/skeleton/styles/skeleton.css';
 	// import '@skeletonlabs/skeleton/styles/skeleton-minimal.css';
+	// import '@skeletonlabs/skeleton/styles/partials/typography-prose.css';
 	// The Skeleton blog stylesheet
 	import '$lib/styles/blog.css';
 	// Global Stylesheets


### PR DESCRIPTION
## Linked Issue

Closes #1640

## Description

Resolve a bug preventing the prose stylesheet from being imported due to the `@layer base` CSS directive.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
