### PR TITLE
bugfix: Enhanced types for the filter action

### DIFF
--- a/.changeset/two-donuts-remember.md
+++ b/.changeset/two-donuts-remember.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Enhanced types for the `filter` action

--- a/packages/skeleton/.eslintrc.cjs
+++ b/packages/skeleton/.eslintrc.cjs
@@ -35,6 +35,8 @@ module.exports = {
 		],
 
 		'no-empty-function': 'off',
-		'@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }]
+		'@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
+
+		'@typescript-eslint/ban-types': ['error', { '{}': false }]
 	}
 };

--- a/packages/skeleton/.eslintrc.cjs
+++ b/packages/skeleton/.eslintrc.cjs
@@ -37,6 +37,6 @@ module.exports = {
 		'no-empty-function': 'off',
 		'@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
 
-		'@typescript-eslint/ban-types': ['error', { '{}': false }]
+		'@typescript-eslint/ban-types': ['error', { types: { '{}': false }, extendDefaults: true }]
 	}
 };

--- a/packages/skeleton/src/lib/actions/Filters/filter.test.ts
+++ b/packages/skeleton/src/lib/actions/Filters/filter.test.ts
@@ -26,16 +26,15 @@ describe('Actions: Filter', () => {
 		render(GreenFall);
 		render(NoirLight);
 		render(Noir);
-		const elements: HTMLCollection = document.getElementsByClassName('filter');
+		const elements = document.getElementsByClassName('filter');
 		for (const element of elements) {
-			const el: any = element;
-			expect(el.getAttribute('class').includes('filter'));
+			expect(element.getAttribute('class')?.includes('filter'));
 		}
 	});
 
 	it('Test the node gets the filter url', async () => {
-		const elem: any = document.createElement('div');
+		const elem = document.createElement('div');
 		filter(elem, 'XPro');
-		expect(elem.getAttribute('style').includes('filter: url("#Emerald")'));
+		expect(elem.getAttribute('style')?.includes('filter: url("#Emerald")'));
 	});
 });

--- a/packages/skeleton/src/lib/actions/Filters/filter.ts
+++ b/packages/skeleton/src/lib/actions/Filters/filter.ts
@@ -1,6 +1,9 @@
 // Action: Filter
 
-export function filter(node: HTMLElement, filterName: string) {
+type Filters = ['Apollo', 'BlueNight', 'Emerald', 'GreenFall', 'Noir', 'NoirLight', 'Rustic', 'Summer84', 'XPro'];
+type FilterName = `#${Filters[number]}` | (string & {});
+
+export function filter(node: HTMLElement, filterName: FilterName) {
 	// Return if no filterName provided
 	if (filterName === undefined) return;
 
@@ -10,7 +13,7 @@ export function filter(node: HTMLElement, filterName: string) {
 	applyFilter();
 
 	return {
-		update(newArgs: any) {
+		update(newArgs: FilterName) {
 			filterName = newArgs;
 			applyFilter();
 		}

--- a/packages/skeleton/src/lib/actions/Filters/filter.ts
+++ b/packages/skeleton/src/lib/actions/Filters/filter.ts
@@ -1,6 +1,8 @@
 // Action: Filter
 
 type Filters = ['Apollo', 'BlueNight', 'Emerald', 'GreenFall', 'Noir', 'NoirLight', 'Rustic', 'Summer84', 'XPro'];
+// This type allows users to get the autocomplete option for our
+// filter presets while also permitting them into adding their own filter.
 type FilterName = `#${Filters[number]}` | (string & {});
 
 export function filter(node: HTMLElement, filterName: FilterName) {

--- a/packages/skeleton/src/lib/components/Avatar/Avatar.test.ts
+++ b/packages/skeleton/src/lib/components/Avatar/Avatar.test.ts
@@ -30,8 +30,8 @@ describe('Avatar.svelte', () => {
 
 	it('Image shown when src prop set', async () => {
 		const { getByTestId } = render(Avatar, { props: { src: imgTextSrc } });
-		const elemImage: any = getByTestId('avatar').querySelector('.avatar-image');
-		expect(elemImage.src).to.eq(imgTextSrc);
+		const elemImage = getByTestId('avatar').querySelector<HTMLImageElement>('.avatar-image');
+		expect(elemImage?.src).to.eq(imgTextSrc);
 	});
 
 	it('Initials shown when no image source provided', async () => {

--- a/packages/skeleton/src/lib/components/Stepper/Step.test.ts
+++ b/packages/skeleton/src/lib/components/Stepper/Step.test.ts
@@ -1,11 +1,11 @@
 import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 
-import { writable, type Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 
 import Step from '$lib/components/Stepper/Step.svelte';
 
-const mockState: Writable<any> = writable({ current: 1, total: 1 }); // NOTE: current/total must match!
+const mockState = writable({ current: 1, total: 1 }); // NOTE: current/total must match!
 
 describe('Step.svelte', () => {
 	it('Renders with mininal props', async () => {


### PR DESCRIPTION
## Description

Filter names are now typesafe.

Note the following type:
```ts 
type FilterName = `#${Filters[number]}` | (string & {});
``` 
This allows users to get the autocomplete option for our filter presets while also permitting them into adding their own filter if they created one.

I also fixed the types for 2 tests, just to finally get rid of their warnings too.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
