### PR TITLE
docs/theme-generator-invalid-rgb

### DIFF
--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
@@ -36,11 +36,34 @@
 		roundedContainer: '8px',
 		borderBase: '1px'
 	});
+	resetColorOnInvalidHex();
 
 	// Local
 	let cssOutput = '';
 	let showThemeCSS = false;
 	let conReports: ContrastReport[] = getContrastReports();
+
+	// only called when initializing the component to avoid color errors.
+	// must be called before onMount.
+	function resetColorOnInvalidHex() {
+		const colorMapping = {
+			primary: '#0FBA81',
+			secondary: '#4F46E5',
+			tertiary: '#0EA5E9',
+			success: '#84cc16',
+			warning: '#EAB308',
+			error: '#D41976',
+			surface: '#495a8f'
+		};
+
+		$storeThemGenForm.colors.forEach((color: ColorSettings, i: number) => {
+			if (hexValueIsValid(color.hex)) return;
+
+			if (color.key in colorMapping) {
+				$storeThemGenForm.colors[i].hex = colorMapping[color.key];
+			}
+		});
+	}
 
 	function randomize(): void {
 		$storeThemGenForm.colors.forEach((_, i: number) => {


### PR DESCRIPTION
## Linked Issue

Closes #1744

## Description

for now, it is not easy to validate colors before saving the value to local storage without introducing big changes.

however, resetting invalid colors on component initialization will solve the problem.

when refactoring the component we might want to introduce a callback function in our LocalStorageStore utility so we can validate colors before saving them to localStorage (I think this would be a cool feature).

## Changsets

-

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
