### PR TITLE
feat: stepper complete button visibility

### DIFF
--- a/.changeset/curly-pillows-check.md
+++ b/.changeset/curly-pillows-check.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: `Stepper's` complete button can be set visible before the last step.

--- a/packages/skeleton/src/lib/components/Stepper/Step.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Step.svelte
@@ -40,6 +40,7 @@
 	export let buttonComplete: CssClasses = getContext('buttonComplete');
 	export let buttonCompleteType: 'submit' | 'reset' | 'button' = getContext('buttonCompleteType');
 	export let buttonCompleteLabel: string = getContext('buttonCompleteLabel');
+	export let buttonCompleteVisible: boolean = getContext('buttonCompleteVisible');
 
 	// Register step on init (keep these paired)
 	const stepIndex = $state.total;
@@ -58,6 +59,7 @@
 
 		if (locked) return;
 		$state.current++;
+
 		/** @event { $state } next - Fires when the NEXT button is pressed per step.  */
 		dispatchParent('next', { step: stepIndex, state: $state });
 		dispatchParent('step', { step: stepIndex, state: $state });
@@ -109,24 +111,27 @@
 						{@html buttonBackLabel}
 					</button>
 				{/if}
-				{#if stepIndex < $state.total - 1}
-					<!-- Button: Next -->
-					<button type={buttonNextType} class="btn {buttonNext}" on:click={onNext} disabled={locked}>
-						{#if locked}
-							<svg class="w-3 aspect-square" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
-								<path
-									d="M144 144v48H304V144c0-44.2-35.8-80-80-80s-80 35.8-80 80zM80 192V144C80 64.5 144.5 0 224 0s144 64.5 144 144v48h16c35.3 0 64 28.7 64 64V448c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V256c0-35.3 28.7-64 64-64H80z"
-								/>
-							</svg>
-						{/if}
-						<span>{@html buttonNextLabel}</span>
-					</button>
-				{:else}
-					<!-- Button: Complete -->
-					<button type={buttonCompleteType} class="btn {buttonComplete}" on:click={onComplete} disabled={locked}>
-						{@html buttonCompleteLabel}
-					</button>
-				{/if}
+				<div>
+					{#if stepIndex < $state.total - 1}
+						<!-- Button: Next -->
+						<button type={buttonNextType} class="btn {buttonNext}" on:click={onNext} disabled={locked}>
+							{#if locked}
+								<svg class="w-3 aspect-square" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+									<path
+										d="M144 144v48H304V144c0-44.2-35.8-80-80-80s-80 35.8-80 80zM80 192V144C80 64.5 144.5 0 224 0s144 64.5 144 144v48h16c35.3 0 64 28.7 64 64V448c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V256c0-35.3 28.7-64 64-64H80z"
+									/>
+								</svg>
+							{/if}
+							<span>{@html buttonNextLabel}</span>
+						</button>
+					{/if}
+					{#if stepIndex === $state.total - 1 || buttonCompleteVisible}
+						<!-- Button: Complete -->
+						<button type={buttonCompleteType} class="btn {buttonComplete}" on:click={onComplete} disabled={locked}>
+							{@html buttonCompleteLabel}
+						</button>
+					{/if}
+				</div>
 			</div>
 		{/if}
 	</div>

--- a/packages/skeleton/src/lib/components/Stepper/Stepper.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Stepper.svelte
@@ -53,6 +53,8 @@
 	export let buttonCompleteType: StepperButton = 'button';
 	/** Provide the HTML label content for the complete button. */
 	export let buttonCompleteLabel = 'Complete';
+	/** Set this prop to make the complete button visible. It is autoset on last step */
+	export let buttonCompleteVisible = false;
 
 	// Props (regions)
 	/** Provide arbitrary classes to the stepper header region. */
@@ -81,6 +83,7 @@
 	setContext('buttonComplete', buttonComplete);
 	setContext('buttonCompleteType', buttonCompleteType);
 	setContext('buttonCompleteLabel', buttonCompleteLabel);
+	setContext('buttonCompleteVisible', buttonCompleteVisible);
 
 	// Classes
 	const cBase = 'space-y-4';

--- a/sites/skeleton.dev/src/routes/(inner)/components/steppers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/steppers/+page.svelte
@@ -29,7 +29,8 @@
 					'buttonNext',
 					'buttonNextLabel',
 					'buttonComplete',
-					'buttonCompleteLabel'
+					'buttonCompleteLabel',
+					'buttonCompleteVisible'
 				]
 			}
 		]
@@ -189,6 +190,32 @@
 			<p>
 				This can be overwritten per each Step as well, which updates the <em>default</em> and <em>header</em> slot placeholder text.
 			</p>
+		</section>
+		<!-- Complete Button Visibility -->
+		<section class="space-y-4">
+			<h2 class="h2">Complete Button Visibility</h2>
+			<p>
+				In some cases, like when the rest of the steps are optional, you might want to make the <code class="code">complete</code> button
+				visible. This can be achieved by setting the prop <code class="code">completeButtonVisible</code>.
+			</p>
+			<p>Note: The value of <code class="code">completeButtonVisible</code> is ignored on last step.</p>
+			<CodeBlock
+				language="html"
+				code={`
+<!-- required step -->
+<Step>...</Step>
+<!-- required step -->
+<Step>...</Step>
+
+<!-- optional step -->
+<Step completeButtonVisible={true}>...</Step>
+<!-- optional step -->
+<Step completeButtonVisible={true}>...</Step>
+
+<!-- optional step, last step -->
+<Step>...</Step>
+			`}
+			/>
 		</section>
 		<!-- Navigation Slot -->
 		<section class="space-y-4">

--- a/sites/skeleton.dev/src/routes/(inner)/components/steppers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/steppers/+page.svelte
@@ -196,9 +196,9 @@
 			<h2 class="h2">Complete Button Visibility</h2>
 			<p>
 				In some cases, like when the rest of the steps are optional, you might want to make the <code class="code">complete</code> button
-				visible. This can be achieved by setting the prop <code class="code">completeButtonVisible</code>.
+				visible. This can be achieved by setting the prop <code class="code">buttonCompleteVisible</code>.
 			</p>
-			<p>Note: The value of <code class="code">completeButtonVisible</code> is ignored on last step.</p>
+			<p>Note: The value of <code class="code">buttonCompleteVisible</code> is ignored on last step.</p>
 			<CodeBlock
 				language="html"
 				code={`
@@ -208,9 +208,9 @@
 <Step>...</Step>
 
 <!-- optional step -->
-<Step completeButtonVisible={true}>...</Step>
+<Step buttonCompleteVisible={true}>...</Step>
 <!-- optional step -->
-<Step completeButtonVisible={true}>...</Step>
+<Step buttonCompleteVisible={true}>...</Step>
 
 <!-- optional step, last step -->
 <Step>...</Step>


### PR DESCRIPTION
## Linked Issue

Closes #1644

## Description

Added prop `completeButtonVisible`, so users can set it to make the button visible before the last step.

## Changsets

feat: `Stepper's` complete button can be set visible before the last step.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
