### PR TITLE
docs: Add missing import `AppRailAnchor`

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/app-rail/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-rail/+page.svelte
@@ -18,7 +18,7 @@
 		feature: DocsFeature.Component,
 		name: 'App Rail',
 		description: 'A side navigation rail component',
-		imports: ['AppRail', 'AppRailTile'],
+		imports: ['AppRail', 'AppRailTile', 'AppRailAnchor'],
 		source: 'components/AppRail',
 		// aria: 'https://www.w3.org/WAI/ARIA/apg/',
 		components: [


### PR DESCRIPTION
## Description

An import of used component was missing in the documentation, added it

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
