### PR TITLE
bugfix: scroll to top of modal, when modal is bigger than view

### DIFF
--- a/.changeset/witty-pigs-wave.md
+++ b/.changeset/witty-pigs-wave.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: fixed Scroll to the top of the modal, when the modal is bigger than the view.

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -71,8 +71,8 @@
 	export let regionFooter: CssClasses = 'flex justify-end space-x-2';
 
 	// Base Styles
-	const cBackdrop = 'fixed top-0 left-0 right-0 bottom-0';
-	const cTransitionLayer = 'w-full h-full p-4 overflow-y-auto flex justify-center';
+	const cBackdrop = 'fixed top-0 left-0 right-0 bottom-0 overflow-y-auto';
+	const cTransitionLayer = 'w-full h-fit min-h-full p-4 overflow-y-auto flex justify-center';
 	const cModal = 'block'; // max-h-full overflow-y-auto overflow-x-hidden
 	const cModalImage = 'w-full h-auto';
 

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -76,7 +76,7 @@
 	// Base Styles
 	const cBackdrop = 'fixed top-0 left-0 right-0 bottom-0 overflow-y-auto';
 	const cTransitionLayer = 'w-full h-fit min-h-full p-4 overflow-y-auto flex justify-center';
-	const cModal = 'block'; // max-h-full overflow-y-auto overflow-x-hidden
+	const cModal = 'block overflow-y-auto'; // max-h-full overflow-y-auto overflow-x-hidden
 	const cModalImage = 'w-full h-auto';
 
 	// Local


### PR DESCRIPTION
## Linked Issue

Closes #1683

## Description

Fixed the bug using the code [suggestion](https://github.com/skeletonlabs/skeleton/issues/1683#issuecomment-1599617938)

## Changsets

bugfix: fixed Scroll to the top of the modal, when the modal is bigger than the view.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
