### PR TITLE
Bugfix: double drawer unexpected closing direction

### DIFF
--- a/.changeset/fast-apricots-sing.md
+++ b/.changeset/fast-apricots-sing.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Fixed double drawers unexpected closing direction.

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -177,6 +177,7 @@
 		use:focusTrap={true}
 	>
 		<!-- Drawer -->
+		<!-- separate In/Out so anim values update -->
 		<div
 			bind:this={elemDrawer}
 			class="drawer {classesDrawer}"
@@ -185,7 +186,8 @@
 			aria-modal="true"
 			aria-labelledby={labelledby}
 			aria-describedby={describedby}
-			transition:fly|local={{ x: anim.x, y: anim.y, duration }}
+			in:fly|local={{ x: anim.x, y: anim.y, duration }}
+			out:fly|local={{ x: anim.x, y: anim.y, duration }}
 		>
 			<!-- Slot: Default -->
 			<slot />


### PR DESCRIPTION
## Linked Issue

Closes #1671

## Description

so by setting the transition like this:
```ts
transition:fly|local={{ x: anim.x, y: anim.y, duration }}
```
apparently svelte will save the params values and use them for `out` transition, so updating these values won't update the transition.

to solve this, I replaced the transition with in/out, so Svelte would check the value of the params before going out. which solves the problem.

Note: this is just my understanding of the issue, I didn't find any official docs that tackle this problem or indicate how Svelte handles the transitions internally, so my interpretation could be awfully wrong 😄.

## Changsets

bugfix: Fixed double drawers unexpected closing direction.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
