### PR TITLE
bugfix/inputchips-updates-twice

### DIFF
--- a/.changeset/twenty-spoons-hope.md
+++ b/.changeset/twenty-spoons-hope.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: InputChips updates bound value only once.

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -158,11 +158,6 @@
 	$: classesInterface = `${cInterface}`;
 	$: classesChipList = `${cChipList}`;
 	$: classesInputField = `${cInputField}`;
-	$: chipValues =
-		value?.map((val, i) => {
-			if (chipValues[i]?.val === val) return chipValues[i];
-			return { id: Math.random(), val: val };
-		}) || [];
 </script>
 
 <div class="input-chip {classesBase}" class:opacity-50={$$restProps.disabled}>


### PR DESCRIPTION
## Linked Issue

Closes #1759

## Description

after deleting 
```ts
$: chipValues =
		value?.map((val, i) => {
			if (chipValues[i]?.val === val) return chipValues[i];
			return { id: Math.random(), val: val };
		}) || [];
```
every thing works as expected and the value is updated only once.

I have tested it with all use cases from the docs.

## Changsets

bugfix: InputChips updates bound value only once.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
