### PR TITLE
bugfix: drawer blur typo

### DIFF
--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -28,7 +28,7 @@
 	/** Backdrop - Provide classes to set the backdrop background color */
 	export let bgBackdrop: CssClasses = 'bg-surface-backdrop-token';
 	/** Backdrop - Provide classes to set the blur style. */
-	export let blur: CssClasses = 'backdrop-blur-xs';
+	export let blur: CssClasses = 'backdrop-blur-sm';
 	/** Backdrop - Provide classes to set padding. */
 	export let padding: CssClasses = '';
 


### PR DESCRIPTION
## Linked Issue

Closes #1662

## Description

'backdrop-blur-xs' -> 'backdrop-blur-sm'

## Changsets

Not sure if we need a changeset for typos, If so, let me know and I will add it.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
