### PR TITLE
bugfix: fixed Typography-Prose headers typo

### DIFF
--- a/.changeset/thick-cougars-notice.md
+++ b/.changeset/thick-cougars-notice.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: fixed Typography-Prose headers typo.

--- a/packages/skeleton/src/lib/styles/partials/typography-prose.css
+++ b/packages/skeleton/src/lib/styles/partials/typography-prose.css
@@ -10,9 +10,9 @@
 	@apply prose-headings:text-token;
 	/* @apply prose-lead:{utility}; */
 	@apply prose-h1:font-heading-token prose-h1:text-3xl prose-h1:md:text-5xl;
-	@apply prose-h2:font-heading-token prose-h1:text-2xl prose-h1:md:text-4xl;
-	@apply prose-h3:font-heading-token prose-h1:text-xl prose-h1:md:text-2xl;
-	@apply prose-h4:font-heading-token prose-h1:text-lg prose-h1:md:text-xl;
+	@apply prose-h2:font-heading-token prose-h2:text-2xl prose-h2:md:text-4xl;
+	@apply prose-h3:font-heading-token prose-h3:text-xl prose-h3:md:text-2xl;
+	@apply prose-h4:font-heading-token prose-h4:text-lg prose-h4:md:text-xl;
 	@apply prose-p:text-base;
 	/* @apply prose-a:{utility}; */
 	@apply prose-a:text-primary-700 prose-a:dark:text-primary-500 prose-a:hover:brightness-110 prose-a:underline;


### PR DESCRIPTION
## Linked Issue

Closes #1646

## Description

fixed Typography-Prose headers typo

## Changsets

bugfix: fixed Typography-Prose headers typo.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
