### PR TITLE
docs/accordion Remove duplicate word exposed in accordion doc

### DIFF
--- a/.changeset/strange-falcons-provide.md
+++ b/.changeset/strange-falcons-provide.md
@@ -1,5 +1,0 @@
----
-"@skeletonlabs/skeleton": patch
----
-
-chore: Remove duplicate word in accordion doc view

--- a/.changeset/strange-falcons-provide.md
+++ b/.changeset/strange-falcons-provide.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: Remove duplicate word in accordion doc view

--- a/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
+++ b/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
@@ -3,7 +3,7 @@
 	/**
 	 * @slot {{}} lead - Allows for an optional leading element, such as an icon.
 	 * @slot {{}} summary - Provide the interactive summary of each item.
-	 * @slot {{}} content - Provide the content content of each item.
+	 * @slot {{}} content - Provide the content of each item.
 	 */
 	// Events:
 	// FORWARDED: do not document these, breaks the type definition


### PR DESCRIPTION
## Linked Issue

Closes #none
## Description

Removed duplicated word "content" in the description of Accordion Items.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/package/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
1 test skipped. Lightswitch test.
- [x] Includes a changeset (if relevant; see above)
