### PR TITLE
docs: typo in Drawer docs

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
@@ -130,7 +130,7 @@ drawerStore.open(drawerSettings);
 		<section class="space-y-4">
 			<h2 class="h2">Styling</h2>
 			<p>
-				For global styles, apply changes via props directly to the Modal component. However, you may also override styles per drawer
+				For global styles, apply changes via props directly to the Drawer component. However, you may also override styles per drawer
 				instance via the <code class="code">DrawerSettings</code>.
 			</p>
 			<DocsPreview background="neutral">


### PR DESCRIPTION
## Description

Seems a typo caused by copy-paste, replaced `Modal` with `Drawer`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)