### PR TITLE
bugfix:fixed spelling mistake @ ratings: con => icon

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/ratings/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/ratings/+page.svelte
@@ -54,7 +54,7 @@
 					code={`
 <Ratings value={3.5} max={5}>
     <svelte:fragment slot="empty">(icon)</svelte:fragment>
-    <svelte:fragment slot="half">(con)</svelte:fragment>
+    <svelte:fragment slot="half">(icon)</svelte:fragment>
     <svelte:fragment slot="full">(icon)</svelte:fragment>
 </Ratings>
 			`}
@@ -104,7 +104,7 @@
 						code={`
 <Ratings bind:value={value.current} max={value.max}>
 	<svelte:fragment slot="empty">(icon)</svelte:fragment>
-	<svelte:fragment slot="half">(con)</svelte:fragment>
+	<svelte:fragment slot="half">(icon)</svelte:fragment>
 	<svelte:fragment slot="full">(icon)</svelte:fragment>
 </Ratings>
 			`}
@@ -142,7 +142,7 @@ function iconClick(event: CustomEvent<{index:number}>): void {
 						code={`
 <Ratings bind:value={value.current} max={value.max} on:icon={iconClick}>
 	<svelte:fragment slot="empty">(icon)</svelte:fragment>
-	<svelte:fragment slot="half">(con)</svelte:fragment>
+	<svelte:fragment slot="half">(icon)</svelte:fragment>
 	<svelte:fragment slot="full">(icon)</svelte:fragment>
 </Ratings>
 			`}


### PR DESCRIPTION
## Linked Issue

~~Closes #...~~

## Description

In the Rating component demos, "icon" is misspelled as "con". This fixes this.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

I'm not sure if I correctly understood this, ngl. Given I only changed the docs, do I have to do anything?

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [X] This PR targets the `dev` branch (NEVER `master`)
- [X] Documentation reflects all relevant changes
- [X] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [X] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [X] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
  ```
  echo "Error: no test specified" && exit 1
  ``` huh?
- [ ] Includes a changeset (if relevant; see above)
