### PR TITLE
bugfix: Enhanced types for the clipboard action

### DIFF
--- a/.changeset/breezy-kings-type.md
+++ b/.changeset/breezy-kings-type.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Enhanced types for the `clipboard` action.

--- a/.changeset/breezy-kings-type.md
+++ b/.changeset/breezy-kings-type.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: Enhanced types for the `clipboard` action.
+bugfix: Enhanced types for the `clipboard` action

--- a/packages/skeleton/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
+++ b/packages/skeleton/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
@@ -1,5 +1,5 @@
 declare namespace svelteHTML {
-	interface HTMLAttributes<T> {
+	interface HTMLAttributes {
 		'on:copyComplete'?: () => void;
 	}
 }

--- a/packages/skeleton/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
+++ b/packages/skeleton/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
@@ -1,5 +1,5 @@
 declare namespace svelteHTML {
 	interface HTMLAttributes<T> {
-		'on:copyComplete'?: (event: any) => any;
+		'on:copyComplete'?: () => void;
 	}
 }


### PR DESCRIPTION
## Description

Made the clipboard action just a little more typesafe.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
