### PR TITLE
Bugfix/autocomplete-allowed-options

### DIFF
--- a/.changeset/two-spoons-cheer.md
+++ b/.changeset/two-spoons-cheer.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Autocomplete `allowedlist`.

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -61,23 +61,20 @@
 	// Local
 	$: listedOptions = options;
 
-	// Allowed Options
-	function filterByAllowed(): void {
+	function filterByAllowDeny() {
+		// Allowed Options
 		if (allowlist.length) {
 			listedOptions = [...options].filter((option: AutocompleteOption) => allowlist.includes(option.value));
-		} else {
-			// IMPORTANT: required if the list goes from populated -> empty
-			listedOptions = [...options];
 		}
-	}
 
-	// Denied Options
-	function filterByDenied(): void {
+		// Denied Options
 		if (denylist.length) {
 			const denySet = new Set(denylist);
 			listedOptions = [...options].filter((option: AutocompleteOption) => !denySet.has(option.value));
-		} else {
-			// IMPORTANT: required if the list goes from populated -> empty
+		}
+
+		// Reset options
+		if (!allowlist.length && !denylist.length) {
 			listedOptions = [...options];
 		}
 	}
@@ -103,8 +100,7 @@
 	}
 
 	// State
-	$: if (allowlist) filterByAllowed();
-	$: if (denylist) filterByDenied();
+	$: if (allowlist || denylist) filterByAllowDeny();
 	$: optionsFiltered = input ? filterOptions() : listedOptions;
 	$: sliceLimit = limit !== undefined ? limit : optionsFiltered.length;
 	// Reactive

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -62,28 +62,30 @@
 	$: listedOptions = options;
 
 	function filterByAllowDeny() {
+		let _options = [...options];
 		// Allowed Options
 		if (allowlist.length) {
-			listedOptions = [...options].filter((option: AutocompleteOption) => allowlist.includes(option.value));
+			_options = _options.filter((option) => allowlist.includes(option.value));
 		}
 
 		// Denied Options
 		if (denylist.length) {
-			const denySet = new Set(denylist);
-			listedOptions = [...options].filter((option: AutocompleteOption) => !denySet.has(option.value));
+			_options = _options.filter((option) => !denylist.includes(option.value));
 		}
 
 		// Reset options
 		if (!allowlist.length && !denylist.length) {
-			listedOptions = [...options];
+			_options = options;
 		}
+
+		listedOptions = _options;
 	}
 
 	function filterOptions(): AutocompleteOption[] {
 		// Create a local copy of options
 		let _options = [...listedOptions];
 		// Filter options
-		_options = _options.filter((option: AutocompleteOption) => {
+		_options = _options.filter((option) => {
 			// Format the input search value
 			const inputFormatted = String(input).toLowerCase().trim();
 			// Format the option
@@ -100,7 +102,7 @@
 	}
 
 	// State
-	$: if (allowlist || denylist) filterByAllowDeny();
+	$: if (allowlist.length || denylist.length) filterByAllowDeny();
 	$: optionsFiltered = input ? filterOptions() : listedOptions;
 	$: sliceLimit = limit !== undefined ? limit : optionsFiltered.length;
 	// Reactive


### PR DESCRIPTION
## Linked Issue

Closes #1723

## Description

After filtering the list by `allowedList`, It's value will reset by the `denyList` logic only if the `denyList` is empty.

### Solution

Checking for both `allowedList` and `DenyList` before resetting the list will solve the issue without side effects.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

bugfix: Autocomplete `allowedlist`.

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
