### PR TITLE
Add passive event listener Modal

### DIFF
--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -201,8 +201,8 @@
 			data-testid="modal-backdrop"
 			on:mousedown={onBackdropInteractionBegin}
 			on:mouseup={onBackdropInteractionEnd}
-			on:touchstart
-			on:touchend
+			on:touchstart|passive
+			on:touchend|passive
 			transition:fade|global={{ duration }}
 			use:focusTrap={true}
 		>


### PR DESCRIPTION
## Linked Issue

Closes #1755

## Description

This error is showing when using [Modals](https://www.skeleton.dev/utilities/modals) :
`[Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952`
