### PR TITLE
Support Svelte 4

### DIFF
--- a/.changeset/healthy-impalas-notice.md
+++ b/.changeset/healthy-impalas-notice.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Adds support for Svelte 4

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 		"cspell": "^6.31.1",
 		"shelljs": "^0.8.5"
 	},
-	"packageManager": "pnpm@8.6.0",
+	"packageManager": "pnpm@8.6.3",
 	"engines": {
-		"pnpm": ">=8.6.0"
+		"pnpm": ">=8.6.3"
 	},
 	"type": "module"
 }

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -43,7 +43,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "2.1.0",
 		"@sveltejs/kit": "1.20.5",
-		"@sveltejs/package": "2.1.0",
+		"@sveltejs/package": "^2.1.0",
 		"@testing-library/dom": "9.3.0",
 		"@testing-library/svelte": "3.2.2",
 		"@typescript-eslint/eslint-plugin": "5.59.9",
@@ -61,7 +61,7 @@
 		"prettier": "2.8.8",
 		"prettier-plugin-svelte": "2.10.1",
 		"svelte": "4.0.0",
-		"svelte-check": "3.4.4",
+		"svelte-check": "^3.4.4",
 		"tailwindcss": "3.3.2",
 		"tslib": "2.5.3",
 		"typescript": "5.0.3",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -45,7 +45,7 @@
 		"@sveltejs/kit": "1.20.5",
 		"@sveltejs/package": "^2.1.0",
 		"@testing-library/dom": "9.3.0",
