### PR TITLE
bugfix/closed-popup-focus

### DIFF
--- a/.changeset/tall-days-shop.md
+++ b/.changeset/tall-days-shop.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: `Popup` content is not interactable when closed.

--- a/packages/skeleton/src/lib/utilities/Popup/popup.ts
+++ b/packages/skeleton/src/lib/utilities/Popup/popup.ts
@@ -104,6 +104,8 @@ export function popup(triggerNode: HTMLElement, args: PopupSettings) {
 		elemPopup.style.display = 'block';
 		elemPopup.style.opacity = '1';
 		elemPopup.style.pointerEvents = 'auto';
+		// enable popup interactions
+		elemPopup.removeAttribute('inert');
 		// Trigger Floating UI autoUpdate (open only)
 		// https://floating-ui.com/docs/autoUpdate
 		popupState.autoUpdateCleanup = autoUpdate(triggerNode, elemPopup, render);
@@ -121,7 +123,8 @@ export function popup(triggerNode: HTMLElement, args: PopupSettings) {
 			if (args.state) args.state({ state: popupState.open });
 			// Update the DOM
 			elemPopup.style.opacity = '0';
-			elemPopup.style.pointerEvents = 'none';
+			// disable popup interactions
+			elemPopup.setAttribute('inert', '');
 			// Cleanup Floating UI autoUpdate (close only)
 			if (popupState.autoUpdateCleanup) popupState.autoUpdateCleanup();
 			// Trigger callback


### PR DESCRIPTION
## Linked Issue

Closes #1713 

## Description

Added inert attribute to popup content when closed and removed it when opened.

## Changsets

bugfix: `Popup` content is not interactable when closed.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
