### PR TITLE
bugfix: interactive ratings icons on demand

### DIFF
--- a/.changeset/young-cameras-sparkle.md
+++ b/.changeset/young-cameras-sparkle.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+bugfix: `Ratings` icons are only interactive when `iconType` is set to `button`.

--- a/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
+++ b/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
@@ -16,11 +16,8 @@
 	export let value = 0;
 	/** Maximum rating value. */
 	export let max = 5;
-	/**
-	 * Defines the icon element type.
-	 * @type {'div' | 'button'}
-	 */
-	export let iconType: 'div' | 'button' = 'div';
+	/** Enables interactive mode for each rating icon. */
+	export let interactive = false;
 
 	// Props (styles)
 	/** Provide classes to set the text color. */
@@ -50,6 +47,8 @@
 	const cBase = 'w-full flex';
 
 	// Reactive
+	$: elemInteractive = interactive ? 'button' : 'span';
+	$: attrInteractive = interactive ? { type: 'button' } : {};
 	$: classesBase = `${cBase} ${text} ${fill} ${justify} ${spacing} ${$$props.class ?? ''}`;
 </script>
 
@@ -57,26 +56,17 @@
 	<!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
 	{#each Array(max) as _, i}
 		{#if Math.floor(value) >= i + 1}
-			<svelte:element
-				this={iconType}
-				type={iconType === 'button' ? 'button' : undefined}
-				class="rating-icon {regionIcon}"
-				on:click={() => iconClick(i)}><slot name="full" /></svelte:element
-			>
+			<svelte:element this={elemInteractive} {...attrInteractive} class="rating-icon {regionIcon}" on:click={() => iconClick(i)}>
+				<slot name="full" />
+			</svelte:element>
 		{:else if value === i + 0.5}
-			<svelte:element
-				this={iconType}
-				type={iconType === 'button' ? 'button' : undefined}
-				class="rating-icon {regionIcon}"
-				on:click={() => iconClick(i)}><slot name="half" /></svelte:element
-			>
+			<svelte:element this={elemInteractive} {...attrInteractive} class="rating-icon {regionIcon}" on:click={() => iconClick(i)}>
+				<slot name="half" />
+			</svelte:element>
 		{:else}
-			<svelte:element
-				this={iconType}
-				type={iconType === 'button' ? 'button' : undefined}
-				class="rating-icon {regionIcon}"
-				on:click={() => iconClick(i)}><slot name="empty" /></svelte:element
-			>
+			<svelte:element this={elemInteractive} {...attrInteractive} class="rating-icon {regionIcon}" on:click={() => iconClick(i)}>
+				<slot name="empty" />
+			</svelte:element>
 		{/if}
 	{/each}
 </div>

--- a/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
+++ b/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
@@ -16,6 +16,11 @@
 	export let value = 0;
 	/** Maximum rating value. */
 	export let max = 5;
+	/**
+	 * Defines the icon element type.
+	 * @type {'div' | 'button'}
+	 */
+	export let iconType: 'div' | 'button' = 'div';
 
 	// Props (styles)
 	/** Provide classes to set the text color. */
@@ -52,11 +57,26 @@
 	<!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
 	{#each Array(max) as _, i}
 		{#if Math.floor(value) >= i + 1}
-			<button type="button" class="rating-icon {regionIcon}" on:click={() => iconClick(i)}><slot name="full" /></button>
+			<svelte:element
+				this={iconType}
+				type={iconType === 'button' ? 'button' : undefined}
+				class="rating-icon {regionIcon}"
+				on:click={() => iconClick(i)}><slot name="full" /></svelte:element
+			>
 		{:else if value === i + 0.5}
-			<button type="button" class="rating-icon {regionIcon}" on:click={() => iconClick(i)}><slot name="half" /></button>
+			<svelte:element
+				this={iconType}
+				type={iconType === 'button' ? 'button' : undefined}
+				class="rating-icon {regionIcon}"
+				on:click={() => iconClick(i)}><slot name="half" /></svelte:element
+			>
 		{:else}
-			<button type="button" class="rating-icon {regionIcon}" on:click={() => iconClick(i)}><slot name="empty" /></button>
+			<svelte:element
+				this={iconType}
+				type={iconType === 'button' ? 'button' : undefined}
+				class="rating-icon {regionIcon}"
+				on:click={() => iconClick(i)}><slot name="empty" /></svelte:element
+			>
 		{/if}
 	{/each}
 </div>

--- a/sites/skeleton.dev/src/routes/(inner)/components/ratings/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/ratings/+page.svelte
@@ -114,9 +114,10 @@
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">User Interactivity</h2>
+			<p>Use <code class="code">iconType="button"</code> to make the icons interactive.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<Ratings class="fill-token" bind:value={value.current} max={value.max} on:icon={updateInteractiveValue}>
+					<Ratings class="fill-token" bind:value={value.current} max={value.max} iconType="button" on:icon={updateInteractiveValue}>
 						<svelte:fragment slot="empty">
 							{@html icons.starEmpty}
 						</svelte:fragment>
@@ -140,7 +141,8 @@ function iconClick(event: CustomEvent<{index:number}>): void {
 					<CodeBlock
 						language="html"
 						code={`
-<Ratings bind:value={value.current} max={value.max} on:icon={iconClick}>
+<Ratings bind:value={value.current} max={value.max} 
+	iconType="button" on:icon={iconClick}>
 	<svelte:fragment slot="empty">(icon)</svelte:fragment>
 	<svelte:fragment slot="half">(icon)</svelte:fragment>
 	<svelte:fragment slot="full">(icon)</svelte:fragment>

--- a/sites/skeleton.dev/src/routes/(inner)/components/ratings/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/ratings/+page.svelte
@@ -114,10 +114,10 @@
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">User Interactivity</h2>
-			<p>Use <code class="code">iconType="button"</code> to make the icons interactive.</p>
+			<p>Use the <code class="code">interactive</code> prop and <code class="code">on:icon</code> events to add interactivity.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<Ratings class="fill-token" bind:value={value.current} max={value.max} iconType="button" on:icon={updateInteractiveValue}>
+					<Ratings class="fill-token" bind:value={value.current} max={value.max} interactive on:icon={updateInteractiveValue}>
 						<svelte:fragment slot="empty">
 							{@html icons.starEmpty}
 						</svelte:fragment>
@@ -141,8 +141,7 @@ function iconClick(event: CustomEvent<{index:number}>): void {
 					<CodeBlock
 						language="html"
 						code={`
-<Ratings bind:value={value.current} max={value.max} 
-	iconType="button" on:icon={iconClick}>
+<Ratings bind:value={value.current} max={value.max} interactive on:icon={iconClick}>
 	<svelte:fragment slot="empty">(icon)</svelte:fragment>
 	<svelte:fragment slot="half">(icon)</svelte:fragment>
 	<svelte:fragment slot="full">(icon)</svelte:fragment>


### PR DESCRIPTION
## Linked Issue

Closes #1685

## Description

Added iconType property to make the icons interactive on demand.

## Changsets

bugfix: `Ratings` icons are only interactive when `iconType` is set to `button`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