-		"@testing-library/svelte": "4.0.0",
+		"@testing-library/svelte": "4.0.1",
 		"@typescript-eslint/eslint-plugin": "5.59.9",
 		"@typescript-eslint/parser": "5.59.9",
 		"@vitest/coverage-c8": "0.32.0",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -73,7 +73,7 @@
 		"esm-env": "1.0.0"
 	},
 	"peerDependencies": {
-		"svelte": ">= 3.55.0 || >= 4"
+		"svelte": "^3.55.0 || ^4.0.0"
 	},
 	"publishConfig": {
 		"types": "./dist/index.d.ts",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -42,7 +42,7 @@
 	"homepage": "https://skeleton.dev/",
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "2.1.0",
-		"@sveltejs/kit": "1.20.2",
+		"@sveltejs/kit": "1.20.4",
 		"@sveltejs/package": "2.0.2",
 		"@testing-library/dom": "9.3.0",
 		"@testing-library/svelte": "3.2.2",
@@ -52,7 +52,7 @@
 		"autoprefixer": "10.4.14",
 		"eslint": "8.42.0",
 		"eslint-config-prettier": "8.8.0",
-		"eslint-plugin-svelte": "^2.30.0",
+		"eslint-plugin-svelte": "^2.31.0",
 		"jsdom": "21.1.1",
 		"postcss": "8.4.24",
 		"postcss-import": "15.1.0",
@@ -60,7 +60,8 @@
 		"postcss-load-config": "4.0.1",
 		"prettier": "2.8.8",
 		"prettier-plugin-svelte": "2.10.1",
-		"svelte-check": "3.4.3",
+		"svelte": "4.0.0",
+		"svelte-check": "3.4.4",
 		"tailwindcss": "3.3.2",
 		"tslib": "2.5.3",
 		"typescript": "5.0.3",
@@ -69,8 +70,10 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"esm-env": "1.0.0",
-		"svelte": "3.58.0"
+		"esm-env": "1.0.0"
+	},
+	"peerDependencies": {
+		"svelte": ">= 3.55.0 || >= 4"
 	},
 	"publishConfig": {
 		"types": "./dist/index.d.ts",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -73,7 +73,7 @@
 		"esm-env": "1.0.0"
 	},
 	"peerDependencies": {
-		"svelte": "^3.55.0 || ^4.0.0"
+		"svelte": "^3.56.0 || ^4.0.0"
 	},
 	"publishConfig": {
 		"types": "./dist/index.d.ts",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -45,7 +45,7 @@
 		"@sveltejs/kit": "1.20.5",
 		"@sveltejs/package": "^2.1.0",
 		"@testing-library/dom": "9.3.0",
-		"@testing-library/svelte": "3.2.2",
+		"@testing-library/svelte": "4.0.0",
 		"@typescript-eslint/eslint-plugin": "5.59.9",
 		"@typescript-eslint/parser": "5.59.9",
 		"@vitest/coverage-c8": "0.32.0",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -42,8 +42,8 @@
 	"homepage": "https://skeleton.dev/",
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "2.1.0",
-		"@sveltejs/kit": "1.20.4",
-		"@sveltejs/package": "2.0.2",
+		"@sveltejs/kit": "1.20.5",
+		"@sveltejs/package": "2.1.0",
 		"@testing-library/dom": "9.3.0",
 		"@testing-library/svelte": "3.2.2",
 		"@typescript-eslint/eslint-plugin": "5.59.9",

--- a/packages/skeleton/pnpm-lock.yaml
+++ b/packages/skeleton/pnpm-lock.yaml
@@ -23,8 +23,8 @@ devDependencies:
     specifier: 9.3.0
     version: 9.3.0
   '@testing-library/svelte':
-    specifier: 4.0.0
-    version: 4.0.0(svelte@4.0.0)
+    specifier: 4.0.1
+    version: 4.0.1(svelte@4.0.0)
   '@typescript-eslint/eslint-plugin':
     specifier: 5.59.9
     version: 5.59.9(@typescript-eslint/parser@5.59.9)(eslint@8.42.0)(typescript@5.0.3)
@@ -571,8 +571,8 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/svelte@4.0.0(svelte@4.0.0):
-    resolution: {integrity: sha512-LRsrUm0FPn/PSdiyFGpix7i3VwgvF65Uw6eLboTM84SWGvRnBlE0VkawrhGl49Phh2nyZ7mS7M0gtVl3OM1eKQ==}
+  /@testing-library/svelte@4.0.1(svelte@4.0.0):
+    resolution: {integrity: sha512-rvqkMlkXPtbtMbYQsWTb666yBAJVrTJcek2TlDogBKhxwYKqbWgvtTftMNclPi5aLgy+QGndTyIf4gtdFKaiXA==}
     engines: {node: '>= 10'}
     peerDependencies:
       svelte: ^3 || ^4

--- a/packages/skeleton/pnpm-lock.yaml
+++ b/packages/skeleton/pnpm-lock.yaml
@@ -12,10 +12,10 @@ dependencies:
 devDependencies:
   '@sveltejs/adapter-auto':
     specifier: 2.1.0
-    version: 2.1.0(@sveltejs/kit@1.20.4)
+    version: 2.1.0(@sveltejs/kit@1.20.5)
   '@sveltejs/kit':
-    specifier: 1.20.4
-    version: 1.20.4(svelte@4.0.0)(vite@4.3.9)
+    specifier: 1.20.5
+    version: 1.20.5(svelte@4.0.0)(vite@4.3.9)
   '@sveltejs/package':
     specifier: ^2.1.0
     version: 2.1.0(svelte@4.0.0)(typescript@5.0.3)
@@ -455,17 +455,17 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.4):
+  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.5):
     resolution: {integrity: sha512-o2pZCfATFtA/Gw/BB0Xm7k4EYaekXxaPGER3xGSY3FvzFJGTlJlZjBseaXwYSM94lZ0HniOjTokN3cWaLX6fow==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.20.4(svelte@4.0.0)(vite@4.3.9)
+      '@sveltejs/kit': 1.20.5(svelte@4.0.0)(vite@4.3.9)
       import-meta-resolve: 3.0.0
     dev: true
 
-  /@sveltejs/kit@1.20.4(svelte@4.0.0)(vite@4.3.9):
-    resolution: {integrity: sha512-MmAzIuMrP7A+8fqDVbxm6ekGHRHL/+Fk8sQPAzPG4G2TxUDtHdn/WcIxeEqHzARMf0OtGSC+VPyOSFuw2Cy2Mg==}
+  /@sveltejs/kit@1.20.5(svelte@4.0.0)(vite@4.3.9):
+    resolution: {integrity: sha512-8rJYZ2boRlO75lwpbpB+DlSzIwmTuamXTpVlDtw4dBk86o3UaDe/+Ro4xCsV/4FtTw2U8xPHyV83edAWbQHG0w==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true

--- a/packages/skeleton/pnpm-lock.yaml
+++ b/packages/skeleton/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -23,8 +23,8 @@ devDependencies:
     specifier: 9.3.0
     version: 9.3.0
   '@testing-library/svelte':
-    specifier: 3.2.2
-    version: 3.2.2(svelte@4.0.0)
+    specifier: 4.0.0
+    version: 4.0.0(svelte@4.0.0)
   '@typescript-eslint/eslint-plugin':
     specifier: 5.59.9
     version: 5.59.9(@typescript-eslint/parser@5.59.9)(eslint@8.42.0)(typescript@5.0.3)
@@ -550,7 +550,7 @@ packages:
       '@babel/code-frame': 7.21.4
       '@babel/runtime': 7.21.5
       '@types/aria-query': 5.0.1
-      aria-query: 5.1.3
+      aria-query: 5.2.1
       chalk: 4.1.2
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
@@ -571,11 +571,11 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/svelte@3.2.2(svelte@4.0.0):
-    resolution: {integrity: sha512-IKwZgqbekC3LpoRhSwhd0JswRGxKdAGkf39UiDXTywK61YyLXbCYoR831e/UUC6EeNW4hiHPY+2WuovxOgI5sw==}
+  /@testing-library/svelte@4.0.0(svelte@4.0.0):
+    resolution: {integrity: sha512-LRsrUm0FPn/PSdiyFGpix7i3VwgvF65Uw6eLboTM84SWGvRnBlE0VkawrhGl49Phh2nyZ7mS7M0gtVl3OM1eKQ==}
     engines: {node: '>= 10'}
     peerDependencies:
-      svelte: 3.x
+      svelte: ^3 || ^4
     dependencies:
       '@testing-library/dom': 8.20.0
       svelte: 4.0.0

--- a/packages/skeleton/pnpm-lock.yaml
+++ b/packages/skeleton/pnpm-lock.yaml
@@ -12,12 +12,12 @@ dependencies:
 devDependencies:
   '@sveltejs/adapter-auto':
     specifier: 2.1.0
-    version: 2.1.0(@sveltejs/kit@1.20.5)
+    version: 2.1.0(@sveltejs/kit@1.20.4)
   '@sveltejs/kit':
-    specifier: 1.20.5
-    version: 1.20.5(svelte@4.0.0)(vite@4.3.9)
+    specifier: 1.20.4
+    version: 1.20.4(svelte@4.0.0)(vite@4.3.9)
   '@sveltejs/package':
-    specifier: 2.1.0
+    specifier: ^2.1.0
     version: 2.1.0(svelte@4.0.0)(typescript@5.0.3)
   '@testing-library/dom':
     specifier: 9.3.0
@@ -71,7 +71,7 @@ devDependencies:
     specifier: 4.0.0
     version: 4.0.0
   svelte-check:
-    specifier: 3.4.4
+    specifier: ^3.4.4
     version: 3.4.4(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0)
   tailwindcss:
     specifier: 3.3.2
@@ -455,17 +455,17 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.5):
+  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.4):
     resolution: {integrity: sha512-o2pZCfATFtA/Gw/BB0Xm7k4EYaekXxaPGER3xGSY3FvzFJGTlJlZjBseaXwYSM94lZ0HniOjTokN3cWaLX6fow==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.20.5(svelte@4.0.0)(vite@4.3.9)
+      '@sveltejs/kit': 1.20.4(svelte@4.0.0)(vite@4.3.9)
       import-meta-resolve: 3.0.0
     dev: true
 
-  /@sveltejs/kit@1.20.5(svelte@4.0.0)(vite@4.3.9):
-    resolution: {integrity: sha512-8rJYZ2boRlO75lwpbpB+DlSzIwmTuamXTpVlDtw4dBk86o3UaDe/+Ro4xCsV/4FtTw2U8xPHyV83edAWbQHG0w==}
+  /@sveltejs/kit@1.20.4(svelte@4.0.0)(vite@4.3.9):
+    resolution: {integrity: sha512-MmAzIuMrP7A+8fqDVbxm6ekGHRHL/+Fk8sQPAzPG4G2TxUDtHdn/WcIxeEqHzARMf0OtGSC+VPyOSFuw2Cy2Mg==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true
@@ -502,7 +502,7 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
       svelte: 4.0.0
-      svelte2tsx: 0.6.14(svelte@4.0.0)(typescript@5.0.3)
+      svelte2tsx: 0.6.16(svelte@4.0.0)(typescript@5.0.3)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -3052,7 +3052,7 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.0.0
-      svelte-preprocess: 5.0.3(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0)(typescript@5.0.3)
+      svelte-preprocess: 5.0.4(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0)(typescript@5.0.3)
       typescript: 5.0.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -3092,8 +3092,8 @@ packages:
       svelte: 4.0.0
     dev: true
 
-  /svelte-preprocess@5.0.3(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==}
+  /svelte-preprocess@5.0.4(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0)(typescript@5.0.3):
+    resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
     peerDependencies:
@@ -3106,7 +3106,7 @@ packages:
       sass: ^1.26.8
       stylus: ^0.55.0
       sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^3.23.0
+      svelte: ^3.23.0 || ^4.0.0-next.0 || ^4.0.0
       typescript: '>=3.9.5 || ^4.0.0 || ^5.0.0'
     peerDependenciesMeta:
       '@babel/core':
@@ -3141,10 +3141,10 @@ packages:
       typescript: 5.0.3
     dev: true
 
-  /svelte2tsx@0.6.14(svelte@4.0.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-Sxo9gtpc3dYWuFQ8fruZG+M+I6OZMIvOxxKjt48Lr8jD6Kr9cNf1Hf/yHUDEgDwQdRbAzn5y0FL9xk8Dx5v9lg==}
+  /svelte2tsx@0.6.16(svelte@4.0.0)(typescript@5.0.3):
+    resolution: {integrity: sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==}
     peerDependencies:
-      svelte: ^3.55
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
       typescript: ^4.9.4 || ^5.0.0
     dependencies:
       dedent-js: 1.0.1

--- a/packages/skeleton/pnpm-lock.yaml
+++ b/packages/skeleton/pnpm-lock.yaml
@@ -8,26 +8,23 @@ dependencies:
   esm-env:
     specifier: 1.0.0
     version: 1.0.0
-  svelte:
-    specifier: 3.58.0
-    version: 3.58.0
 
 devDependencies:
   '@sveltejs/adapter-auto':
     specifier: 2.1.0
-    version: 2.1.0(@sveltejs/kit@1.20.2)
+    version: 2.1.0(@sveltejs/kit@1.20.4)
   '@sveltejs/kit':
-    specifier: 1.20.2
-    version: 1.20.2(svelte@3.58.0)(vite@4.3.9)
+    specifier: 1.20.4
+    version: 1.20.4(svelte@4.0.0)(vite@4.3.9)
   '@sveltejs/package':
     specifier: 2.0.2
-    version: 2.0.2(svelte@3.58.0)(typescript@5.0.3)
+    version: 2.0.2(svelte@4.0.0)(typescript@5.0.3)
   '@testing-library/dom':
     specifier: 9.3.0
     version: 9.3.0
   '@testing-library/svelte':
     specifier: 3.2.2
-    version: 3.2.2(svelte@3.58.0)
+    version: 3.2.2(svelte@4.0.0)
   '@typescript-eslint/eslint-plugin':
     specifier: 5.59.9
     version: 5.59.9(@typescript-eslint/parser@5.59.9)(eslint@8.42.0)(typescript@5.0.3)
@@ -47,8 +44,8 @@ devDependencies:
     specifier: 8.8.0
     version: 8.8.0(eslint@8.42.0)
   eslint-plugin-svelte:
-    specifier: ^2.30.0
-    version: 2.30.0(eslint@8.42.0)(svelte@3.58.0)
+    specifier: ^2.31.0
+    version: 2.31.0(eslint@8.42.0)(svelte@4.0.0)
   jsdom:
     specifier: 21.1.1
     version: 21.1.1
@@ -69,10 +66,13 @@ devDependencies:
     version: 2.8.8
   prettier-plugin-svelte:
     specifier: 2.10.1
-    version: 2.10.1(prettier@2.8.8)(svelte@3.58.0)
+    version: 2.10.1(prettier@2.8.8)(svelte@4.0.0)
+  svelte:
+    specifier: 4.0.0
+    version: 4.0.0
   svelte-check:
-    specifier: 3.4.3
-    version: 3.4.3(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@3.58.0)
+    specifier: 3.4.4
+    version: 3.4.4(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0)
   tailwindcss:
     specifier: 3.3.2
     version: 3.3.2
@@ -455,17 +455,17 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.2):
+  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.4):
     resolution: {integrity: sha512-o2pZCfATFtA/Gw/BB0Xm7k4EYaekXxaPGER3xGSY3FvzFJGTlJlZjBseaXwYSM94lZ0HniOjTokN3cWaLX6fow==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.20.2(svelte@3.58.0)(vite@4.3.9)
+      '@sveltejs/kit': 1.20.4(svelte@4.0.0)(vite@4.3.9)
       import-meta-resolve: 3.0.0
     dev: true
 
-  /@sveltejs/kit@1.20.2(svelte@3.58.0)(vite@4.3.9):
-    resolution: {integrity: sha512-MtR1i+HtmYWcRgtubw1GQqT/+CWXL/z24PegE0xYAdObbhdr7YtEfmoe705D/JZMtMmoPXrmSk4W0MfL5A3lYw==}
+  /@sveltejs/kit@1.20.4(svelte@4.0.0)(vite@4.3.9):
+    resolution: {integrity: sha512-MmAzIuMrP7A+8fqDVbxm6ekGHRHL/+Fk8sQPAzPG4G2TxUDtHdn/WcIxeEqHzARMf0OtGSC+VPyOSFuw2Cy2Mg==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true
@@ -473,7 +473,7 @@ packages:
       svelte: ^3.54.0 || ^4.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.1(svelte@3.58.0)(vite@4.3.9)
+      '@sveltejs/vite-plugin-svelte': 2.4.1(svelte@4.0.0)(vite@4.3.9)
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.3.1
@@ -484,15 +484,14 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.3
-      svelte: 3.58.0
-      tiny-glob: 0.2.9
+      svelte: 4.0.0
       undici: 5.22.1
       vite: 4.3.9(@types/node@20.1.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/package@2.0.2(svelte@3.58.0)(typescript@5.0.3):
+  /@sveltejs/package@2.0.2(svelte@4.0.0)(typescript@5.0.3):
     resolution: {integrity: sha512-cCOCcO8yMHnhHyaR51nQtvKZ3o/vSU9UYI1EXLT1j2CKNPMuH1/g6JNwKcNNrtQGwwquudc69ZeYy8D/TDNwEw==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -502,13 +501,13 @@ packages:
       chokidar: 3.5.3
       kleur: 4.1.5
       sade: 1.8.1
-      svelte: 3.58.0
-      svelte2tsx: 0.6.14(svelte@3.58.0)(typescript@5.0.3)
+      svelte: 4.0.0
+      svelte2tsx: 0.6.14(svelte@4.0.0)(typescript@5.0.3)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@1.0.2(@sveltejs/vite-plugin-svelte@2.4.1)(svelte@3.58.0)(vite@4.3.9):
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.2(@sveltejs/vite-plugin-svelte@2.4.1)(svelte@4.0.0)(vite@4.3.9):
     resolution: {integrity: sha512-Cy1dUMcYCnDVV/hPLXa43YZJ2jGKVW5rA0xuNL9dlmYhT0yoS1g7+FOFSRlgk0BXKk/Oc7grs+8BVA5Iz2fr8A==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -516,28 +515,28 @@ packages:
       svelte: ^3.54.0 || ^4.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.1(svelte@3.58.0)(vite@4.3.9)
+      '@sveltejs/vite-plugin-svelte': 2.4.1(svelte@4.0.0)(vite@4.3.9)
       debug: 4.3.4
-      svelte: 3.58.0
+      svelte: 4.0.0
       vite: 4.3.9(@types/node@20.1.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.4.1(svelte@3.58.0)(vite@4.3.9):
+  /@sveltejs/vite-plugin-svelte@2.4.1(svelte@4.0.0)(vite@4.3.9):
     resolution: {integrity: sha512-bNNKvoRY89ptY7udeBSCmTdCVwkjmMcZ0j/z9J5MuedT8jPjq0zrknAo/jF1sToAza4NVaAgR9AkZoD9oJJmnA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.2(@sveltejs/vite-plugin-svelte@2.4.1)(svelte@3.58.0)(vite@4.3.9)
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.2(@sveltejs/vite-plugin-svelte@2.4.1)(svelte@4.0.0)(vite@4.3.9)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.0
-      svelte: 3.58.0
-      svelte-hmr: 0.15.1(svelte@3.58.0)
+      svelte: 4.0.0
+      svelte-hmr: 0.15.1(svelte@4.0.0)
       vite: 4.3.9(@types/node@20.1.5)
       vitefu: 0.2.4(vite@4.3.9)
     transitivePeerDependencies:
@@ -572,14 +571,14 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/svelte@3.2.2(svelte@3.58.0):
+  /@testing-library/svelte@3.2.2(svelte@4.0.0):
     resolution: {integrity: sha512-IKwZgqbekC3LpoRhSwhd0JswRGxKdAGkf39UiDXTywK61YyLXbCYoR831e/UUC6EeNW4hiHPY+2WuovxOgI5sw==}
     engines: {node: '>= 10'}
     peerDependencies:
       svelte: 3.x
     dependencies:
       '@testing-library/dom': 8.20.0
-      svelte: 3.58.0
+      svelte: 4.0.0
     dev: true
 
   /@tootallnate/once@2.0.0:
@@ -603,6 +602,10 @@ packages:
 
   /@types/cookie@0.5.1:
     resolution: {integrity: sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==}
+    dev: true
+
+  /@types/estree@1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -905,6 +908,12 @@ packages:
       deep-equal: 2.2.1
     dev: true
 
+  /aria-query@5.2.1:
+    resolution: {integrity: sha512-7uFg4b+lETFgdaJyETnILsXgnnzVnkHcgRbwbPwevm5x/LmUlt3MjczMRe1zg824iBgXZNRPTBftNYyRSKLp2g==}
+    dependencies:
+      dequal: 2.0.3
+    dev: true
+
   /array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
     dependencies:
@@ -944,6 +953,12 @@ packages:
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
+    dev: true
+
+  /axobject-query@3.2.1:
+    resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
+    dependencies:
+      dequal: 2.0.3
     dev: true
 
   /balanced-match@1.0.2:
@@ -1097,6 +1112,16 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /code-red@1.0.3:
+    resolution: {integrity: sha512-kVwJELqiILQyG5aeuyKFbdsI1fmQy1Cmf7dQ8eGmVuJoaRVdwey7WaMknr2ZFeVSYSKT0rExsa8EGw0aoI/1QQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@types/estree': 1.0.1
+      acorn: 8.8.2
+      estree-walker: 3.0.3
+      periscopic: 3.1.0
+    dev: true
+
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
@@ -1164,6 +1189,14 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
+
+  /css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      mdn-data: 2.0.30
+      source-map-js: 1.0.2
     dev: true
 
   /cssesc@3.0.0:
@@ -1265,6 +1298,11 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+    dev: true
+
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
     dev: true
 
   /detect-indent@6.1.0:
@@ -1407,8 +1445,8 @@ packages:
       eslint: 8.42.0
     dev: true
 
-  /eslint-plugin-svelte@2.30.0(eslint@8.42.0)(svelte@3.58.0):
-    resolution: {integrity: sha512-2/qj0BJsfM0U2j4EjGb7iC/0nbUvXx1Gn78CdtyuXpi/rSomLPCPwnsZsloXMzlt6Xwe8LBlpRvZObSKEHLP5A==}
+  /eslint-plugin-svelte@2.31.0(eslint@8.42.0)(svelte@4.0.0):
+    resolution: {integrity: sha512-Q70jPFRraTkc/giPSfY7yuatmJcb5fPelWNplevqd45gfaJDjc3qXRtWQ6m9U5tWVVYERU9dcdUod294vwD8Gw==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0-0
@@ -1426,8 +1464,9 @@ packages:
       postcss: 8.4.24
       postcss-load-config: 3.1.4(postcss@8.4.24)
       postcss-safe-parser: 6.0.0(postcss@8.4.24)
-      svelte: 3.58.0
-      svelte-eslint-parser: 0.30.0(svelte@3.58.0)
+      postcss-selector-parser: 6.0.13
+      svelte: 4.0.0
+      svelte-eslint-parser: 0.31.0(svelte@4.0.0)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -1542,6 +1581,12 @@ packages:
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+    dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.1
     dev: true
 
   /esutils@2.0.3:
@@ -1724,10 +1769,6 @@ packages:
       type-fest: 0.20.2
     dev: true
 
-  /globalyzer@0.1.0:
-    resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
-    dev: true
-
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -1738,10 +1779,6 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
-    dev: true
-
-  /globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: true
 
   /gopd@1.0.1:
@@ -1984,6 +2021,12 @@ packages:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
     dev: true
 
+  /is-reference@3.0.1:
+    resolution: {integrity: sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==}
+    dependencies:
+      '@types/estree': 1.0.1
+    dev: true
+
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -2181,6 +2224,10 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+    dev: true
+
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2246,6 +2293,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       blueimp-md5: 2.19.0
+    dev: true
+
+  /mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
     dev: true
 
   /merge2@1.4.1:
@@ -2511,6 +2562,14 @@ packages:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
+  /periscopic@3.1.0:
+    resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 3.0.3
+      is-reference: 3.0.1
+    dev: true
+
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
@@ -2613,6 +2672,15 @@ packages:
       postcss: 8.4.24
     dev: true
 
+  /postcss-scss@4.0.6(postcss@8.4.24):
+    resolution: {integrity: sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.19
+    dependencies:
+      postcss: 8.4.24
+    dev: true
+
   /postcss-selector-parser@6.0.13:
     resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}
     engines: {node: '>=4'}
@@ -2644,14 +2712,14 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte@2.10.1(prettier@2.8.8)(svelte@3.58.0):
+  /prettier-plugin-svelte@2.10.1(prettier@2.8.8)(svelte@4.0.0):
     resolution: {integrity: sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
       prettier: 2.8.8
-      svelte: 3.58.0
+      svelte: 4.0.0
     dev: true
 
   /prettier@2.8.8:
@@ -2971,8 +3039,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svelte-check@3.4.3(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@3.58.0):
-    resolution: {integrity: sha512-O07soQFY3X0VDt+bcGc6D5naz0cLtjwnmNP9JsEBPVyMemFEqUhL2OdLqvkl5H/u8Jwm50EiAU4BPRn5iin/kg==}
+  /svelte-check@3.4.4(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0):
+    resolution: {integrity: sha512-Uys9+R65cj8TmP8f5UpS7B2xKpNLYNxEWJsA5ZoKcWq/uwvABFF7xS6iPQGLoa7hxz0DS6xU60YFpmq06E4JxA==}
     hasBin: true
     peerDependencies:
       svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0
@@ -2983,8 +3051,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 3.58.0
-      svelte-preprocess: 5.0.3(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@3.58.0)(typescript@5.0.3)
+      svelte: 4.0.0
+      svelte-preprocess: 5.0.3(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0)(typescript@5.0.3)
       typescript: 5.0.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -2998,8 +3066,8 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-eslint-parser@0.30.0(svelte@3.58.0):
-    resolution: {integrity: sha512-H0Cn2TKr70DU9p/Gb04CfwtS7eK28MYumrHYPaDNkIFbfwGDLADpbERBn7u8G1Rcm2RMr2/mL6mq0J2e8iKFlA==}
+  /svelte-eslint-parser@0.31.0(svelte@4.0.0):
+    resolution: {integrity: sha512-/31RpBf/e3YjoFphjsyo3JRyN1r4UalGAGafXrZ6EJK4h4COOO0rbfBoen5byGsXnIJKsrlC1lkEd2Vzpq2IDg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       svelte: ^3.37.0 || ^4.0.0-0
@@ -3010,19 +3078,21 @@ packages:
       eslint-scope: 7.2.0
       eslint-visitor-keys: 3.4.1
       espree: 9.5.2
-      svelte: 3.58.0
+      postcss: 8.4.24
+      postcss-scss: 4.0.6(postcss@8.4.24)
+      svelte: 4.0.0
     dev: true
 
-  /svelte-hmr@0.15.1(svelte@3.58.0):
+  /svelte-hmr@0.15.1(svelte@4.0.0):
     resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:
-      svelte: 3.58.0
+      svelte: 4.0.0
     dev: true
 
-  /svelte-preprocess@5.0.3(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@3.58.0)(typescript@5.0.3):
+  /svelte-preprocess@5.0.3(postcss-load-config@4.0.1)(postcss@8.4.24)(svelte@4.0.0)(typescript@5.0.3):
     resolution: {integrity: sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -3067,11 +3137,11 @@ packages:
       postcss-load-config: 4.0.1(postcss@8.4.24)
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 3.58.0
+      svelte: 4.0.0
       typescript: 5.0.3
     dev: true
 
-  /svelte2tsx@0.6.14(svelte@3.58.0)(typescript@5.0.3):
+  /svelte2tsx@0.6.14(svelte@4.0.0)(typescript@5.0.3):
     resolution: {integrity: sha512-Sxo9gtpc3dYWuFQ8fruZG+M+I6OZMIvOxxKjt48Lr8jD6Kr9cNf1Hf/yHUDEgDwQdRbAzn5y0FL9xk8Dx5v9lg==}
     peerDependencies:
       svelte: ^3.55
@@ -3079,13 +3149,28 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 3.58.0
+      svelte: 4.0.0
       typescript: 5.0.3
     dev: true
 
-  /svelte@3.58.0:
-    resolution: {integrity: sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==}
-    engines: {node: '>= 8'}
+  /svelte@4.0.0:
+    resolution: {integrity: sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.18
+      acorn: 8.8.2
+      aria-query: 5.2.1
+      axobject-query: 3.2.1
+      code-red: 1.0.3
+      css-tree: 2.3.1
+      estree-walker: 3.0.3
+      is-reference: 3.0.1
+      locate-character: 3.0.0
+      magic-string: 0.30.0
+      periscopic: 3.1.0
+    dev: true
 
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3152,13 +3237,6 @@ packages:
   /time-zone@1.0.0:
     resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
-    dev: true
-
-  /tiny-glob@0.2.9:
-    resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
-    dependencies:
-      globalyzer: 0.1.0
-      globrex: 0.1.2
     dev: true
 
   /tinybench@2.5.0:

--- a/packages/skeleton/pnpm-lock.yaml
+++ b/packages/skeleton/pnpm-lock.yaml
@@ -12,13 +12,13 @@ dependencies:
 devDependencies:
   '@sveltejs/adapter-auto':
     specifier: 2.1.0
-    version: 2.1.0(@sveltejs/kit@1.20.4)
+    version: 2.1.0(@sveltejs/kit@1.20.5)
   '@sveltejs/kit':
-    specifier: 1.20.4
-    version: 1.20.4(svelte@4.0.0)(vite@4.3.9)
+    specifier: 1.20.5
+    version: 1.20.5(svelte@4.0.0)(vite@4.3.9)
   '@sveltejs/package':
-    specifier: 2.0.2
-    version: 2.0.2(svelte@4.0.0)(typescript@5.0.3)
+    specifier: 2.1.0
+    version: 2.1.0(svelte@4.0.0)(typescript@5.0.3)
   '@testing-library/dom':
     specifier: 9.3.0
     version: 9.3.0
@@ -455,17 +455,17 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.4):
+  /@sveltejs/adapter-auto@2.1.0(@sveltejs/kit@1.20.5):
     resolution: {integrity: sha512-o2pZCfATFtA/Gw/BB0Xm7k4EYaekXxaPGER3xGSY3FvzFJGTlJlZjBseaXwYSM94lZ0HniOjTokN3cWaLX6fow==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.20.4(svelte@4.0.0)(vite@4.3.9)
+      '@sveltejs/kit': 1.20.5(svelte@4.0.0)(vite@4.3.9)
       import-meta-resolve: 3.0.0
     dev: true
 
-  /@sveltejs/kit@1.20.4(svelte@4.0.0)(vite@4.3.9):
-    resolution: {integrity: sha512-MmAzIuMrP7A+8fqDVbxm6ekGHRHL/+Fk8sQPAzPG4G2TxUDtHdn/WcIxeEqHzARMf0OtGSC+VPyOSFuw2Cy2Mg==}
+  /@sveltejs/kit@1.20.5(svelte@4.0.0)(vite@4.3.9):
+    resolution: {integrity: sha512-8rJYZ2boRlO75lwpbpB+DlSzIwmTuamXTpVlDtw4dBk86o3UaDe/+Ro4xCsV/4FtTw2U8xPHyV83edAWbQHG0w==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     requiresBuild: true
@@ -491,12 +491,12 @@ packages:
       - supports-color
     dev: true
 
-  /@sveltejs/package@2.0.2(svelte@4.0.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-cCOCcO8yMHnhHyaR51nQtvKZ3o/vSU9UYI1EXLT1j2CKNPMuH1/g6JNwKcNNrtQGwwquudc69ZeYy8D/TDNwEw==}
+  /@sveltejs/package@2.1.0(svelte@4.0.0)(typescript@5.0.3):
+    resolution: {integrity: sha512-c6PLH9G2YLQ48kqrS2XX422BrLNABBstSiapamchVJaQnOTXyJmUR8KmoCCySnzVy3PiYL6jg12UnoPmjW3SwA==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
-      svelte: ^3.44.0
+      svelte: ^3.44.0 || ^4.0.0
     dependencies:
       chokidar: 3.5.3
       kleur: 4.1.5

--- a/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
+++ b/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
@@ -10,7 +10,7 @@
 	// DISPATCHED: document directly above the definition, like props (ex: paginator)
 
 	import { getContext } from 'svelte';
-	import { createEventDispatcher } from 'svelte/internal';
+	import { createEventDispatcher } from 'svelte';
 	import type { Writable } from 'svelte/store';
 	import { slide } from 'svelte/transition';
 

--- a/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
+++ b/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
@@ -15,7 +15,10 @@
 	import { slide } from 'svelte/transition';
 
 	// Event Dispatcher
-	const dispatch = createEventDispatcher();
+	type AccordionItemEvent = {
+		toggle: { event?: Event; id: string; open: boolean; autocollapse: boolean };
+	};
+	const dispatch = createEventDispatcher<AccordionItemEvent>();
 
 	// Types
 	import type { CssClasses } from '../../index.js';

--- a/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
+++ b/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
@@ -21,7 +21,7 @@
 	const dispatch = createEventDispatcher<AccordionItemEvent>();
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	// Props (state)
 	/** Set open by default on load. */
@@ -69,7 +69,7 @@
 	export let regionCaret: CssClasses = getContext('regionCaret');
 
 	// Change open behavior based on auto-collapse mode
-	function setActive(event?: Event): void {
+	function setActive(event?: SvelteEvent<MouseEvent, HTMLButtonElement>): void {
 		if (autocollapse === true) {
 			// Set item active
 			active.set(id);
@@ -81,7 +81,7 @@
 		onToggle(event);
 	}
 
-	function onToggle(event?: Event): void {
+	function onToggle(event?: SvelteEvent<MouseEvent, HTMLButtonElement>): void {
 		const currentOpenState = autocollapse ? $active === id : open;
 		/** @event {{ event: Event, id: string, open: boolean, autocollapse: boolean }} toggle - Fires when an accordion item is toggled. */
 		dispatch('toggle', { event, id: `accordion-control-${id}`, open: currentOpenState, autocollapse });

--- a/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
@@ -38,7 +38,7 @@
 	$: classesLabel = `${cLabel} ${regionLabel}`;
 
 	// RestProps
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -66,6 +66,8 @@
 
 <label class="app-rail-tile {classesBase}" data-testid="app-rail-tile" {title} on:mouseover on:mouseleave on:focus on:blur>
 	<!-- A11y attributes are not allowed on <label> -->
+	<!-- TODO: Remove for V2 -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div class="app-rail-wrapper {classesWrapper}" on:keydown on:keyup on:keypress>
 		<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
 		<div class="h-0 w-0 overflow-hidden">

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -58,7 +58,7 @@
 	$: classesLabel = `${cLabel} ${regionLabel}`;
 
 	// RestProps
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -6,8 +6,11 @@
 	// Types
 	import type { AutocompleteOption } from './types.js';
 
-	// Custom Dispatcher
-	const dispatch = createEventDispatcher();
+	// Event Dispatcher
+	type AutocompleteEvent = {
+		selection: AutocompleteOption;
+	};
+	const dispatch = createEventDispatcher<AutocompleteEvent>();
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
+++ b/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
@@ -15,9 +15,9 @@
 	/** Provide the fallback image element source. */
 	export let fallback = '';
 	/**
-	 * Image only. Provide an Svelte action reference, such as `filter`.
+	 * Image only. Provide a Svelte action reference, such as `filter`.
 	 */
-	export let action: Action = () => {};
+	export let action: Action<HTMLElement, any> = () => {};
 	/** Image only. Provide Svelte action params, such as Apollo. */
 	export let actionParams = '';
 

--- a/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
+++ b/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
@@ -17,7 +17,7 @@
 	/**
 	 * Image only. Provide a Svelte action reference, such as `filter`.
 	 */
-	export let action: Action<HTMLElement, any> = () => {};
+	export let action: Action<HTMLElement, string> = () => {};
 	/** Image only. Provide Svelte action params, such as Apollo. */
 	export let actionParams = '';
 

--- a/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
+++ b/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
@@ -49,6 +49,8 @@
 	}
 </script>
 
+<!-- TODO: Remove for V2 -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <figure class="avatar {classesBase}" data-testid="avatar" on:click on:keydown on:keyup on:keypress>
 	{#if src}
 		<img

--- a/packages/skeleton/src/lib/components/ConicGradient/ConicGradient.svelte
+++ b/packages/skeleton/src/lib/components/ConicGradient/ConicGradient.svelte
@@ -95,6 +95,8 @@
 	{#if legend && generatedLegendList}
 		<ul class="conic-list list {classesLegend}">
 			{#each generatedLegendList as { color, label, value }}
+				<!-- TODO: Remove for V2 -->
+				<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 				<li class="conic-item {hover}" on:click on:keydown on:keyup on:keypress>
 					<span class="conic-swatch {cSwatch}" style:background={color} />
 					<span class="conic-label flex-auto">{label}</span>

--- a/packages/skeleton/src/lib/components/FileButton/FileButton.svelte
+++ b/packages/skeleton/src/lib/components/FileButton/FileButton.svelte
@@ -28,7 +28,7 @@
 		elemFileInput.click();
 	}
 
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/FileDropzone/FileDropzone.svelte
+++ b/packages/skeleton/src/lib/components/FileDropzone/FileDropzone.svelte
@@ -44,7 +44,7 @@
 	$: classesInterface = `${cInterface}`;
 
 	// Pruned RestProps
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, onMount } from 'svelte/internal';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import { fly, scale } from 'svelte/transition';
 	import { flip } from 'svelte/animate';
 

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -4,13 +4,13 @@
 	import { flip } from 'svelte/animate';
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	// Event Dispatcher
 	type InputChipEvent = {
-		add: { event: Event; chipIndex: number; chipValue: string };
-		remove: { event: Event; chipIndex: number; chipValue: string };
-		invalid: { event: Event; input: string };
+		add: { event: SubmitEvent; chipIndex: number; chipValue: string };
+		remove: { event: MouseEvent; chipIndex: number; chipValue: string };
+		invalid: { event: SubmitEvent; input: string };
 	};
 	const dispatch = createEventDispatcher<InputChipEvent>();
 
@@ -117,7 +117,7 @@
 		return true;
 	}
 
-	function addChip(event: Event): void {
+	function addChip(event: SvelteEvent<SubmitEvent, HTMLFormElement>): void {
 		event.preventDefault();
 		// Validate
 		inputValid = validate();
@@ -140,7 +140,7 @@
 		input = '';
 	}
 
-	function removeChip(event: Event, chipIndex: number, chipValue: string): void {
+	function removeChip(event: SvelteEvent<MouseEvent, HTMLButtonElement>, chipIndex: number, chipValue: string): void {
 		if ($$restProps.disabled) return;
 		// Remove value from array
 		value.splice(chipIndex, 1);

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -7,7 +7,12 @@
 	import type { CssClasses } from '../../index.js';
 
 	// Event Dispatcher
-	const dispatch = createEventDispatcher();
+	type InputChipEvent = {
+		add: { event: Event; chipIndex: number; chipValue: string };
+		remove: { event: Event; chipIndex: number; chipValue: string };
+		invalid: { event: Event; input: string };
+	};
+	const dispatch = createEventDispatcher<InputChipEvent>();
 
 	// Props
 	/** Bind the input value. */

--- a/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
@@ -8,7 +8,7 @@
 	import { getContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	// Props
 	/** Set the radio group binding value. */
@@ -78,7 +78,7 @@
 	}
 
 	// A11y Key Down Handler
-	function onKeyDown(event: KeyboardEvent): void {
+	function onKeyDown(event: SvelteEvent<KeyboardEvent, HTMLDivElement>): void {
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();
 			elemInput.click();

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -4,7 +4,12 @@
 	import type { CssClasses, PaginationSettings } from '../../index.js';
 	import { leftAngles, leftArrow, rightAngles, rightArrow } from './icons.js';
 
-	const dispatch = createEventDispatcher();
+	// Event Dispatcher
+	type PaginatorEvent = {
+		amount: number;
+		page: number;
+	};
+	const dispatch = createEventDispatcher<PaginatorEvent>();
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/Radio/RadioItem.svelte
+++ b/packages/skeleton/src/lib/components/Radio/RadioItem.svelte
@@ -2,7 +2,7 @@
 	import { getContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	// Props
 	/**
@@ -40,7 +40,7 @@
 	let elemInput: HTMLElement;
 
 	// A11y Key Down Handler
-	function onKeyDown(event: KeyboardEvent): void {
+	function onKeyDown(event: SvelteEvent<KeyboardEvent, HTMLDivElement>): void {
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();
 			elemInput.click();
@@ -54,7 +54,7 @@
 	$: classesBase = `${cBase} ${padding} ${rounded} ${classesActive} ${classesDisabled} ${$$props.class ?? ''}`;
 
 	// RestProps
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/RangeSlider/RangeSlider.svelte
+++ b/packages/skeleton/src/lib/components/RangeSlider/RangeSlider.svelte
@@ -63,7 +63,7 @@
 	$: classesInput = `${cBaseInput} ${accent}`;
 
 	// Prune $$restProps to avoid overwriting $$props.class
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
+++ b/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
@@ -6,7 +6,7 @@
 	 * @slot {{}} full - Provide a full rating icon.
 	 */
 
-	import { createEventDispatcher } from 'svelte/internal';
+	import { createEventDispatcher } from 'svelte';
 
 	// Types
 	import type { CssClasses } from '../../index.js';

--- a/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
+++ b/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
@@ -32,7 +32,10 @@
 	export let regionIcon: CssClasses = '';
 
 	// Event Dispatcher
-	const dispatch = createEventDispatcher();
+	type RatingsEvent = {
+		icon: { index: number };
+	};
+	const dispatch = createEventDispatcher<RatingsEvent>();
 
 	function iconClick(index: number): void {
 		/** @event {{ index: number  }} icon - Fires when an icons is clicked */

--- a/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
+++ b/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
@@ -21,7 +21,7 @@
 	 * @type {'sm' | 'md' | 'lg'}
 	 */
 	export let size = 'md';
-	/** Provide classe to set the inactive state background color. */
+	/** Provide classes to set the inactive state background color. */
 	export let background: CssClasses = 'bg-surface-400 dark:bg-surface-700';
 	/** Provide classes to set the active state background color. */
 	export let active: CssClasses = 'bg-surface-900 dark:bg-surface-300';

--- a/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
+++ b/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte/internal';
+	import { createEventDispatcher } from 'svelte';
 
 	// Types
 	import type { CssClasses } from '../../index.js';

--- a/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
+++ b/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
@@ -2,11 +2,11 @@
 	import { createEventDispatcher } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	// Event Dispatcher
 	type SlideToggleEvent = {
-		keyup: KeydownEvent;
+		keyup: SvelteEvent<KeyboardEvent, HTMLDivElement>;
 	};
 	const dispatch = createEventDispatcher<SlideToggleEvent>();
 
@@ -52,11 +52,8 @@
 		default: trackSize = 'w-16 h-8';
 	}
 
-	type KeydownEvent = KeyboardEvent & {
-		currentTarget: EventTarget & HTMLDivElement;
-	};
 	// A11y Input Handlers
-	function onKeyDown(event: KeydownEvent): void {
+	function onKeyDown(event: SvelteEvent<KeyboardEvent, HTMLDivElement>) {
 		// Enter/Space to toggle element
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();
@@ -80,7 +77,7 @@
 	$: classesThumb = `${cThumb} ${rounded} ${cThumbBackground} ${cThumbPos}`;
 
 	// Prune $$restProps to avoid overwriting $$props.class
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
+++ b/packages/skeleton/src/lib/components/SlideToggle/SlideToggle.svelte
@@ -4,8 +4,11 @@
 	// Types
 	import type { CssClasses } from '../../index.js';
 
-	// Event Handler
-	const dispatch = createEventDispatcher();
+	// Event Dispatcher
+	type SlideToggleEvent = {
+		keyup: KeydownEvent;
+	};
+	const dispatch = createEventDispatcher<SlideToggleEvent>();
 
 	// Props
 	/**
@@ -49,14 +52,18 @@
 		default: trackSize = 'w-16 h-8';
 	}
 
+	type KeydownEvent = KeyboardEvent & {
+		currentTarget: EventTarget & HTMLDivElement;
+	};
 	// A11y Input Handlers
-	function onKeyDown(event: any): void {
+	function onKeyDown(event: KeydownEvent): void {
 		// Enter/Space to toggle element
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();
 			/** @event {{ event }} keyup Fires when the component is focused and key is pressed. */
 			dispatch('keyup', event);
-			event.target.firstChild.click();
+			const inputElem = event.currentTarget.firstChild as HTMLLabelElement;
+			inputElem.click();
 		}
 	}
 

--- a/packages/skeleton/src/lib/components/Stepper/Step.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Step.svelte
@@ -12,7 +12,7 @@
 
 	// Types
 	import type { CssClasses } from '../../index.js';
-	import type { StepperDispatchParent, StepperState } from './types.js';
+	import type { StepperEventDispatcher, StepperState } from './types.js';
 
 	// Props
 	export let locked = false;
@@ -27,7 +27,7 @@
 
 	// Context
 	export let state: Writable<StepperState> = getContext('state');
-	export let dispatchParent: StepperDispatchParent = getContext('dispatchParent');
+	export let dispatchParent = getContext<StepperEventDispatcher>('dispatchParent');
 	export let stepTerm: string = getContext('stepTerm');
 	export let gap: CssClasses = getContext('gap');
 	export let justify: CssClasses = getContext('justify');

--- a/packages/skeleton/src/lib/components/Stepper/Stepper.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Stepper.svelte
@@ -5,10 +5,10 @@
 
 	// Types
 	import type { CssClasses } from '../../index.js';
-	import type { StepperButton, StepperDispatchParent, StepperState } from './types.js';
+	import type { StepperButton, StepperEvent, StepperState } from './types.js';
 
 	// Event Dispatcher
-	const dispatchParent: StepperDispatchParent = createEventDispatcher();
+	const dispatch = createEventDispatcher<StepperEvent>();
 
 	// Props
 	/** Provide classes to style the stepper header gap. */
@@ -65,7 +65,7 @@
 
 	// Context
 	setContext('state', state);
-	setContext('dispatchParent', dispatchParent);
+	setContext('dispatchParent', dispatch);
 	setContext('stepTerm', stepTerm);
 	setContext('gap', gap);
 	setContext('justify', justify);

--- a/packages/skeleton/src/lib/components/Stepper/types.ts
+++ b/packages/skeleton/src/lib/components/Stepper/types.ts
@@ -1,7 +1,15 @@
+import type { EventDispatcher } from 'svelte';
+
 export interface StepperState {
 	current: number;
 	total: number;
 }
 
 export type StepperButton = 'submit' | 'reset' | 'button';
-export type StepperDispatchParent = <EventKey extends string>(type: EventKey, detail: { step: number; state: StepperState }) => boolean;
+export type StepperEvent = {
+	next: { step: number; state: StepperState };
+	step: { step: number; state: StepperState };
+	back: { step: number; state: StepperState };
+	complete: { step: number; state: StepperState };
+};
+export type StepperEventDispatcher = EventDispatcher<StepperEvent>;

--- a/packages/skeleton/src/lib/components/Tab/Tab.svelte
+++ b/packages/skeleton/src/lib/components/Tab/Tab.svelte
@@ -105,7 +105,7 @@
 	$: classesTab = `${regionTab}`;
 
 	// RestProps
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/Tab/Tab.svelte
+++ b/packages/skeleton/src/lib/components/Tab/Tab.svelte
@@ -7,7 +7,7 @@
 	import { getContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	// Props
 	/**
@@ -58,7 +58,7 @@
 	let elemInput: HTMLElement;
 
 	// A11y Key Down Handler
-	function onKeyDown(event: KeyboardEvent): void {
+	function onKeyDown(event: SvelteEvent<KeyboardEvent, HTMLDivElement>): void {
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();
 			elemInput.click();

--- a/packages/skeleton/src/lib/components/Tab/TabAnchor.svelte
+++ b/packages/skeleton/src/lib/components/Tab/TabAnchor.svelte
@@ -41,7 +41,7 @@
 	$: classesInterface = `${cInterface} ${spacing}`;
 
 	// RestProps
-	function prunedRestProps(): any {
+	function prunedRestProps() {
 		delete $$restProps.class;
 		return $$restProps;
 	}

--- a/packages/skeleton/src/lib/components/Tab/TabGroup.svelte
+++ b/packages/skeleton/src/lib/components/Tab/TabGroup.svelte
@@ -60,6 +60,8 @@
 	$: classesPanel = `${cPanel} ${regionPanel}`;
 </script>
 
+<!-- TODO: Remove for V2 -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="tab-group {classesBase}" data-testid="tab-group" on:click on:keypress on:keydown on:keyup>
 	<!-- Tab List -->
 	<div class="tab-list {classesList}" role="tablist" aria-labelledby={labelledby}>

--- a/packages/skeleton/src/lib/components/Table/Table.svelte
+++ b/packages/skeleton/src/lib/components/Table/Table.svelte
@@ -4,7 +4,7 @@
 	import { tableA11y } from '../../utilities/DataTable/actions.js';
 
 	// Types
-	import type { CssClasses, TableSource } from '../../index.js';
+	import type { CssClasses, SvelteEvent, TableSource } from '../../index.js';
 
 	// Event Dispatcher
 	type TableEvent = {
@@ -42,7 +42,7 @@
 	export let regionFootCell: CssClasses = '';
 
 	// Row Click Handler
-	function onRowClick(event: MouseEvent | KeyboardEvent, rowIndex: number): void {
+	function onRowClick(event: SvelteEvent<MouseEvent | KeyboardEvent, HTMLTableRowElement>, rowIndex: number): void {
 		if (!interactive) return;
 		event.preventDefault();
 		event.stopPropagation();
@@ -53,7 +53,7 @@
 	}
 
 	// Row Keydown Handler
-	function onRowKeydown(event: KeyboardEvent, rowIndex: number): void {
+	function onRowKeydown(event: SvelteEvent<KeyboardEvent, HTMLTableRowElement>, rowIndex: number): void {
 		if (['Enter', 'Space'].includes(event.code)) onRowClick(event, rowIndex);
 	}
 

--- a/packages/skeleton/src/lib/components/Table/Table.svelte
+++ b/packages/skeleton/src/lib/components/Table/Table.svelte
@@ -6,7 +6,11 @@
 	// Types
 	import type { CssClasses, TableSource } from '../../index.js';
 
-	const dispatch = createEventDispatcher();
+	// Event Dispatcher
+	type TableEvent = {
+		selected: string[];
+	};
+	const dispatch = createEventDispatcher<TableEvent>();
 
 	// Props
 	/**

--- a/packages/skeleton/src/lib/components/TableOfContents/TableOfContents.svelte
+++ b/packages/skeleton/src/lib/components/TableOfContents/TableOfContents.svelte
@@ -139,6 +139,8 @@
 		<nav class="toc-list {classesList}">
 			<div class="toc-label {classesLabel}">{label}</div>
 			{#each filteredHeadingsList as headingElem}
+				<!-- TODO: Remove for V2 -->
+				<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 				<!-- prettier-ignore -->
 				<li
 					class="toc-list-item {classesListItem} {setHeadingClasses(headingElem)} {headingElem.id === activeHeaderId ? active : ''}"

--- a/packages/skeleton/src/lib/index.ts
+++ b/packages/skeleton/src/lib/index.ts
@@ -13,6 +13,7 @@ export type { PopupSettings } from './utilities/Popup/types.js';
 
 // This type alias is to identify CSS classes within component props, which enables Tailwind IntelliSense
 export type CssClasses = string;
+export type SvelteEvent<E extends Event = Event, T extends EventTarget = Element> = E & { currentTarget: EventTarget & T };
 
 // Stores ---
 

--- a/packages/skeleton/src/lib/utilities/CodeBlock/CodeBlock.svelte
+++ b/packages/skeleton/src/lib/utilities/CodeBlock/CodeBlock.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
-	// Event Handler
-	const dispatch = createEventDispatcher();
+	// Event Dispatcher
+	type CodeBlockEvent = {
+		copy: never;
+	};
+	const dispatch = createEventDispatcher<CodeBlockEvent>();
 
 	// Types
 	import type { CssClasses } from '../../index.js';
@@ -61,8 +64,8 @@
 		copyState = true;
 		// prettier-ignore
 		setTimeout(() => { copyState = false; }, 2000);
-		/** @event {{}} copy - Fires when the Copy button is pressed.  */
-		dispatch('copy', {});
+		/** @event {} copy - Fires when the Copy button is pressed.  */
+		dispatch('copy');
 	}
 
 	// Trigger syntax highlighting if highlight.js is available

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -169,6 +169,8 @@
 
 {#if $drawerStore.open === true}
 	<!-- Backdrop -->
+	<!-- TODO: Remove for V2 -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
 		bind:this={elemBackdrop}
 		class="drawer-backdrop {classesBackdrop}"

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -3,8 +3,12 @@
 	import { createEventDispatcher } from 'svelte';
 	import { BROWSER } from 'esm-env';
 
-	// Event Handler
-	const dispatch = createEventDispatcher();
+	// Event Dispatcher
+	type DrawerEvent = {
+		backdrop: MouseEvent;
+		drawer: MouseEvent;
+	};
+	const dispatch = createEventDispatcher<DrawerEvent>();
 
 	// Types
 	import type { CssClasses } from '../../index.js';

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -11,7 +11,7 @@
 	const dispatch = createEventDispatcher<DrawerEvent>();
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	// Actions
 	import { focusTrap } from '../../actions/FocusTrap/focusTrap.js';
@@ -131,7 +131,7 @@
 	}
 
 	// Input Handlers
-	function onDrawerInteraction(event: MouseEvent): void {
+	function onDrawerInteraction(event: SvelteEvent<MouseEvent, HTMLDivElement>): void {
 		if (event.target === elemBackdrop) {
 			drawerStore.close();
 			/** @event {{ event }} backdrop - Fires on backdrop interaction.  */
@@ -141,7 +141,7 @@
 			dispatch('drawer', event);
 		}
 	}
-	function onKeydownWindow(event: KeyboardEvent): void {
+	function onKeydownWindow(event: SvelteEvent<KeyboardEvent, Window>): void {
 		if (!$drawerStore) return;
 		if (event.code === 'Escape') drawerStore.close();
 	}

--- a/packages/skeleton/src/lib/utilities/LightSwitch/LightSwitch.svelte
+++ b/packages/skeleton/src/lib/utilities/LightSwitch/LightSwitch.svelte
@@ -3,8 +3,7 @@
 	import { modeCurrent, setModeUserPrefers, setModeCurrent, setInitialClassState, getModeOsPrefers } from './lightswitch.js';
 
 	// Types
-	import type { CssClasses } from '../../index.js';
-	type OnKeyDownEvent = KeyboardEvent & { currentTarget: EventTarget & HTMLDivElement };
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	// Props
 	/** Provide classes to set the light background color. */
@@ -43,7 +42,7 @@
 	}
 
 	// A11y Input Handlers
-	function onKeyDown(event: OnKeyDownEvent): void {
+	function onKeyDown(event: SvelteEvent<KeyboardEvent, HTMLDivElement>): void {
 		// Enter/Space triggers selection event
 		if (['Enter', 'Space'].includes(event.code)) {
 			event.preventDefault();

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -198,11 +198,11 @@
 			on:mouseup={onBackdropInteractionEnd}
 			on:touchstart
 			on:touchend
-			transition:fade={{ duration }}
+			transition:fade|global={{ duration }}
 			use:focusTrap={true}
 		>
 			<!-- Transition Layer -->
-			<div class="modal-transition {classesTransitionLayer}" transition:fly={{ duration, opacity: flyOpacity, x: flyX, y: flyY }}>
+			<div class="modal-transition {classesTransitionLayer}" transition:fly|global={{ duration, opacity: flyOpacity, x: flyX, y: flyY }}>
 				{#if $modalStore[0].type !== 'component'}
 					<!-- Modal: Presets -->
 					<div
@@ -211,7 +211,7 @@
 						role="dialog"
 						aria-modal="true"
 						aria-label={$modalStore[0].title ?? ''}
-						transition:fly={{ duration, opacity: 0, y: 100 }}
+						transition:fly|global={{ duration, opacity: 0, y: 100 }}
 					>
 						<!-- Header -->
 						{#if $modalStore[0]?.title}

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -194,6 +194,8 @@
 {#if $modalStore.length > 0}
 	{#key $modalStore}
 		<!-- Backdrop -->
+		<!-- TODO: Remove for V2 -->
+		<!-- svelte-ignore a11y-no-static-element-interactions -->
 		<div
 			class="modal-backdrop {classesBackdrop}"
 			data-testid="modal-backdrop"

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -9,7 +9,7 @@
 	const dispatch = createEventDispatcher<ModalEvent>();
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, SvelteEvent } from '../../index.js';
 
 	import { modalStore } from './stores.js';
 	import { focusTrap } from '../../actions/FocusTrap/focusTrap.js';
@@ -103,14 +103,14 @@
 	});
 
 	// Event Handlers ---
-	function onBackdropInteractionBegin(event: MouseEvent): void {
+	function onBackdropInteractionBegin(event: SvelteEvent<MouseEvent, HTMLDivElement>): void {
 		if (!(event.target instanceof Element)) return;
 		const classList = event.target.classList;
 		if (classList.contains('modal-backdrop') || classList.contains('modal-transition')) {
 			registeredInteractionWithBackdrop = true;
 		}
 	}
-	function onBackdropInteractionEnd(event: MouseEvent): void {
+	function onBackdropInteractionEnd(event: SvelteEvent<MouseEvent, HTMLDivElement>): void {
 		if (!(event.target instanceof Element)) return;
 		const classList = event.target.classList;
 		if ((classList.contains('modal-backdrop') || classList.contains('modal-transition')) && registeredInteractionWithBackdrop) {
@@ -133,7 +133,7 @@
 		modalStore.close();
 	}
 
-	function onPromptSubmit(event: SubmitEvent): void {
+	function onPromptSubmit(event: SvelteEvent<SubmitEvent, HTMLFormElement>): void {
 		event.preventDefault();
 		if ($modalStore[0].response) $modalStore[0].response(promptValue);
 		modalStore.close();
@@ -141,7 +141,7 @@
 
 	// A11y ---
 
-	function onKeyDown(event: KeyboardEvent): void {
+	function onKeyDown(event: SvelteEvent<KeyboardEvent, Window>): void {
 		if (!$modalStore.length) return;
 		if (event.code === 'Escape') onClose();
 	}

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -2,8 +2,11 @@
 	import { createEventDispatcher } from 'svelte';
 	import { fade, fly } from 'svelte/transition';
 
-	// Event Handler
-	const dispatch = createEventDispatcher();
+	// Event Dispatcher
+	type ModalEvent = {
+		backdrop: MouseEvent;
+	};
+	const dispatch = createEventDispatcher<ModalEvent>();
 
 	// Types
 	import type { CssClasses } from '../../index.js';

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -125,8 +125,8 @@
 			{#each filteredToasts as t, i (t)}
 				<div
 					animate:flip={{ duration }}
-					in:receive={{ key: t.id }}
-					out:send={{ key: t.id }}
+					in:receive|global={{ key: t.id }}
+					out:send|global={{ key: t.id }}
 					on:mouseenter={() => onMouseEnter(i)}
 					on:mouseleave={() => onMouseLeave(i)}
 				>

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -129,19 +129,18 @@
 					out:send|global={{ key: t.id }}
 					on:mouseenter={() => onMouseEnter(i)}
 					on:mouseleave={() => onMouseLeave(i)}
+					role={t.hideDismiss ? 'alert' : 'alertdialog'}
+					aria-live="polite"
 				>
 					<!-- Toast -->
-					<div
-						class="toast {classesToast} {t.background ?? background} {t.classes ?? ''}"
-						role="alert"
-						aria-live="polite"
-						data-testid="toast"
-					>
+					<div class="toast {classesToast} {t.background ?? background} {t.classes ?? ''}" data-testid="toast">
 						<div class="text-base">{@html t.message}</div>
 						{#if t.action || !t.hideDismiss}
 							<div class="toast-actions {cToastActions}">
 								{#if t.action}<button class={buttonAction} on:click={() => onAction(i)}>{@html t.action.label}</button>{/if}
-								{#if !t.hideDismiss}<button class={buttonDismiss} on:click={() => toastStore.close(t.id)}>{buttonDismissLabel}</button>{/if}
+								{#if !t.hideDismiss}<button class={buttonDismiss} aria-label="Dismiss toast" on:click={() => toastStore.close(t.id)}
+										>{buttonDismissLabel}</button
+									>{/if}
 							</div>
 						{/if}
 					</div>


### PR DESCRIPTION
## Linked Issue

Closes #1689 

## Description

Adds support for Svelte 4. Currently a WIP.

Current issues:
- [x] Updated all dependencies that now support Svelte 4
- [x] Performed a full audit making sure we cover everything from the [migration guide](https://svelte.dev/docs/v4-migration-guide)
- [x] Updated all component transitions
- [x] Fixed all import paths that targeted `svelte/internal` 
- [x] Added Svelte 3 and 4 as peer dependencies
- [x] Enhanced all types for custom dispatched events
- [x] Nuked some `any`'s from existence
- [x] Added a `SvelteEvent` utility type
- [x] There are 2 kinds of a11y warnings that comes with Svelte 4 that we should resolve before merging:
  - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md
  - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-interactions.md
- [x] Determine the lowest version of Svelte we want to support Svelte (v3.56.0)

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
