### PR TITLE
bugfix: fix a11y warning in Ratings component

### DIFF
--- a/.changeset/big-ligers-rest.md
+++ b/.changeset/big-ligers-rest.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Fix accessibility warning in Ratings component due to applied `on:click` for non-interactive elements.

--- a/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
+++ b/packages/skeleton/src/lib/components/Ratings/Ratings.svelte
@@ -46,30 +46,44 @@
 		});
 	}
 
+	function isFull(value: number, index: number) {
+		return Math.floor(value) >= index + 1;
+	}
+
+	function isHalf(value: number, index: number) {
+		return value === index + 0.5;
+	}
+
 	// Classes
 	const cBase = 'w-full flex';
 
 	// Reactive
-	$: elemInteractive = interactive ? 'button' : 'span';
-	$: attrInteractive = interactive ? { type: 'button' } : {};
 	$: classesBase = `${cBase} ${text} ${fill} ${justify} ${spacing} ${$$props.class ?? ''}`;
 </script>
 
 <div class="ratings {classesBase}" data-testid="rating-bar">
 	<!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
 	{#each Array(max) as _, i}
-		{#if Math.floor(value) >= i + 1}
-			<svelte:element this={elemInteractive} {...attrInteractive} class="rating-icon {regionIcon}" on:click={() => iconClick(i)}>
-				<slot name="full" />
-			</svelte:element>
-		{:else if value === i + 0.5}
-			<svelte:element this={elemInteractive} {...attrInteractive} class="rating-icon {regionIcon}" on:click={() => iconClick(i)}>
-				<slot name="half" />
-			</svelte:element>
+		{#if interactive}
+			<button class="rating-icon {regionIcon}" type="button" on:click={() => iconClick(i)}>
+				{#if isFull(value, i)}
+					<slot name="full" />
+				{:else if isHalf(value, i)}
+					<slot name="half" />
+				{:else}
+					<slot name="empty" />
+				{/if}
+			</button>
 		{:else}
-			<svelte:element this={elemInteractive} {...attrInteractive} class="rating-icon {regionIcon}" on:click={() => iconClick(i)}>
-				<slot name="empty" />
-			</svelte:element>
+			<span class="rating-icon {regionIcon}">
+				{#if isFull(value, i)}
+					<slot name="full" />
+				{:else if isHalf(value, i)}
+					<slot name="half" />
+				{:else}
+					<slot name="empty" />
+				{/if}
+			</span>
 		{/if}
 	{/each}
 </div>


### PR DESCRIPTION
## Description

Before this fix, the following warning occurred:

    A11y: <svelte:element> with click handler must have an ARIA role

This was an issue because the `on:click` binding was always applied, even when the element would be not interactive (a `span`).

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
