### PR TITLE
RadioGroup vertical spacing fix

### DIFF
--- a/.changeset/clean-carrots-nail.md
+++ b/.changeset/clean-carrots-nail.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: removed horizontal space on vertical radio group.

--- a/packages/skeleton/src/lib/components/Radio/RadioGroup.svelte
+++ b/packages/skeleton/src/lib/components/Radio/RadioGroup.svelte
@@ -12,7 +12,7 @@
 	/** Provide classes to set the border styles. */
 	export let border: CssClasses = 'border-token border-surface-400-500-token';
 	/** Provide classes horizontal spacing between items. */
-	export let spacing: CssClasses = 'space-x-1';
+	export let spacing: CssClasses = '';
 	/** Provide classes to set the border radius. */
 	export let rounded: CssClasses = 'rounded-token';
 
@@ -44,6 +44,8 @@
 	const cBase = 'p-1';
 
 	// Reactive
+	// display space-x only on row flex as it is not needed on column flex.
+	$: spacing = `${display.includes('flex-col') ? '' : 'space-x-1'}`;
 	$: classesBase = `${cBase} ${display} ${background} ${border} ${spacing} ${rounded} ${$$props.class ?? ''}`;
 </script>
 


### PR DESCRIPTION
## Linked Issue

Closes #1672

## Description

display space-x only on row flex as it is not needed on column flex

## Changsets

bugfix: removed horizontal space on vertical radio group.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
