### PR TITLE
bugfix/paginator-buttons-accessiblilty

### DIFF
--- a/.changeset/great-seals-march.md
+++ b/.changeset/great-seals-march.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: paginator buttons are now accessible.

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -70,6 +70,16 @@
 	 */
 	export let buttonTextLast: CssClasses = rightAngles;
 
+	// Props (A11y)
+	/** Provide the ARIA label for the First page button. */
+	export let labelFirst = 'First page';
+	/** Provide the ARIA label for the Previous page button. */
+	export let labelPrevious = 'Previous page';
+	/** Provide the ARIA label for the Next page button. */
+	export let labelNext = 'Next page';
+	/** Provide the ARIA label for the Last page button. */
+	export let labelLast = 'Last page';
+
 	// Base Classes
 	const cBase = 'flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4';
 	const cLabel = 'w-full md:w-auto';
@@ -168,7 +178,7 @@
 		{#if showFirstLastButtons}
 			<button
 				type="button"
-				aria-label="First page"
+				aria-label={labelFirst}
 				class={buttonClasses}
 				on:click={() => {
 					gotoPage(0);
@@ -182,7 +192,7 @@
 		{#if showPreviousNextButtons}
 			<button
 				type="button"
-				aria-label="Previous page"
+				aria-label={labelPrevious}
 				class={buttonClasses}
 				on:click={() => {
 					gotoPage(settings.offset - 1);
@@ -212,7 +222,7 @@
 		{#if showPreviousNextButtons}
 			<button
 				type="button"
-				aria-label="Next page"
+				aria-label={labelNext}
 				class={buttonClasses}
 				on:click={() => {
 					gotoPage(settings.offset + 1);
@@ -226,7 +236,7 @@
 		{#if showFirstLastButtons}
 			<button
 				type="button"
-				aria-label="Last page"
+				aria-label={labelLast}
 				class={buttonClasses}
 				on:click={() => {
 					gotoPage(lastPage);

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -168,6 +168,7 @@
 		{#if showFirstLastButtons}
 			<button
 				type="button"
+				aria-label="First page"
 				class={buttonClasses}
 				on:click={() => {
 					gotoPage(0);
@@ -181,6 +182,7 @@
 		{#if showPreviousNextButtons}
 			<button
 				type="button"
+				aria-label="Previous page"
 				class={buttonClasses}
 				on:click={() => {
 					gotoPage(settings.offset - 1);
@@ -210,6 +212,7 @@
 		{#if showPreviousNextButtons}
 			<button
 				type="button"
+				aria-label="Next page"
 				class={buttonClasses}
 				on:click={() => {
 					gotoPage(settings.offset + 1);
@@ -223,6 +226,7 @@
 		{#if showFirstLastButtons}
 			<button
 				type="button"
+				aria-label="Last page"
 				class={buttonClasses}
 				on:click={() => {
 					gotoPage(lastPage);


### PR DESCRIPTION
## Linked Issue

Closes #1707

## Description

Added aria-label to icon buttons (first, previous, next, last)

## Changsets

bugfix: paginator buttons are now accessible.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
