### PR TITLE
chore: fixes the `Semicolon or block is expected` postcss parsing error

### DIFF
--- a/packages/skeleton/postcss.config.cjs
+++ b/packages/skeleton/postcss.config.cjs
@@ -1,3 +1,4 @@
+const path = require('path');
 const tailwindcss = require('tailwindcss');
 const autoprefixer = require('autoprefixer');
 
@@ -5,7 +6,7 @@ const config = {
 	plugins: [
 		require('postcss-import'),
 		//Some plugins, like tailwindcss/nesting, need to run before Tailwind,
-		tailwindcss(),
+		tailwindcss(path.resolve(__dirname, './tailwind.config.cjs')),
 		//But others, like autoprefixer, need to run after,
 		autoprefixer
 	]

--- a/packages/skeleton/svelte.config.js
+++ b/packages/skeleton/svelte.config.js
@@ -1,5 +1,9 @@
 import adapter from '@sveltejs/adapter-auto';
 import { vitePreprocess } from '@sveltejs/kit/vite';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -7,7 +11,11 @@ const config = {
 	// for more information about preprocessors
 	preprocess: [
 		vitePreprocess({
-			postcss: true
+			style: {
+				css: {
+					postcss: join(__dirname, 'postcss.config.cjs')
+				}
+			}
 		})
 	],
 	kit: {

--- a/sites/skeleton.dev/postcss.config.cjs
+++ b/sites/skeleton.dev/postcss.config.cjs
@@ -1,6 +1,7 @@
+const path = require('path');
+const tailwindcss = require('tailwindcss');
+const autoprefixer = require('autoprefixer');
+
 module.exports = {
-	plugins: {
-		tailwindcss: {},
-		autoprefixer: {}
-	}
+	plugins: [tailwindcss(path.resolve(__dirname, './tailwind.config.cjs')), autoprefixer]
 };

--- a/sites/skeleton.dev/svelte.config.js
+++ b/sites/skeleton.dev/svelte.config.js
@@ -1,5 +1,9 @@
 import adapter from '@sveltejs/adapter-vercel';
 import { vitePreprocess } from '@sveltejs/kit/vite';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -7,7 +11,11 @@ const config = {
 	// for more information about preprocessors
 	preprocess: [
 		vitePreprocess({
-			postcss: true
+			style: {
+				css: {
+					postcss: join(__dirname, 'postcss.config.cjs')
+				}
+			}
 		})
 	],
 	kit: {


### PR DESCRIPTION
## Description

This fixes the _terribly annoying_ postcss parsing error that mainly occurs when you're working directly with the whole monorepo in your editor:

![depicts the error message highlighted](https://i.imgur.com/NyORn0b.png)

To reproduce, open the project in vscode from the **root of the monorepo** and checkout the `dev` branch. 
Open the `sites/skeleton.dev/src/routes/+page.svelte` file and you should see the error shown above.

## Changsets

No changeset needed

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
