### PR TITLE
feat/tree-view-select

### DIFF
--- a/.changeset/fresh-carrots-lick.md
+++ b/.changeset/fresh-carrots-lick.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Added `tree-view` single/multi selection mode, Enabled `data-driven` for tree-view.

--- a/cspell.json
+++ b/cspell.json
@@ -79,6 +79,7 @@
 		"Menlo",
 		"minima",
 		"mininal",
+		"Morty",
 		"Muertos",
 		"Nahua",
 		"Neue",

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -46,6 +46,68 @@
 	/** Provide the ARIA labelledby value. */
 	export let labelledby = '';
 
+	// Functionality
+	/**
+	 * expands all tree view items.
+	 * @type {() => void}
+	 */
+	export function expandAll(): void {
+		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
+		detailsElements.forEach((details) => {
+			if (!details.open) {
+				const summary: HTMLElement | null = details.querySelector('summary.tree-item-summary');
+				if (summary) summary.click();
+			}
+		});
+	}
+	/**
+	 * collapses all tree view items.
+	 * @type {() => void}
+	 */
+	export function collapseAll() {
+		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
+		detailsElements.forEach((details) => {
+			if (details.open) {
+				const summary: HTMLElement | null = details.querySelector('summary.tree-item-summary');
+				if (summary) summary.click();
+			}
+		});
+	}
+	/**
+	 * select all tree view items. Only available in Multiple selection mode.
+	 * @type {() => void}
+	 */
+	export function selectAll() {
+		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
+		detailsElements.forEach((details) => {
+			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
+			if (!input) return;
+			if (!input.checked) {
+				// needs delay
+				setTimeout(() => {
+					input.click();
+				}, 5);
+			}
+		});
+	}
+	/**
+	 * deselect all tree view items. Only available in Multiple selection mode.
+	 * @type {() => void}
+	 */
+	export function deselectAll() {
+		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
+		detailsElements.forEach((details) => {
+			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
+			if (!input) return;
+			if (input.checked) {
+				// needs delay
+				setTimeout(() => {
+					input.click();
+				}, 5);
+			}
+		});
+	}
+
 	// Context API
 	setContext('selection', selection);
 	setContext('multiple', multiple);
@@ -63,8 +125,19 @@
 
 	// Reactive
 	$: classesBase = `${width} ${spacing} ${$$props.class ?? ''}`;
+
+	// Locals
+	let tree: HTMLDivElement;
 </script>
 
-<div class="tree {classesBase}" data-testid="tree" role="tree" aria-multiselectable="true" aria-label={labelledby} aria-disabled={disabled}>
+<div
+	bind:this={tree}
+	class="tree {classesBase}"
+	data-testid="tree"
+	role="tree"
+	aria-multiselectable="true"
+	aria-label={labelledby}
+	aria-disabled={disabled}
+>
 	<slot />
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -9,6 +9,8 @@
 	export let selection = false;
 	/** Enable selection of multiple items. */
 	export let multiple = false;
+	/** Set the tree disabled state */
+	export let disabled = false;
 	/** Provide classes to set the tree width. */
 	export let width: CssClasses = 'w-full';
 	/** Provide classes to set the vertical spacing between items. */
@@ -47,6 +49,7 @@
 	// Context API
 	setContext('selection', selection);
 	setContext('multiple', multiple);
+	setContext('disabled', disabled);
 	setContext('padding', padding);
 	setContext('indent', indent);
 	setContext('hover', hover);
@@ -60,10 +63,8 @@
 
 	// Reactive
 	$: classesBase = `${width} ${spacing} ${$$props.class ?? ''}`;
-
-	let child: any;
 </script>
 
-<div class="tree {classesBase}" data-testid="tree" role="tree" aria-multiselectable="true" aria-label={labelledby}>
+<div class="tree {classesBase}" data-testid="tree" role="tree" aria-multiselectable="true" aria-label={labelledby} aria-disabled={disabled}>
 	<slot />
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -5,11 +5,10 @@
 	import type { CssClasses } from '../../index.js';
 
 	// Props (parent)
-	/**
-	 * Provide the tree selection mode.
-	 * @type {'multi' | 'single' | 'none'}
-	 */
-	export let selection: 'multi' | 'single' | 'none' = 'none';
+	/** Enable tree-view selection */
+	export let selection = false;
+	/** Enable selection of multiple items. */
+	export let multiple = false;
 	/** Provide classes to set the tree width. */
 	export let width: CssClasses = 'w-full';
 	/** Provide classes to set the vertical spacing between items. */
@@ -47,6 +46,7 @@
 
 	// Context API
 	setContext('selection', selection);
+	setContext('multiple', multiple);
 	setContext('padding', padding);
 	setContext('indent', indent);
 	setContext('hover', hover);
@@ -60,6 +60,8 @@
 
 	// Reactive
 	$: classesBase = `${width} ${spacing} ${$$props.class ?? ''}`;
+
+	let child: any;
 </script>
 
 <div class="tree {classesBase}" data-testid="tree" role="tree" aria-multiselectable="true" aria-label={labelledby}>

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -5,6 +5,11 @@
 	import type { CssClasses } from '../../index.js';
 
 	// Props (parent)
+	/**
+	 * Provide the tree selection mode.
+	 * @type {'multi' | 'single' | 'none'}
+	 */
+	export let selection: 'multi' | 'single' | 'none' = 'none';
 	/** Provide classes to set the tree width. */
 	export let width: CssClasses = 'w-full';
 	/** Provide classes to set the vertical spacing between items. */
@@ -41,6 +46,7 @@
 	export let labelledby = '';
 
 	// Context API
+	setContext('selection', selection);
 	setContext('padding', padding);
 	setContext('indent', indent);
 	setContext('hover', hover);

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -53,10 +53,10 @@
 	 */
 	export function expandAll(): void {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach(details => {
-			if(!details.open) {
-				const summary : HTMLElement | null = details.querySelector('summary.tree-item-summary');
-				if(summary) summary.click();
+		detailsElements.forEach((details) => {
+			if (!details.open) {
+				const summary: HTMLElement | null = details.querySelector('summary.tree-item-summary');
+				if (summary) summary.click();
 			}
 		});
 	}
@@ -66,10 +66,10 @@
 	 */
 	export function collapseAll() {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach(details => {
-			if(details.open) {
-				const summary : HTMLElement | null = details.querySelector('summary.tree-item-summary');
-				if(summary) summary.click();
+		detailsElements.forEach((details) => {
+			if (details.open) {
+				const summary: HTMLElement | null = details.querySelector('summary.tree-item-summary');
+				if (summary) summary.click();
 			}
 		});
 	}
@@ -79,10 +79,10 @@
 	 */
 	export function selectAll() {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach(details => {
-			const input : HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
-			if(!input) return;
-			if(!input.checked) {
+		detailsElements.forEach((details) => {
+			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
+			if (!input) return;
+			if (!input.checked) {
 				// needs delay
 				setTimeout(() => {
 					input.click();
@@ -96,10 +96,10 @@
 	 */
 	export function deselectAll() {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach(details => {
-			const input : HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
-			if(!input) return;
-			if(input.checked){
+		detailsElements.forEach((details) => {
+			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
+			if (!input) return;
+			if (input.checked) {
 				// needs delay
 				setTimeout(() => {
 					input.click();
@@ -130,6 +130,14 @@
 	let tree: HTMLDivElement;
 </script>
 
-<div bind:this={tree} class="tree {classesBase}" data-testid="tree" role="tree" aria-multiselectable="true" aria-label={labelledby} aria-disabled={disabled}>
+<div
+	bind:this={tree}
+	class="tree {classesBase}"
+	data-testid="tree"
+	role="tree"
+	aria-multiselectable="true"
+	aria-label={labelledby}
+	aria-disabled={disabled}
+>
 	<slot />
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -144,7 +144,7 @@
 	class="tree {classesBase}"
 	data-testid="tree"
 	role="tree"
-	aria-multiselectable="true"
+	aria-multiselectable={multiple}
 	aria-label={labelledby}
 	aria-disabled={disabled}
 >

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -53,10 +53,10 @@
 	 */
 	export function expandAll(): void {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach((details) => {
-			if (!details.open) {
-				const summary: HTMLElement | null = details.querySelector('summary.tree-item-summary');
-				if (summary) summary.click();
+		detailsElements.forEach(details => {
+			if(!details.open) {
+				const summary : HTMLElement | null = details.querySelector('summary.tree-item-summary');
+				if(summary) summary.click();
 			}
 		});
 	}
@@ -66,10 +66,10 @@
 	 */
 	export function collapseAll() {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach((details) => {
-			if (details.open) {
-				const summary: HTMLElement | null = details.querySelector('summary.tree-item-summary');
-				if (summary) summary.click();
+		detailsElements.forEach(details => {
+			if(details.open) {
+				const summary : HTMLElement | null = details.querySelector('summary.tree-item-summary');
+				if(summary) summary.click();
 			}
 		});
 	}
@@ -79,10 +79,10 @@
 	 */
 	export function selectAll() {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach((details) => {
-			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
-			if (!input) return;
-			if (!input.checked) {
+		detailsElements.forEach(details => {
+			const input : HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
+			if(!input) return;
+			if(!input.checked) {
 				// needs delay
 				setTimeout(() => {
 					input.click();
@@ -96,10 +96,10 @@
 	 */
 	export function deselectAll() {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach((details) => {
-			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
-			if (!input) return;
-			if (input.checked) {
+		detailsElements.forEach(details => {
+			const input : HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
+			if(!input) return;
+			if(input.checked){
 				// needs delay
 				setTimeout(() => {
 					input.click();
@@ -130,14 +130,6 @@
 	let tree: HTMLDivElement;
 </script>
 
-<div
-	bind:this={tree}
-	class="tree {classesBase}"
-	data-testid="tree"
-	role="tree"
-	aria-multiselectable="true"
-	aria-label={labelledby}
-	aria-disabled={disabled}
->
+<div bind:this={tree} class="tree {classesBase}" data-testid="tree" role="tree" aria-multiselectable="true" aria-label={labelledby} aria-disabled={disabled}>
 	<slot />
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -2,7 +2,8 @@
 	import { setContext } from 'svelte';
 
 	// Types
-	import type { CssClasses } from '../../index.js';
+	import type { CssClasses, TreeViewNode } from '../../index.js';
+	import TreeViewDataDrivenItem from './TreeViewDataDrivenItem.svelte';
 
 	// Props (parent)
 	/** Enable tree-view selection */
@@ -11,6 +12,9 @@
 	export let multiple = false;
 	/** Set the tree disabled state */
 	export let disabled = false;
+	/** Provide data-driven nodes. */
+	export let nodes: TreeViewNode[] = [];
+
 	/** Provide classes to set the tree width. */
 	export let width: CssClasses = 'w-full';
 	/** Provide classes to set the vertical spacing between items. */
@@ -139,5 +143,9 @@
 	aria-label={labelledby}
 	aria-disabled={disabled}
 >
-	<slot />
+	{#if !nodes || nodes.length === 0}
+		<slot />
+	{:else}
+		<TreeViewDataDrivenItem {nodes} />
+	{/if}
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -6,21 +6,25 @@
 	import TreeViewDataDrivenItem from './TreeViewDataDrivenItem.svelte';
 
 	// Props (parent)
-	/** Enable tree-view selection */
+	/** Enable tree-view selection. */
 	export let selection = false;
 	/** Enable selection of multiple items. */
 	export let multiple = false;
-	/** Set the tree disabled state */
-	export let disabled = false;
-	/** Provide data-driven nodes. */
+	/**
+	 * Provide data-driven nodes.
+	 * @type {TreeViewNode[]}
+	 */
 	export let nodes: TreeViewNode[] = [];
-
 	/** Provide classes to set the tree width. */
 	export let width: CssClasses = 'w-full';
 	/** Provide classes to set the vertical spacing between items. */
 	export let spacing: CssClasses = 'space-y-1';
 
 	// Props (children)
+	/** Set open by default on load. */
+	export let open = false;
+	/** Set the tree disabled state */
+	export let disabled = false;
 	/** Provide classes to set the tree item padding styles. */
 	export let padding: CssClasses = 'py-4 px-4';
 	/** Provide classes to set the tree children indentation */
@@ -68,7 +72,7 @@
 	 * collapses all tree view items.
 	 * @type {() => void}
 	 */
-	export function collapseAll() {
+	export function collapseAll(): void {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
 		detailsElements.forEach((details) => {
 			if (details.open) {
@@ -81,7 +85,7 @@
 	 * select all tree view items. Only available in Multiple selection mode.
 	 * @type {() => void}
 	 */
-	export function selectAll() {
+	export function selectAll(): void {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
 		detailsElements.forEach((details) => {
 			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
@@ -98,7 +102,7 @@
 	 * deselect all tree view items. Only available in Multiple selection mode.
 	 * @type {() => void}
 	 */
-	export function deselectAll() {
+	export function deselectAll(): void {
 		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
 		detailsElements.forEach((details) => {
 			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
@@ -113,6 +117,7 @@
 	}
 
 	// Context API
+	setContext('open', open);
 	setContext('selection', selection);
 	setContext('multiple', multiple);
 	setContext('disabled', disabled);
@@ -143,9 +148,9 @@
 	aria-label={labelledby}
 	aria-disabled={disabled}
 >
-	{#if !nodes || nodes.length === 0}
-		<slot />
+	{#if nodes && nodes.length > 0}
+		<TreeViewDataDrivenItem bind:nodes />
 	{:else}
-		<TreeViewDataDrivenItem {nodes} />
+		<slot />
 	{/if}
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewDataDrivenItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewDataDrivenItem.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import TreeViewDataDrivenItem from './TreeViewDataDrivenItem.svelte';
+	import TreeViewItem from './TreeViewItem.svelte';
+	import type { TreeViewNode } from './types.js';
+
+	/** Provide data-driven nodes. */
+	export let nodes: TreeViewNode[] = [];
+</script>
+
+{#each nodes as node}
+	<TreeViewItem open={node.open} hideLead={!node.lead} hideChildren={!node.children || node.children.length === 0} disabled={node.disabled}>
+		{@html node.content}
+		<svelte:fragment slot="lead">
+			{@html node.lead}
+		</svelte:fragment>
+		<svelte:fragment slot="children">
+			<TreeViewDataDrivenItem nodes={node.children} />
+		</svelte:fragment>
+	</TreeViewItem>
+{/each}

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewDataDrivenItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewDataDrivenItem.svelte
@@ -1,20 +1,93 @@
 <script lang="ts">
+	/**
+	 * This component is only in Data-driven tree-view to add children recursively.
+	 */
+	import { createEventDispatcher, getContext, onMount } from 'svelte';
 	import TreeViewDataDrivenItem from './TreeViewDataDrivenItem.svelte';
 	import TreeViewItem from './TreeViewItem.svelte';
 	import type { TreeViewNode } from './types.js';
 
+	// events
+	const dispatch = createEventDispatcher();
+
+	// this can't be passed using context, since we have to pass it to recursive children.
 	/** Provide data-driven nodes. */
 	export let nodes: TreeViewNode[] = [];
+
+	// Context API
+	/** Enable tree-view selection */
+	export let selection: boolean = getContext('selection');
+	/** Enable selection of multiple items. */
+	export let multiple: boolean = getContext('multiple');
+
+	// Locals
+	let group: unknown;
+	let name = '';
+
+	// Lifecycle
+	onMount(() => {
+		// random number as name
+		name = String(Math.random());
+
+		if (selection) {
+			group = multiple ? [] : '';
+			// manage group (checking) on initialization.
+			nodes.forEach((node) => {
+				if (!node.checked) return;
+
+				if (multiple) {
+					if (!Array.isArray(group)) return;
+					group.push(node.value);
+				} else {
+					group = node.value;
+				}
+			});
+		}
+	});
+
+	// Functionality
+	function onCheckChange() {
+		nodes.forEach((node) => {
+			if (multiple) {
+				if (!Array.isArray(group)) return;
+				node.checked = group.includes(node.value);
+			} else {
+				node.checked = group === node.value;
+			}
+		});
+		nodes = nodes;
+		// notify parent to update values. Important to recursively update parents.
+		dispatch('change');
+	}
+
+	export let parents: TreeViewItem[] = [];
+	let children: TreeViewItem[][] = [];
 </script>
 
-{#each nodes as node}
-	<TreeViewItem open={node.open} hideLead={!node.lead} hideChildren={!node.children || node.children.length === 0} disabled={node.disabled}>
-		{@html node.content}
-		<svelte:fragment slot="lead">
-			{@html node.lead}
-		</svelte:fragment>
-		<svelte:fragment slot="children">
-			<TreeViewDataDrivenItem nodes={node.children} />
-		</svelte:fragment>
-	</TreeViewItem>
-{/each}
+{#if nodes && nodes.length > 0}
+	{#each nodes as node, i}
+		<TreeViewItem
+			bind:this={parents[i]}
+			bind:open={node.open}
+			hideLead={!node.lead}
+			hideChildren={!node.children || node.children.length === 0}
+			bind:disabled={node.disabled}
+			bind:group
+			bind:name
+			bind:indeterminate={node.indeterminate}
+			bind:value={node.value}
+			bind:children={children[i]}
+			on:change={onCheckChange}
+			on:click
+			on:toggle
+		>
+			{@html node.content}
+			<svelte:fragment slot="lead">
+				{@html node.lead}
+			</svelte:fragment>
+			<svelte:fragment slot="children">
+				<TreeViewDataDrivenItem nodes={node.children} on:change={onCheckChange} bind:parents={children[i]} />
+			</svelte:fragment>
+		</TreeViewItem>
+	{/each}
+{/if}

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -48,7 +48,8 @@
 
 	// Classes
 	const cBase = '';
-	const cSummary = 'list-none flex items-center cursor-pointer';
+	// [&::-webkit-details-marker]:hidden -> hide default arrow on webkit browsers
+	const cSummary = 'list-none [&::-webkit-details-marker]:hidden flex items-center cursor-pointer';
 	const cSymbol = 'fill-current w-3 text-center transition-transform duration-[200ms]';
 	const cChildren = '';
 
@@ -98,7 +99,6 @@
 
 	// Reactive State Classes
 	$: classesCaretState = open ? caretOpen : caretClosed;
-	// $: classesCaretVisible = $$slots.children ? 'block' : 'hidden';
 	// Reactive Classes
 	$: classesBase = `${cBase} ${$$props.class ?? ''}`;
 	$: classesSummary = `${cSummary} ${spacing} ${rounded} ${padding} ${hover} ${regionSummary}`;
@@ -106,8 +106,6 @@
 	$: classesCaret = `${classesCaretState}`;
 	$: classesHyphen = `${hyphenOpacity}`;
 	$: classesChildren = `${cChildren} ${indent} ${regionChildren}`;
-
-	$: console.log(selected);
 </script>
 
 <details bind:open class="tree-item {classesBase}" data-testid="tree-item" bind:this={treeItem}>

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -206,7 +206,10 @@
 			}
 			return undefined;
 		}
+
 		let rootTree: HTMLDivElement | undefined = undefined;
+		let lastVisibleElement: HTMLElement | undefined | null = null;
+
 		switch (event.code) {
 			case 'ArrowRight':
 				if (!open) open = true;
@@ -233,7 +236,6 @@
 			case 'End':
 				event.preventDefault();
 				rootTree = getRootTree();
-				let lastVisibleElement: HTMLElement | undefined | null = null;
 				// focus on last node
 				if (rootTree) {
 					const detailsElements = rootTree?.querySelectorAll('details');

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -10,6 +10,8 @@
 	// Props (state)
 	/** Set open by default on load. */
 	export let open = false;
+	/** Set the tree disabled state */
+	export let disabled: boolean = getContext('disabled');
 	/**
 	 * Set the radio group binding value.
 	 * @type {unknown}
@@ -67,6 +69,10 @@
 	let indeterminate = false;
 
 	// Functionality
+	function onSummaryClick(event: MouseEvent) {
+		// prevent any action when disabled
+		if (disabled) event.preventDefault();
+	}
 	// Svelte Checkbox Bugfix
 	// GitHub: https://github.com/sveltejs/svelte/issues/2308
 	// REPL: https://svelte.dev/repl/de117399559f4e7e9e14e2fc9ab243cc?version=3.12.1
@@ -184,24 +190,27 @@
 	const cSummary = 'list-none [&::-webkit-details-marker]:hidden flex items-center cursor-pointer';
 	const cSymbol = 'fill-current w-3 text-center transition-transform duration-[200ms]';
 	const cChildren = '';
+	const cDisabled = 'opacity-50 !cursor-not-allowed';
 
 	// Reactive State Classes
 	$: classesCaretState = open && $$slots.children ? caretOpen : caretClosed;
 	// Reactive Classes
+	$: classesDisabled = disabled ? cDisabled : '';
 	$: classesBase = `${cBase} ${$$props.class ?? ''}`;
-	$: classesSummary = `${cSummary} ${spacing} ${rounded} ${padding} ${hover} ${regionSummary}`;
+	$: classesSummary = `${cSummary} ${classesDisabled} ${spacing} ${rounded} ${padding} ${hover} ${regionSummary}`;
 	$: classesSymbol = `${cSymbol} ${classesCaret} ${regionSymbol}`;
 	$: classesCaret = `${classesCaretState}`;
 	$: classesHyphen = `${hyphenOpacity}`;
 	$: classesChildren = `${cChildren} ${indent} ${regionChildren}`;
 </script>
 
-<details bind:open class="tree-item {classesBase}" data-testid="tree-item">
+<details bind:open class="tree-item {classesBase}" data-testid="tree-item" aria-disabled={disabled}>
 	<summary
 		class="tree-item-summary {classesSummary}"
 		role="treeitem"
-		aria-selected="false"
+		aria-selected={checked}
 		aria-expanded={$$slots.children ? open : undefined}
+		on:click={onSummaryClick}
 		on:click
 		on:keydown
 		on:keyup

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -10,7 +10,7 @@
 	// Props (state)
 	/** Set open by default on load. */
 	export let open = false;
-	/** Set the tree disabled state */
+	/** Set the tree item disabled state */
 	export let disabled: boolean = getContext('disabled');
 	/**
 	 * Set the radio group binding value.
@@ -63,6 +63,12 @@
 	export let regionSymbol: CssClasses = getContext('regionSymbol');
 	/** Provide arbitrary classes to the children region. */
 	export let regionChildren: CssClasses = getContext('regionChildren');
+
+	// Props (work around)
+	/** Don't use this prop, workaround until svelte implements conditional slots */
+	export let hideLead = false;
+	/** Don't use this prop, workaround until svelte implements conditional slots */
+	export let hideChildren = false;
 
 	// Locals
 	let checked = false;
@@ -193,7 +199,7 @@
 	const cDisabled = 'opacity-50 !cursor-not-allowed';
 
 	// Reactive State Classes
-	$: classesCaretState = open && $$slots.children ? caretOpen : caretClosed;
+	$: classesCaretState = open && $$slots.children && !hideChildren ? caretOpen : caretClosed;
 	// Reactive Classes
 	$: classesDisabled = disabled ? cDisabled : '';
 	$: classesBase = `${cBase} ${$$props.class ?? ''}`;
@@ -217,7 +223,7 @@
 	>
 		<!-- Symbol -->
 		<div class="tree-summary-symbol {classesSymbol}">
-			{#if $$slots.children}
+			{#if $$slots.children && !hideChildren}
 				<!-- SVG Caret -->
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
 					<path
@@ -241,7 +247,7 @@
 		{/if}
 
 		<!-- Slot: Lead -->
-		{#if $$slots.lead}
+		{#if $$slots.lead && !hideLead}
 			<div class="tree-item-lead">
 				<slot name="lead" />
 			</div>

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -234,9 +234,9 @@
 		<!-- Selection -->
 		{#if selection && name && group}
 			{#if multiple}
-				<input class="checkbox" type="checkbox" {name} {value} bind:checked bind:indeterminate on:click on:change />
+				<input class="checkbox tree-item-checkbox" type="checkbox" {name} {value} bind:checked bind:indeterminate on:click on:change />
 			{:else}
-				<input class="radio" type="radio" bind:group {name} {value} on:click on:change />
+				<input class="radio tree-item-radio" type="radio" bind:group {name} {value} on:click on:change />
 			{/if}
 		{/if}
 

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -186,7 +186,7 @@
 	const cChildren = '';
 
 	// Reactive State Classes
-	$: classesCaretState = open ? caretOpen : caretClosed;
+	$: classesCaretState = open && $$slots.children ? caretOpen : caretClosed;
 	// Reactive Classes
 	$: classesBase = `${cBase} ${$$props.class ?? ''}`;
 	$: classesSummary = `${cSummary} ${spacing} ${rounded} ${padding} ${hover} ${regionSummary}`;

--- a/packages/skeleton/src/lib/components/TreeView/types.ts
+++ b/packages/skeleton/src/lib/components/TreeView/types.ts
@@ -1,0 +1,12 @@
+export interface TreeViewNode {
+	/** Main content. accepts HTML. */
+	content: string;
+	/** Lead content. accepts HTML. */
+	lead?: string;
+	/** Set open by default on load. */
+	open?: boolean;
+	/** Set the tree disabled state. */
+	disabled?: boolean;
+	/** children nodes. */
+	children?: TreeViewNode[];
+}

--- a/packages/skeleton/src/lib/components/TreeView/types.ts
+++ b/packages/skeleton/src/lib/components/TreeView/types.ts
@@ -9,4 +9,10 @@ export interface TreeViewNode {
 	disabled?: boolean;
 	/** children nodes. */
 	children?: TreeViewNode[];
+	/** Set the input's value. */
+	value?: unknown;
+	/** input checked */
+	checked?: boolean;
+	/** input is set to indeterminate, only availabe in multiple selection mode. */
+	indeterminate?: boolean;
 }

--- a/packages/skeleton/src/lib/index.ts
+++ b/packages/skeleton/src/lib/index.ts
@@ -10,6 +10,7 @@ export type { ToastSettings } from './utilities/Toast/types.js';
 export type { TableSource } from './components/Table/types.js';
 export type { PaginationSettings } from './components/Paginator/types.js';
 export type { PopupSettings } from './utilities/Popup/types.js';
+export type { TreeViewNode } from './components/TreeView/types.js';
 
 // This type alias is to identify CSS classes within component props, which enables Tailwind IntelliSense
 export type CssClasses = string;
@@ -99,6 +100,7 @@ export { default as TabAnchor } from './components/Tab/TabAnchor.svelte';
 export { default as TableOfContents } from './components/TableOfContents/TableOfContents.svelte';
 export { default as TreeView } from './components/TreeView/TreeView.svelte';
 export { default as TreeViewItem } from './components/TreeView/TreeViewItem.svelte';
+export { default as TreeViewDataDrivenItem } from './components/TreeView/TreeViewDataDrivenItem.svelte';
 // Utility Components
 export { default as CodeBlock } from './utilities/CodeBlock/CodeBlock.svelte';
 export { default as Modal } from './utilities/Modal/Modal.svelte';

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -110,21 +110,21 @@
 					<TreeView>
 						<TreeViewItem open>
 							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-skull" />
+								<i class="fa-solid fa-folder" />
 							</svelte:fragment>
-							<p>Item 1</p>
+							<p>Folder</p>
 							<svelte:fragment slot="children">
 								<TreeViewItem>
 									<svelte:fragment slot="lead">
-										<i class="fa-solid fa-skull-crossbones" />
+										<i class="fa-solid fa-file" />
 									</svelte:fragment>
-									<p>Child 1</p>
+									<p>File 1</p>
 								</TreeViewItem>
 								<TreeViewItem>
 									<svelte:fragment slot="lead">
-										<i class="fa-solid fa-skull-crossbones" />
+										<i class="fa-solid fa-file" />
 									</svelte:fragment>
-									<p>Child 2</p>
+									<p>File 2</p>
 								</TreeViewItem>
 							</svelte:fragment>
 						</TreeViewItem>

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -29,10 +29,17 @@
 	};
 
 	// Locals
-	let valueSingle: string = 'books';
+	let mediumSingle: string = 'books';
 	let booksSingle: string = 'Clean Code';
-	let valueMultiple = ['books', 'movies'];
+	let relationalMediumSingle: string = 'books';
+	let relationalBooksSingle: string = 'Clean Code';
+	let childrenSingle: TreeViewItem[] = [];
+
+	let mediumMultiple = ['books', 'movies'];
 	let booksMultiple = ['Clean Code', 'The Art of Unix Programming'];
+	let relationalMediumMultiple = ['movies'];
+	let relationalBooksMultiple: string[] = [];
+	let childrenMultiple: TreeViewItem[] = [];
 </script>
 
 <DocsShell {settings}>
@@ -42,7 +49,7 @@
 			<svelte:fragment slot="preview">
 				<div class="w-full max-w-[480px] card p-4 text-token">
 					<TreeView>
-						<TreeViewItem on:toggle={(e) => console.log(e.detail.open)}>
+						<TreeViewItem>
 							<p>Item 1</p>
 							<svelte:fragment slot="children">
 								<TreeViewItem>
@@ -157,11 +164,12 @@
 		<section class="space-y-4">
 			<h2 class="h2">Selection</h2>
 			<p>Enable selection using the prop <code class="code">selection</code></p>
+			<!-- Single -->
 			<h3 class="h3">Single</h3>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<TreeView selection={true}>
-						<TreeViewItem bind:group={valueSingle} name="medium" value="books">
+						<TreeViewItem bind:group={mediumSingle} name="medium" value="books">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-book-skull" />
 							</svelte:fragment>
@@ -178,13 +186,13 @@
 								</TreeViewItem>
 							</svelte:fragment>
 						</TreeViewItem>
-						<TreeViewItem bind:group={valueSingle} name="medium" value="movies">
+						<TreeViewItem bind:group={mediumSingle} name="medium" value="movies">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-film" />
 							</svelte:fragment>
 							<p>Movies</p>
 						</TreeViewItem>
-						<TreeViewItem bind:group={valueSingle} name="medium" value="tv">
+						<TreeViewItem bind:group={mediumSingle} name="medium" value="tv">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-tv" />
 							</svelte:fragment>
@@ -238,14 +246,15 @@ let booksSingle: string = 'Clean Code';
 					/>
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<div class="text-center"><code class="code">Selected medium: {valueSingle} <br /> Selected book: {booksSingle}</code></div>
+					<div class="text-center"><code class="code">Selected medium: {mediumSingle} <br /> Selected book: {booksSingle}</code></div>
 				</svelte:fragment>
 			</DocsPreview>
+			<!-- Multiple -->
 			<h3 class="h3">Multiple</h3>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<TreeView selection={true} multiple={true}>
-						<TreeViewItem bind:group={valueMultiple} name="medium" value="books">
+						<TreeViewItem bind:group={mediumMultiple} name="medium" value="books">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-book-skull" />
 							</svelte:fragment>
@@ -262,13 +271,13 @@ let booksSingle: string = 'Clean Code';
 								</TreeViewItem>
 							</svelte:fragment>
 						</TreeViewItem>
-						<TreeViewItem bind:group={valueMultiple} name="medium" value="movies">
+						<TreeViewItem bind:group={mediumMultiple} name="medium" value="movies">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-film" />
 							</svelte:fragment>
 							<p>Movies</p>
 						</TreeViewItem>
-						<TreeViewItem bind:group={valueMultiple} name="medium" value="tv">
+						<TreeViewItem bind:group={mediumMultiple} name="medium" value="tv">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-tv" />
 							</svelte:fragment>
@@ -324,11 +333,173 @@ let booksMultiple = ['Clean Code', 'The Art of Unix Programming']
 				<svelte:fragment slot="footer">
 					<div class="text-center">
 						<code class="code"
-							>Selected mediums: {valueMultiple.length ? valueMultiple : 'None'} <br /> Selected books: {booksMultiple.length
+							>Selected mediums: {mediumMultiple.length ? mediumMultiple : 'None'} <br /> Selected books: {booksMultiple.length
 								? booksMultiple
 								: 'None'}</code
 						>
 					</div>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- Relational -->
+			<h3 class="h3">Relational</h3>
+			<p>
+				By passing children references to a parent <code class="code">TreeViewItem</code>, the check value of the parent will be relational,
+				meaning it will react to the check value of the children.
+			</p>
+			<DocsPreview background="neutral" regionFooter="text-center">
+				<svelte:fragment slot="preview">
+					<TreeView selection={true}>
+						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="books" open children={childrenSingle}>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem bind:this={childrenSingle[0]} bind:group={relationalBooksSingle} name="r_books" value="Clean Code">
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem bind:this={childrenSingle[1]} bind:group={relationalBooksSingle} name="r_books" value="The Clean Coder">
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem
+									bind:this={childrenSingle[2]}
+									bind:group={relationalBooksSingle}
+									name="r_books"
+									value="The Art of Unix Programming"
+								>
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let mediumSingle: string = 'books';
+let booksSingle: string = 'Clean Code';
+let children: TreeViewItem[] = [];
+`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView selection={true}>
+	<TreeViewItem bind:group={mediumSingle} name="medium" value="books" children={children}>
+		<svelte:fragment slot="lead">
+			(icon)
+		</svelte:fragment>
+		<p>Books</p>
+		<svelte:fragment slot="children">
+			<TreeViewItem bind:this={children[0]} bind:group={booksSingle} name="books" value="Clean Code">
+				<p>Clean Code</p>
+			</TreeViewItem>
+			<TreeViewItem bind:this={children[1]} bind:group={booksSingle} name="books" value="The Clean Coder">
+				<p>The Clean Coder</p>
+			</TreeViewItem>
+			<TreeViewItem bind:this={children[2]} bind:group={booksSingle} name="books" value="The Art of Unix Programming">
+				<p>The Art of Unix Programming</p>
+			</TreeViewItem>
+		</svelte:fragment>
+	</TreeViewItem>
+	<!-- ... -->
+</TreeView>
+			`}
+					/>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<p>Select <code class="code">Movies</code> to see relational checking.</p>
+				</svelte:fragment>
+			</DocsPreview>
+			<DocsPreview background="neutral" regionFooter="text-center">
+				<svelte:fragment slot="preview">
+					<TreeView selection={true} multiple={true}>
+						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="books" open children={childrenMultiple}>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem bind:this={childrenMultiple[0]} bind:group={relationalBooksMultiple} name="r_books" value="Clean Code">
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem bind:this={childrenMultiple[1]} bind:group={relationalBooksMultiple} name="r_books" value="The Clean Coder">
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem
+									bind:this={childrenMultiple[2]}
+									bind:group={relationalBooksMultiple}
+									name="r_books"
+									value="The Art of Unix Programming"
+								>
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let mediumMultiple = ['movies'];
+let booksMultiple: string[] = [];
+let children: TreeViewItem[] = [];
+`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView selection={true} multiple={true}>
+	<TreeViewItem bind:group={mediumMultiple} name="medium" value="books" children={children}>
+		<svelte:fragment slot="lead">
+			(icon)
+		</svelte:fragment>
+		<p>Books</p>
+		<svelte:fragment slot="children">
+			<TreeViewItem bind:this={children[0]} bind:group={booksMultiple} name="books" value="Clean Code">
+				<p>Clean Code</p>
+			</TreeViewItem>
+			<TreeViewItem bind:this={children[1]} bind:group={booksMultiple} name="books" value="The Clean Coder">
+				<p>The Clean Coder</p>
+			</TreeViewItem>
+			<TreeViewItem bind:this={children[2]} bind:group={booksMultiple} name="books" value="The Art of Unix Programming">
+				<p>The Art of Unix Programming</p>
+			</TreeViewItem>
+		</svelte:fragment>
+	</TreeViewItem>
+	<!-- ... -->
+</TreeView>
+			`}
+					/>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<p>Select children of <code class="code">Books</code> to see relational checking.</p>
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -40,6 +40,10 @@
 	let relationalMediumMultiple = ['movies'];
 	let relationalBooksMultiple: string[] = [];
 	let childrenMultiple: TreeViewItem[] = [];
+
+	let expandTree: TreeView;
+
+	let selectMultiple: string[] = [];
 </script>
 
 <DocsShell {settings}>
@@ -168,7 +172,7 @@
 			<h3 class="h3">Single</h3>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<TreeView selection={true}>
+					<TreeView selection>
 						<TreeViewItem bind:group={mediumSingle} name="medium" value="books">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-book-skull" />
@@ -211,7 +215,7 @@ let booksSingle: string = 'Clean Code';
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView selection={true}>
+<TreeView selection>
 	<TreeViewItem bind:group={mediumSingle} name="medium" value="books">
 		<svelte:fragment slot="lead">
 			(icon)
@@ -253,7 +257,7 @@ let booksSingle: string = 'Clean Code';
 			<h3 class="h3">Multiple</h3>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<TreeView selection={true} multiple={true}>
+					<TreeView selection multiple>
 						<TreeViewItem bind:group={mediumMultiple} name="medium" value="books">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-book-skull" />
@@ -296,7 +300,7 @@ let booksMultiple = ['Clean Code', 'The Art of Unix Programming']
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView selection={true} multiple={true}>
+<TreeView selection multiple>
 	<TreeViewItem bind:group={mediumMultiple} name="medium" value="books">
 		<svelte:fragment slot="lead">
 			(icon)
@@ -348,7 +352,7 @@ let booksMultiple = ['Clean Code', 'The Art of Unix Programming']
 			</p>
 			<DocsPreview background="neutral" regionFooter="text-center">
 				<svelte:fragment slot="preview">
-					<TreeView selection={true}>
+					<TreeView selection>
 						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="books" open children={childrenSingle}>
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-book-skull" />
@@ -397,7 +401,7 @@ let children: TreeViewItem[] = [];
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView selection={true}>
+<TreeView selection>
 	<TreeViewItem bind:group={mediumSingle} name="medium" value="books" children={children}>
 		<svelte:fragment slot="lead">
 			(icon)
@@ -426,7 +430,7 @@ let children: TreeViewItem[] = [];
 			</DocsPreview>
 			<DocsPreview background="neutral" regionFooter="text-center">
 				<svelte:fragment slot="preview">
-					<TreeView selection={true} multiple={true}>
+					<TreeView selection multiple>
 						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="books" open children={childrenMultiple}>
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-book-skull" />
@@ -475,7 +479,7 @@ let children: TreeViewItem[] = [];
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView selection={true} multiple={true}>
+<TreeView selection multiple>
 	<TreeViewItem bind:group={mediumMultiple} name="medium" value="books" children={children}>
 		<svelte:fragment slot="lead">
 			(icon)
@@ -572,8 +576,151 @@ let children: TreeViewItem[] = [];
 			`}
 					/>
 				</svelte:fragment>
+			</DocsPreview>
+		</section>
+		<!-- Expand/Collapse all -->
+		<section class="space-y-4">
+			<h2 class="h2">Expand/Collapse all</h2>
+			<p>
+				By binding to the <code class="code">tree</code> we can call the functions <code class="code">expandAll()</code>,
+				<code class="code">collapseAll()</code>.
+			</p>
+			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
+				<svelte:fragment slot="preview">
+					<TreeView bind:this={expandTree}>
+						<TreeViewItem>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem>
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem>
+									<p>The Flash</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>Guardians of the Galaxy</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>Black Panther</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem>
+									<p>The Simpsons</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>Rick and Morty</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>Family Guy</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<p>Select children of <code class="code">Books</code> to see relational checking.</p>
+					<button class="btn variant-filled-primary" on:click={expandTree.expandAll}> Expand all </button>
+					<button class="btn variant-filled-secondary" on:click={expandTree.collapseAll}> Collapse all </button>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let tree: TreeView;
+// expand all
+tree.expandAll();
+// collapse all
+tree.collapseAll();
+					`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView bind:this={tree}>
+	<!-- ... -->
+</TreeView>
+			`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
+		<!-- Select/Deselect all -->
+		<section class="space-y-4">
+			<h2 class="h2">Select/Deselect all</h2>
+			<p>
+				By binding to the <code class="code">tree</code> we can call the functions <code class="code">selectAll()</code>,
+				<code class="code">deselectAll()</code>.
+			</p>
+			<p>Note: These functions are excecuted only in <code class="code">multiple</code> selection mode.</p>
+			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
+				<svelte:fragment slot="preview">
+					<TreeView selection multiple bind:this={expandTree}>
+						<TreeViewItem bind:group={selectMultiple} name="s_medium" value="books">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={selectMultiple} name="s_medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={selectMultiple} name="s_medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<button class="btn variant-filled-primary" on:click={expandTree.selectAll}> Select all </button>
+					<button class="btn variant-filled-secondary" on:click={expandTree.deselectAll}> Deselect all </button>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let tree: TreeView;
+// select all
+tree.selectAll();
+// deselect all
+tree.deselectAll();
+					`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView bind:this={tree} selection multiple>
+	<!-- ... -->
+</TreeView>
+			`}
+					/>
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -3,7 +3,7 @@
 	import { DocsFeature, type DocsShellSettings } from '$lib/layouts/DocsShell/types';
 	import DocsPreview from '$lib/components/DocsPreview/DocsPreview.svelte';
 	// Components
-	import { TreeView, TreeViewItem } from '@skeletonlabs/skeleton';
+	import { TreeView, TreeViewItem, type TreeViewNode } from '@skeletonlabs/skeleton';
 	// Utilities
 	import { CodeBlock } from '@skeletonlabs/skeleton';
 	// Sveld
@@ -45,6 +45,24 @@
 	let selectTree: TreeView;
 
 	let selectMultiple: string[] = [];
+
+	let simpleDD: TreeViewNode[] = [
+		{
+			content: 'Books',
+			lead: '<i class="fa-solid fa-book-skull"></i>',
+			open: true,
+			children: [{ content: 'Clean Code' }, { content: 'The Clean Coder' }, { content: 'The Art of Unix Programming' }]
+		},
+		{
+			content: 'Movies',
+			lead: '<i class="fa-solid fa-film"></i>',
+			children: [{ content: 'The Flash' }, { content: 'Guardians of the Galaxy' }, { content: 'Black Panther' }]
+		},
+		{
+			content: 'TV',
+			lead: '<i class="fa-solid fa-tv"></i>'
+		}
+	];
 </script>
 
 <DocsShell {settings}>
@@ -721,6 +739,41 @@ tree.deselectAll();
 	<!-- ... -->
 </TreeView>
 			`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
+		<section class="space-y-4">
+			<h2 class="h2">Data driven tree-view</h2>
+			<h3 class="h3">Simple</h3>
+			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
+				<svelte:fragment slot="preview">
+					<TreeView nodes={simpleDD} />
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let nodes: TreeViewNode[] = [
+	{
+		content: 'Books',
+		lead: '(icon)',
+		open: true,
+		children: [
+			{ content: 'Clean Code' },
+			{ content: 'The Clean Coder' },
+			{ content: 'The Art of Unix Programming' },
+		]
+	},
+	// ...
+]
+						`}
+					/>
+					<CodeBlock
+						langauge="html"
+						code={`
+<TreeView nodes={nodes}/>
+						`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -27,6 +27,9 @@
 			}
 		]
 	};
+
+	let test = false;
+	$: console.log(test);
 </script>
 
 <DocsShell {settings}>
@@ -142,6 +145,57 @@
 		(item 1)
 	</TreeViewItem>
 </TreeView>
+					`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
+		<!-- Selection -->
+		<section class="space-y-4">
+			<h2 class="h2">Selection</h2>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<TreeView selection="multi">
+						<TreeViewItem open bind:selected={test}>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-folder" />
+							</svelte:fragment>
+							<p>Folder</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem>
+									<svelte:fragment slot="lead">
+										<i class="fa-solid fa-folder" />
+									</svelte:fragment>
+									<p>Folder 2</p>
+									<svelte:fragment slot="children">
+										<TreeViewItem>
+											<svelte:fragment slot="lead">
+												<i class="fa-solid fa-file" />
+											</svelte:fragment>
+											<p>File 1</p>
+										</TreeViewItem>
+										<TreeViewItem>
+											<svelte:fragment slot="lead">
+												<i class="fa-solid fa-file" />
+											</svelte:fragment>
+											<p>File 2</p>
+										</TreeViewItem>
+									</svelte:fragment>
+								</TreeViewItem>
+								<TreeViewItem>
+									<svelte:fragment slot="lead">
+										<i class="fa-solid fa-file" />
+									</svelte:fragment>
+									<p>File 2</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="html"
+						code={`
 					`}
 					/>
 				</svelte:fragment>

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -15,7 +15,7 @@
 		feature: DocsFeature.Component,
 		name: 'Tree Views',
 		description: 'Display information in a hierarchical structure using collapsible nodes.',
-		imports: ['TreeView', 'TreeViewItem'],
+		imports: ['TreeView', 'TreeViewItem', 'type TreeViewNode'],
 		source: 'components/TreeView',
 		aria: 'https://www.w3.org/WAI/ARIA/apg/patterns/treeview/',
 		components: [
@@ -23,18 +23,34 @@
 			{
 				label: 'TreeViewItem',
 				sveld: sveldTreeViewItem,
-				overrideProps: []
+				overrideProps: [
+					'open',
+					'selection',
+					'multiple',
+					'disabled',
+					'padding',
+					'indent',
+					'hover',
+					'rounded',
+					'caretOpen',
+					'hyphenOpacity',
+					'regionSummary',
+					'regionSymbol',
+					'regionChildren'
+				]
 			}
 		]
 	};
 
 	// Locals
+	// single
 	let mediumSingle: string = 'books';
 	let booksSingle: string = 'Clean Code';
 	let relationalMediumSingle: string = 'books';
 	let relationalBooksSingle: string = 'Clean Code';
 	let childrenSingle: TreeViewItem[] = [];
 
+	// multi
 	let mediumMultiple = ['books', 'movies'];
 	let booksMultiple = ['Clean Code', 'The Art of Unix Programming'];
 	let relationalMediumMultiple = ['movies'];
@@ -51,16 +67,87 @@
 			content: 'Books',
 			lead: '<i class="fa-solid fa-book-skull"></i>',
 			open: true,
-			children: [{ content: 'Clean Code' }, { content: 'The Clean Coder' }, { content: 'The Art of Unix Programming' }]
+			children: [
+				{ content: 'Clean Code', value: 'Clean Code' },
+				{ content: 'The Clean Coder', value: 'The Clean Coder' },
+				{ content: 'The Art of Unix Programming', value: 'The Art of Unix Programming' }
+			],
+			value: 'books'
 		},
 		{
 			content: 'Movies',
 			lead: '<i class="fa-solid fa-film"></i>',
-			children: [{ content: 'The Flash' }, { content: 'Guardians of the Galaxy' }, { content: 'Black Panther' }]
+			children: [
+				{ content: 'The Flash', value: 'The Flash' },
+				{ content: 'Guardians of the Galaxy', value: 'Guardians of the Galaxy' },
+				{ content: 'Black Panther', value: 'Black Panther' }
+			],
+			value: 'movies'
 		},
 		{
 			content: 'TV',
-			lead: '<i class="fa-solid fa-tv"></i>'
+			lead: '<i class="fa-solid fa-tv"></i>',
+			value: 'tv'
+		}
+	];
+
+	let singleDD: TreeViewNode[] = [
+		{
+			content: 'Books',
+			lead: '<i class="fa-solid fa-book-skull"></i>',
+			open: true,
+			checked: true,
+			children: [
+				{ content: 'Clean Code', value: 'Clean Code' },
+				{ content: 'The Clean Coder', value: 'The Clean Coder' },
+				{ content: 'The Art of Unix Programming', value: 'The Art of Unix Programming', checked: true }
+			],
+			value: 'books'
+		},
+		{
+			content: 'Movies',
+			lead: '<i class="fa-solid fa-film"></i>',
+			children: [
+				{ content: 'The Flash', value: 'The Flash' },
+				{ content: 'Guardians of the Galaxy', value: 'Guardians of the Galaxy' },
+				{ content: 'Black Panther', value: 'Black Panther' }
+			],
+			value: 'movies'
+		},
+		{
+			content: 'TV',
+			lead: '<i class="fa-solid fa-tv"></i>',
+			value: 'tv'
+		}
+	];
+
+	let multipleDD: TreeViewNode[] = [
+		{
+			content: 'Books',
+			lead: '<i class="fa-solid fa-book-skull"></i>',
+			open: true,
+			indeterminate: true,
+			children: [
+				{ content: 'Clean Code', value: 'Clean Code' },
+				{ content: 'The Clean Coder', value: 'The Clean Coder', checked: true },
+				{ content: 'The Art of Unix Programming', value: 'The Art of Unix Programming', checked: true }
+			],
+			value: 'books'
+		},
+		{
+			content: 'Movies',
+			lead: '<i class="fa-solid fa-film"></i>',
+			children: [
+				{ content: 'The Flash', value: 'The Flash' },
+				{ content: 'Guardians of the Galaxy', value: 'Guardians of the Galaxy' },
+				{ content: 'Black Panther', value: 'Black Panther' }
+			],
+			value: 'movies'
+		},
+		{
+			content: 'TV',
+			lead: '<i class="fa-solid fa-tv"></i>',
+			value: 'tv'
 		}
 	];
 </script>
@@ -444,7 +531,7 @@ let children: TreeViewItem[] = [];
 					/>
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<p>Select <code class="code">Movies</code> to see relational checking.</p>
+					<p>Check <code class="code">Movies</code> to see relational checking in action.</p>
 				</svelte:fragment>
 			</DocsPreview>
 			<DocsPreview background="neutral" regionFooter="text-center">
@@ -522,10 +609,11 @@ let children: TreeViewItem[] = [];
 					/>
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<p>Select children of <code class="code">Books</code> to see relational checking.</p>
+					<p>Check children of <code class="code">Books</code> to see relational checking in action.</p>
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
+		<!-- Disbled -->
 		<section class="space-y-4">
 			<h2 class="h2">Disabled</h2>
 			<DocsPreview background="neutral">
@@ -602,7 +690,7 @@ let children: TreeViewItem[] = [];
 			<h2 class="h2">Expand/Collapse all</h2>
 			<p>
 				By binding to the <code class="code">tree</code> we can call the functions <code class="code">expandAll()</code>,
-				<code class="code">collapseAll()</code>.
+				<code class="code">collapseAll()</code> directly from the bound object.
 			</p>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
 				<svelte:fragment slot="preview">
@@ -691,7 +779,7 @@ tree.collapseAll();
 			<h2 class="h2">Select/Deselect all</h2>
 			<p>
 				By binding to the <code class="code">tree</code> we can call the functions <code class="code">selectAll()</code>,
-				<code class="code">deselectAll()</code>.
+				<code class="code">deselectAll()</code> directly from the bound object.
 			</p>
 			<p>Note: These functions are excecuted only in <code class="code">multiple</code> selection mode.</p>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
@@ -743,12 +831,14 @@ tree.deselectAll();
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
+		<!-- Data-Driven -->
 		<section class="space-y-4">
 			<h2 class="h2">Data driven tree-view</h2>
-			<h3 class="h3">Simple</h3>
+			<!-- Simple data driven -->
+			<h3 class="h3">Simple data driven</h3>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
 				<svelte:fragment slot="preview">
-					<TreeView nodes={simpleDD} />
+					<TreeView bind:nodes={simpleDD} />
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock
@@ -770,9 +860,82 @@ let nodes: TreeViewNode[] = [
 						`}
 					/>
 					<CodeBlock
-						langauge="html"
+						language="html"
 						code={`
 <TreeView nodes={nodes}/>
+						`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- Single data driven -->
+			<h3 class="h3">Single data driven</h3>
+			<p>
+				Note: relational checking is auto applied in <code class="code">Data-Driven</code> mode. This means setting a child as checked in the
+				initial data, won't have effect if the parent wasn't checked too.
+			</p>
+			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
+				<svelte:fragment slot="preview">
+					<TreeView bind:nodes={singleDD} selection />
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let nodes: TreeViewNode[] = [
+	{
+		content: 'Books',
+		lead: '(icon)',
+		open: true,
+		checked: true,
+		children: [
+			{ content: 'Clean Code' },
+			{ content: 'The Clean Coder' },
+			{ content: 'The Art of Unix Programming', checked: true },
+		]
+	},
+	// ...
+]
+						`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView bind:nodes={nodes} selection/>
+						`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- Multiple data driven -->
+			<h3 class="h3">Multiple data driven</h3>
+			<p>Note: relational checking is auto applied in <code class="code">Data-Driven</code> mode.</p>
+			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
+				<svelte:fragment slot="preview">
+					<TreeView bind:nodes={multipleDD} selection multiple />
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let nodes: TreeViewNode[] = [
+	{
+		content: 'Books',
+		lead: '(icon)',
+		open: true,
+		indeterminate: true,
+		children: [
+			{ content: 'Clean Code', checked: true },
+			{ content: 'The Clean Coder', checked: true },
+			{ content: 'The Art of Unix Programming' },
+		]
+	},
+	// ...
+]
+						`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView bind:nodes={nodes} selection multiple/>
 						`}
 					/>
 				</svelte:fragment>

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -28,8 +28,11 @@
 		]
 	};
 
-	let test = false;
-	$: console.log(test);
+	// Locals
+	let valueSingle: string = 'books';
+	let booksSingle: string = 'Clean Code';
+	let valueMultiple = ['books', 'movies'];
+	let booksMultiple = ['Clean Code', 'The Art of Unix Programming'];
 </script>
 
 <DocsShell {settings}>
@@ -153,51 +156,179 @@
 		<!-- Selection -->
 		<section class="space-y-4">
 			<h2 class="h2">Selection</h2>
+			<p>Enable selection using the prop <code class="code">selection</code></p>
+			<h3 class="h3">Single</h3>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<TreeView selection="multi">
-						<TreeViewItem open bind:selected={test}>
+					<TreeView selection={true}>
+						<TreeViewItem bind:group={valueSingle} name="medium" value="books">
 							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-folder" />
+								<i class="fa-solid fa-book-skull" />
 							</svelte:fragment>
-							<p>Folder</p>
+							<p>Books</p>
 							<svelte:fragment slot="children">
-								<TreeViewItem>
-									<svelte:fragment slot="lead">
-										<i class="fa-solid fa-folder" />
-									</svelte:fragment>
-									<p>Folder 2</p>
-									<svelte:fragment slot="children">
-										<TreeViewItem>
-											<svelte:fragment slot="lead">
-												<i class="fa-solid fa-file" />
-											</svelte:fragment>
-											<p>File 1</p>
-										</TreeViewItem>
-										<TreeViewItem>
-											<svelte:fragment slot="lead">
-												<i class="fa-solid fa-file" />
-											</svelte:fragment>
-											<p>File 2</p>
-										</TreeViewItem>
-									</svelte:fragment>
+								<TreeViewItem bind:group={booksSingle} name="books" value="Clean Code">
+									<p>Clean Code</p>
 								</TreeViewItem>
-								<TreeViewItem>
-									<svelte:fragment slot="lead">
-										<i class="fa-solid fa-file" />
-									</svelte:fragment>
-									<p>File 2</p>
+								<TreeViewItem bind:group={booksSingle} name="books" value="The Clean Coder">
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem bind:group={booksSingle} name="books" value="The Art of Unix Programming">
+									<p>The Art of Unix Programming</p>
 								</TreeViewItem>
 							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem bind:group={valueSingle} name="medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={valueSingle} name="medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
 						</TreeViewItem>
 					</TreeView>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock
+						language="ts"
+						code={`
+let mediumSingle: string = 'books';
+let booksSingle: string = 'Clean Code';
+`}
+					/>
+					<CodeBlock
 						language="html"
 						code={`
-					`}
+<TreeView selection={true}>
+	<TreeViewItem bind:group={mediumSingle} name="medium" value="books">
+		<svelte:fragment slot="lead">
+			(icon)
+		</svelte:fragment>
+		<p>Books</p>
+		<svelte:fragment slot="children">
+			<TreeViewItem bind:group={booksSingle} name="books" value="Clean Code">
+				<p>Clean Code</p>
+			</TreeViewItem>
+			<TreeViewItem bind:group={booksSingle} name="books" value="The Clean Coder">
+				<p>The Clean Coder</p>
+			</TreeViewItem>
+			<TreeViewItem bind:group={booksSingle} name="books" value="The Art of Unix Programming">
+				<p>The Art of Unix Programming</p>
+			</TreeViewItem>
+		</svelte:fragment>
+	</TreeViewItem>
+	<TreeViewItem bind:group={mediumSingle} name="medium" value="movies">
+		<svelte:fragment slot="lead">
+			(icon)
+		</svelte:fragment>
+		<p>Movies</p>
+	</TreeViewItem>
+	<TreeViewItem bind:group={mediumSingle} name="medium" value="tv">
+		<svelte:fragment slot="lead">
+			(icon)
+		</svelte:fragment>
+		<p>TV</p>
+	</TreeViewItem>
+</TreeView>
+			`}
 					/>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<div class="text-center"><code class="code">Selected medium: {valueSingle} <br /> Selected book: {booksSingle}</code></div>
+				</svelte:fragment>
+			</DocsPreview>
+			<h3 class="h3">Multiple</h3>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<TreeView selection={true} multiple={true}>
+						<TreeViewItem bind:group={valueMultiple} name="medium" value="books">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem bind:group={booksMultiple} name="books" value="Clean Code">
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem bind:group={booksMultiple} name="books" value="The Clean Coder">
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem bind:group={booksMultiple} name="books" value="The Art of Unix Programming">
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem bind:group={valueMultiple} name="medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={valueMultiple} name="medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let mediumMultiple = ['books', 'movies'];
+let booksMultiple = ['Clean Code', 'The Art of Unix Programming']
+`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView selection={true} multiple={true}>
+	<TreeViewItem bind:group={mediumMultiple} name="medium" value="books">
+		<svelte:fragment slot="lead">
+			(icon)
+		</svelte:fragment>
+		<p>Books</p>
+		<svelte:fragment slot="children">
+			<TreeViewItem bind:group={booksMultiple} name="books" value="Clean Code">
+				<p>Clean Code</p>
+			</TreeViewItem>
+			<TreeViewItem bind:group={booksMultiple} name="books" value="The Clean Coder">
+				<p>The Clean Coder</p>
+			</TreeViewItem>
+			<TreeViewItem bind:group={booksMultiple} name="books" value="The Art of Unix Programming">
+				<p>The Art of Unix Programming</p>
+			</TreeViewItem>
+		</svelte:fragment>
+	</TreeViewItem>
+	<TreeViewItem bind:group={mediumMultiple} name="medium" value="movies">
+		<svelte:fragment slot="lead">
+			(icon)
+		</svelte:fragment>
+		<p>Movies</p>
+	</TreeViewItem>
+	<TreeViewItem bind:group={mediumMultiple} name="medium" value="tv">
+		<svelte:fragment slot="lead">
+			(icon)
+		</svelte:fragment>
+		<p>TV</p>
+	</TreeViewItem>
+</TreeView>
+			`}
+					/>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<div class="text-center">
+						<code class="code"
+							>Selected mediums: {valueMultiple.length ? valueMultiple : 'None'} <br /> Selected books: {booksMultiple.length
+								? booksMultiple
+								: 'None'}</code
+						>
+					</div>
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -52,10 +52,10 @@
 
 	// Locals
 	// single
-	let mediumSingle: string = 'books';
-	let booksSingle: string = 'Clean Code';
-	let relationalMediumSingle: string = 'books';
-	let relationalBooksSingle: string = 'Clean Code';
+	let mediumSingle = 'books';
+	let booksSingle = 'Clean Code';
+	let relationalMediumSingle = 'books';
+	let relationalBooksSingle = 'Clean Code';
 	let childrenSingle: TreeViewItem[] = [];
 
 	// multi
@@ -267,9 +267,7 @@
 						code={`
 <TreeView>
 	<TreeViewItem>
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
+		<svelte:fragment slot="lead">(icon)</svelte:fragment>
 		(item 1)
 	</TreeViewItem>
 </TreeView>
@@ -278,352 +276,9 @@
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
-		<!-- Selection -->
-		<section class="space-y-4">
-			<h2 class="h2">Selection</h2>
-			<p>Enable selection using the prop <code class="code">selection</code></p>
-			<!-- Single -->
-			<h3 class="h3">Single</h3>
-			<DocsPreview background="neutral">
-				<svelte:fragment slot="preview">
-					<TreeView selection>
-						<TreeViewItem bind:group={mediumSingle} name="medium" value="books">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-book-skull" />
-							</svelte:fragment>
-							<p>Books</p>
-							<svelte:fragment slot="children">
-								<TreeViewItem bind:group={booksSingle} name="books" value="Clean Code">
-									<p>Clean Code</p>
-								</TreeViewItem>
-								<TreeViewItem bind:group={booksSingle} name="books" value="The Clean Coder">
-									<p>The Clean Coder</p>
-								</TreeViewItem>
-								<TreeViewItem bind:group={booksSingle} name="books" value="The Art of Unix Programming">
-									<p>The Art of Unix Programming</p>
-								</TreeViewItem>
-							</svelte:fragment>
-						</TreeViewItem>
-						<TreeViewItem bind:group={mediumSingle} name="medium" value="movies">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-film" />
-							</svelte:fragment>
-							<p>Movies</p>
-						</TreeViewItem>
-						<TreeViewItem bind:group={mediumSingle} name="medium" value="tv">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-tv" />
-							</svelte:fragment>
-							<p>TV</p>
-						</TreeViewItem>
-					</TreeView>
-				</svelte:fragment>
-				<svelte:fragment slot="source">
-					<CodeBlock
-						language="ts"
-						code={`
-let mediumSingle: string = 'books';
-let booksSingle: string = 'Clean Code';
-`}
-					/>
-					<CodeBlock
-						language="html"
-						code={`
-<TreeView selection>
-	<TreeViewItem bind:group={mediumSingle} name="medium" value="books">
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
-		<p>Books</p>
-		<svelte:fragment slot="children">
-			<TreeViewItem bind:group={booksSingle} name="books" value="Clean Code">
-				<p>Clean Code</p>
-			</TreeViewItem>
-			<TreeViewItem bind:group={booksSingle} name="books" value="The Clean Coder">
-				<p>The Clean Coder</p>
-			</TreeViewItem>
-			<TreeViewItem bind:group={booksSingle} name="books" value="The Art of Unix Programming">
-				<p>The Art of Unix Programming</p>
-			</TreeViewItem>
-		</svelte:fragment>
-	</TreeViewItem>
-	<TreeViewItem bind:group={mediumSingle} name="medium" value="movies">
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
-		<p>Movies</p>
-	</TreeViewItem>
-	<TreeViewItem bind:group={mediumSingle} name="medium" value="tv">
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
-		<p>TV</p>
-	</TreeViewItem>
-</TreeView>
-			`}
-					/>
-				</svelte:fragment>
-				<svelte:fragment slot="footer">
-					<div class="text-center"><code class="code">Selected medium: {mediumSingle} <br /> Selected book: {booksSingle}</code></div>
-				</svelte:fragment>
-			</DocsPreview>
-			<!-- Multiple -->
-			<h3 class="h3">Multiple</h3>
-			<DocsPreview background="neutral">
-				<svelte:fragment slot="preview">
-					<TreeView selection multiple>
-						<TreeViewItem bind:group={mediumMultiple} name="medium" value="books">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-book-skull" />
-							</svelte:fragment>
-							<p>Books</p>
-							<svelte:fragment slot="children">
-								<TreeViewItem bind:group={booksMultiple} name="books" value="Clean Code">
-									<p>Clean Code</p>
-								</TreeViewItem>
-								<TreeViewItem bind:group={booksMultiple} name="books" value="The Clean Coder">
-									<p>The Clean Coder</p>
-								</TreeViewItem>
-								<TreeViewItem bind:group={booksMultiple} name="books" value="The Art of Unix Programming">
-									<p>The Art of Unix Programming</p>
-								</TreeViewItem>
-							</svelte:fragment>
-						</TreeViewItem>
-						<TreeViewItem bind:group={mediumMultiple} name="medium" value="movies">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-film" />
-							</svelte:fragment>
-							<p>Movies</p>
-						</TreeViewItem>
-						<TreeViewItem bind:group={mediumMultiple} name="medium" value="tv">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-tv" />
-							</svelte:fragment>
-							<p>TV</p>
-						</TreeViewItem>
-					</TreeView>
-				</svelte:fragment>
-				<svelte:fragment slot="source">
-					<CodeBlock
-						language="ts"
-						code={`
-let mediumMultiple = ['books', 'movies'];
-let booksMultiple = ['Clean Code', 'The Art of Unix Programming']
-`}
-					/>
-					<CodeBlock
-						language="html"
-						code={`
-<TreeView selection multiple>
-	<TreeViewItem bind:group={mediumMultiple} name="medium" value="books">
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
-		<p>Books</p>
-		<svelte:fragment slot="children">
-			<TreeViewItem bind:group={booksMultiple} name="books" value="Clean Code">
-				<p>Clean Code</p>
-			</TreeViewItem>
-			<TreeViewItem bind:group={booksMultiple} name="books" value="The Clean Coder">
-				<p>The Clean Coder</p>
-			</TreeViewItem>
-			<TreeViewItem bind:group={booksMultiple} name="books" value="The Art of Unix Programming">
-				<p>The Art of Unix Programming</p>
-			</TreeViewItem>
-		</svelte:fragment>
-	</TreeViewItem>
-	<TreeViewItem bind:group={mediumMultiple} name="medium" value="movies">
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
-		<p>Movies</p>
-	</TreeViewItem>
-	<TreeViewItem bind:group={mediumMultiple} name="medium" value="tv">
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
-		<p>TV</p>
-	</TreeViewItem>
-</TreeView>
-			`}
-					/>
-				</svelte:fragment>
-				<svelte:fragment slot="footer">
-					<div class="text-center">
-						<code class="code"
-							>Selected mediums: {mediumMultiple.length ? mediumMultiple : 'None'} <br /> Selected books: {booksMultiple.length
-								? booksMultiple
-								: 'None'}</code
-						>
-					</div>
-				</svelte:fragment>
-			</DocsPreview>
-			<!-- Relational -->
-			<h3 class="h3">Relational</h3>
-			<p>
-				By passing children references to a parent <code class="code">TreeViewItem</code>, the check value of the parent will be relational,
-				meaning it will react to the check value of the children.
-			</p>
-			<DocsPreview background="neutral" regionFooter="text-center">
-				<svelte:fragment slot="preview">
-					<TreeView selection>
-						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="books" open children={childrenSingle}>
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-book-skull" />
-							</svelte:fragment>
-							<p>Books</p>
-							<svelte:fragment slot="children">
-								<TreeViewItem bind:this={childrenSingle[0]} bind:group={relationalBooksSingle} name="r_books" value="Clean Code">
-									<p>Clean Code</p>
-								</TreeViewItem>
-								<TreeViewItem bind:this={childrenSingle[1]} bind:group={relationalBooksSingle} name="r_books" value="The Clean Coder">
-									<p>The Clean Coder</p>
-								</TreeViewItem>
-								<TreeViewItem
-									bind:this={childrenSingle[2]}
-									bind:group={relationalBooksSingle}
-									name="r_books"
-									value="The Art of Unix Programming"
-								>
-									<p>The Art of Unix Programming</p>
-								</TreeViewItem>
-							</svelte:fragment>
-						</TreeViewItem>
-						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="movies">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-film" />
-							</svelte:fragment>
-							<p>Movies</p>
-						</TreeViewItem>
-						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="tv">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-tv" />
-							</svelte:fragment>
-							<p>TV</p>
-						</TreeViewItem>
-					</TreeView>
-				</svelte:fragment>
-				<svelte:fragment slot="source">
-					<CodeBlock
-						language="ts"
-						code={`
-let mediumSingle: string = 'books';
-let booksSingle: string = 'Clean Code';
-let children: TreeViewItem[] = [];
-`}
-					/>
-					<CodeBlock
-						language="html"
-						code={`
-<TreeView selection>
-	<TreeViewItem bind:group={mediumSingle} name="medium" value="books" children={children}>
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
-		<p>Books</p>
-		<svelte:fragment slot="children">
-			<TreeViewItem bind:this={children[0]} bind:group={booksSingle} name="books" value="Clean Code">
-				<p>Clean Code</p>
-			</TreeViewItem>
-			<TreeViewItem bind:this={children[1]} bind:group={booksSingle} name="books" value="The Clean Coder">
-				<p>The Clean Coder</p>
-			</TreeViewItem>
-			<TreeViewItem bind:this={children[2]} bind:group={booksSingle} name="books" value="The Art of Unix Programming">
-				<p>The Art of Unix Programming</p>
-			</TreeViewItem>
-		</svelte:fragment>
-	</TreeViewItem>
-	<!-- ... -->
-</TreeView>
-			`}
-					/>
-				</svelte:fragment>
-				<svelte:fragment slot="footer">
-					<p>Check <code class="code">Movies</code> to see relational checking in action.</p>
-				</svelte:fragment>
-			</DocsPreview>
-			<DocsPreview background="neutral" regionFooter="text-center">
-				<svelte:fragment slot="preview">
-					<TreeView selection multiple>
-						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="books" open children={childrenMultiple}>
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-book-skull" />
-							</svelte:fragment>
-							<p>Books</p>
-							<svelte:fragment slot="children">
-								<TreeViewItem bind:this={childrenMultiple[0]} bind:group={relationalBooksMultiple} name="r_books" value="Clean Code">
-									<p>Clean Code</p>
-								</TreeViewItem>
-								<TreeViewItem bind:this={childrenMultiple[1]} bind:group={relationalBooksMultiple} name="r_books" value="The Clean Coder">
-									<p>The Clean Coder</p>
-								</TreeViewItem>
-								<TreeViewItem
-									bind:this={childrenMultiple[2]}
-									bind:group={relationalBooksMultiple}
-									name="r_books"
-									value="The Art of Unix Programming"
-								>
-									<p>The Art of Unix Programming</p>
-								</TreeViewItem>
-							</svelte:fragment>
-						</TreeViewItem>
-						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="movies">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-film" />
-							</svelte:fragment>
-							<p>Movies</p>
-						</TreeViewItem>
-						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="tv">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-tv" />
-							</svelte:fragment>
-							<p>TV</p>
-						</TreeViewItem>
-					</TreeView>
-				</svelte:fragment>
-				<svelte:fragment slot="source">
-					<CodeBlock
-						language="ts"
-						code={`
-let mediumMultiple = ['movies'];
-let booksMultiple: string[] = [];
-let children: TreeViewItem[] = [];
-`}
-					/>
-					<CodeBlock
-						language="html"
-						code={`
-<TreeView selection multiple>
-	<TreeViewItem bind:group={mediumMultiple} name="medium" value="books" children={children}>
-		<svelte:fragment slot="lead">
-			(icon)
-		</svelte:fragment>
-		<p>Books</p>
-		<svelte:fragment slot="children">
-			<TreeViewItem bind:this={children[0]} bind:group={booksMultiple} name="books" value="Clean Code">
-				<p>Clean Code</p>
-			</TreeViewItem>
-			<TreeViewItem bind:this={children[1]} bind:group={booksMultiple} name="books" value="The Clean Coder">
-				<p>The Clean Coder</p>
-			</TreeViewItem>
-			<TreeViewItem bind:this={children[2]} bind:group={booksMultiple} name="books" value="The Art of Unix Programming">
-				<p>The Art of Unix Programming</p>
-			</TreeViewItem>
-		</svelte:fragment>
-	</TreeViewItem>
-	<!-- ... -->
-</TreeView>
-			`}
-					/>
-				</svelte:fragment>
-				<svelte:fragment slot="footer">
-					<p>Check children of <code class="code">Books</code> to see relational checking in action.</p>
-				</svelte:fragment>
-			</DocsPreview>
-		</section>
 		<!-- Disbled -->
 		<section class="space-y-4">
-			<h2 class="h2">Disabled</h2>
+			<h2 class="h2">Disabled State</h2>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<TreeView disabled>
@@ -670,36 +325,25 @@ let children: TreeViewItem[] = [];
 					</TreeView>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
+					<p>Disable the entire tree view component</p>
+					<CodeBlock language="html" code={`<TreeView disabled></TreeView>`} />
+					<p>Disable individual item components.</p>
 					<CodeBlock
 						language="html"
 						code={`
-<!-- Disable tree -->
-<TreeView disabled>
-	<!-- ... -->
-</TreeView>
-
-<!-- Disable tree items -->
 <TreeView>
-	<TreeViewItem disabled>
-		<!-- ... -->
-	</TreeViewItem>
-	<!-- Opened, disabled Tree item -->
-	<TreeViewItem open disabled>
-		<!-- ... -->
-	</TreeViewItem>
+	<TreeViewItem disabled></TreeViewItem>
+	<TreeViewItem open disabled></TreeViewItem>
 </TreeView>
 			`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
-		<!-- Expand/Collapse all -->
+		<!-- Expand & Collapse -->
 		<section class="space-y-4">
-			<h2 class="h2">Expand/Collapse all</h2>
-			<p>
-				By binding to the <code class="code">tree</code> we can call the functions <code class="code">expandAll()</code>,
-				<code class="code">collapseAll()</code> directly from the bound object.
-			</p>
+			<h2 class="h2">Expand & Collapse</h2>
+			<p>We can bind the tree view and trigger methods for expanding or collapsing all children at once.</p>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
 				<svelte:fragment slot="preview">
 					<TreeView bind:this={expandTree}>
@@ -757,39 +401,341 @@ let children: TreeViewItem[] = [];
 					</TreeView>
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<button class="btn variant-filled-primary" on:click={expandTree.expandAll}> Expand all </button>
-					<button class="btn variant-filled-secondary" on:click={expandTree.collapseAll}> Collapse all </button>
+					<button class="btn variant-filled" on:click={expandTree.expandAll}>Expand</button>
+					<button class="btn variant-filled" on:click={expandTree.collapseAll}>Collapse</button>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="ts"
 						code={`
-let tree: TreeView;
-// expand all
-tree.expandAll();
-// collapse all
-tree.collapseAll();
+let myTreeView: TreeView;\n
+myTreeView.expandAll();
+myTreeView.collapseAll();
 					`}
 					/>
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView bind:this={tree}>
+<TreeView bind:this={myTreeView}></TreeView>
+			`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
+
+		<hr />
+
+		<!-- Selection -->
+		<section class="space-y-4">
+			<h2 class="h2">Selection</h2>
+			<p>Each tree view provides a number of selection options.</p>
+			<!-- Single -->
+			<h3 class="h3">Single</h3>
+			<p>When using single selection, our items are setup and treated as radio inputs.</p>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<TreeView selection>
+						<TreeViewItem bind:group={mediumSingle} name="medium" value="books">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem bind:group={booksSingle} name="books" value="Clean Code">
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem bind:group={booksSingle} name="books" value="The Clean Coder">
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem bind:group={booksSingle} name="books" value="The Art of Unix Programming">
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem bind:group={mediumSingle} name="medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={mediumSingle} name="medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let medium = 'books';
+let books = 'Clean Code';
+`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView selection>
+	<TreeViewItem bind:group={medium} name="medium" value="books">
+		<svelte:fragment slot="lead">(icon)</svelte:fragment>
+		<p>Books</p>
+		<svelte:fragment slot="children">
+			<TreeViewItem bind:group={books} name="books" value="Clean Code">
+				<p>Clean Code</p>
+			</TreeViewItem>
+			<TreeViewItem bind:group={books} name="books" value="The Clean Coder">
+				<p>The Clean Coder</p>
+			</TreeViewItem>
+			<TreeViewItem bind:group={books} name="books" value="The Art of Unix Programming">
+				<p>The Art of Unix Programming</p>
+			</TreeViewItem>
+		</svelte:fragment>
+	</TreeViewItem>
+	<!-- ... -->
+</TreeView>
+			`}
+					/>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<div class="flex justify-center items-center gap-4">
+						<span>Medium: <code class="code">{mediumSingle}</code></span>
+						<span>Books: <code class="code">{booksSingle}</code></span>
+					</div>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- Multiple -->
+			<h3 class="h3">Multiple</h3>
+			<p>When using multiple selection, our items are setup and treated as checkbox inputs.</p>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<TreeView selection multiple>
+						<TreeViewItem bind:group={mediumMultiple} name="medium" value="books">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem bind:group={booksMultiple} name="books" value="Clean Code">
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem bind:group={booksMultiple} name="books" value="The Clean Coder">
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem bind:group={booksMultiple} name="books" value="The Art of Unix Programming">
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem bind:group={mediumMultiple} name="medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={mediumMultiple} name="medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let medums = ['books', 'movies'];
+let books = ['Clean Code', 'The Art of Unix Programming']
+`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView selection multiple>
+	<TreeViewItem bind:group={medums} name="medium" value="books">
+		<svelte:fragment slot="lead">(icon)</svelte:fragment>
+		<p>Books</p>
+		<svelte:fragment slot="children">
+			<TreeViewItem bind:group={books} name="books" value="Clean Code">
+				<p>Clean Code</p>
+			</TreeViewItem>
+			<TreeViewItem bind:group={books} name="books" value="The Clean Coder">
+				<p>The Clean Coder</p>
+			</TreeViewItem>
+			<TreeViewItem bind:group={books} name="books" value="The Art of Unix Programming">
+				<p>The Art of Unix Programming</p>
+			</TreeViewItem>
+		</svelte:fragment>
+	</TreeViewItem>
+	<!-- ... -->
+</TreeView>
+			`}
+					/>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<div class="flex justify-center items-center gap-4">
+						<span>Mediums: <code class="code">{mediumMultiple.length ? mediumMultiple : 'None'}</code></span>
+						<span>Books: <code class="code">{booksMultiple.length ? booksMultiple : 'None'}</code></span>
+					</div>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- Relational -->
+			<h3 class="h3">Relational</h3>
+			<p>Use the <code class="code">children</code> prop to create a relational connection between parent and children.</p>
+			<DocsPreview background="neutral" regionFooter="text-center">
+				<svelte:fragment slot="preview">
+					<TreeView selection>
+						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="books" open children={childrenSingle}>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem bind:this={childrenSingle[0]} bind:group={relationalBooksSingle} name="r_books" value="Clean Code">
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem bind:this={childrenSingle[1]} bind:group={relationalBooksSingle} name="r_books" value="The Clean Coder">
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem
+									bind:this={childrenSingle[2]}
+									bind:group={relationalBooksSingle}
+									name="r_books"
+									value="The Art of Unix Programming"
+								>
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={relationalMediumSingle} name="r_medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let medium = 'books';
+let book = 'Clean Code';
+let bookChildren: TreeViewItem[] = [];
+`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView selection>
+	<TreeViewItem bind:group={medium} name="medium" value="books" children={bookChildren}>
+		<svelte:fragment slot="lead">(icon)</svelte:fragment>
+		<p>Books</p>
+		<svelte:fragment slot="children">
+			<TreeViewItem bind:this={bookChildren[0]} bind:group={book} name="books" value="Clean Code">
+				<p>Clean Code</p>
+			</TreeViewItem>
+			<TreeViewItem bind:this={bookChildren[1]} bind:group={book} name="books" value="The Clean Coder">
+				<p>The Clean Coder</p>
+			</TreeViewItem>
+			<TreeViewItem bind:this={bookChildren[2]} bind:group={book} name="books" value="The Art of Unix Programming">
+				<p>The Art of Unix Programming</p>
+			</TreeViewItem>
+		</svelte:fragment>
+	</TreeViewItem>
 	<!-- ... -->
 </TreeView>
 			`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
-		</section>
-		<!-- Select/Deselect all -->
-		<section class="space-y-4">
-			<h2 class="h2">Select/Deselect all</h2>
-			<p>
-				By binding to the <code class="code">tree</code> we can call the functions <code class="code">selectAll()</code>,
-				<code class="code">deselectAll()</code> directly from the bound object.
-			</p>
-			<p>Note: These functions are excecuted only in <code class="code">multiple</code> selection mode.</p>
+			<DocsPreview background="neutral" regionFooter="text-center">
+				<svelte:fragment slot="preview">
+					<TreeView selection multiple>
+						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="books" open children={childrenMultiple}>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem bind:this={childrenMultiple[0]} bind:group={relationalBooksMultiple} name="r_books" value="Clean Code">
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem bind:this={childrenMultiple[1]} bind:group={relationalBooksMultiple} name="r_books" value="The Clean Coder">
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem
+									bind:this={childrenMultiple[2]}
+									bind:group={relationalBooksMultiple}
+									name="r_books"
+									value="The Art of Unix Programming"
+								>
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="movies">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+						</TreeViewItem>
+						<TreeViewItem bind:group={relationalMediumMultiple} name="r_medium" value="tv">
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+let mediums = ['movies'];
+let books: string[] = [];
+let booksChildren: TreeViewItem[] = [];
+`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<TreeView selection multiple>
+	<TreeViewItem bind:group={mediums} name="medium" value="books" children={children}>
+		<svelte:fragment slot="lead">(icon)</svelte:fragment>
+		<p>Books</p>
+		<svelte:fragment slot="children">
+			<TreeViewItem bind:this={booksChildren[0]} bind:group={books} name="books" value="Clean Code">
+				<p>Clean Code</p>
+			</TreeViewItem>
+			<TreeViewItem bind:this={booksChildren[1]} bind:group={books} name="books" value="The Clean Coder">
+				<p>The Clean Coder</p>
+			</TreeViewItem>
+			<TreeViewItem bind:this={booksChildren[2]} bind:group={books} name="books" value="The Art of Unix Programming">
+				<p>The Art of Unix Programming</p>
+			</TreeViewItem>
+		</svelte:fragment>
+	</TreeViewItem>
+	<!-- ... -->
+</TreeView>
+			`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+			<!-- Toggle All -->
+			<h3 class="h3">Toggle All</h3>
+			<p>By binding to the tree view component we can then toggle selection for all items.</p>
+			<blockquote class="blockquote">
+				Note: Available only when using <code class="code">multiple</code> selection mode.
+			</blockquote>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
 				<svelte:fragment slot="preview">
 					<TreeView selection multiple bind:this={selectTree}>
@@ -814,36 +760,34 @@ tree.collapseAll();
 					</TreeView>
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<button class="btn variant-filled-primary" on:click={selectTree.selectAll}> Select all </button>
-					<button class="btn variant-filled-secondary" on:click={selectTree.deselectAll}> Deselect all </button>
+					<button class="btn variant-filled" on:click={selectTree.selectAll}> Select </button>
+					<button class="btn variant-filled" on:click={selectTree.deselectAll}> Deselect </button>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="ts"
 						code={`
-let tree: TreeView;
-// select all
+let tree: TreeView;\n
 tree.selectAll();
-// deselect all
 tree.deselectAll();
 					`}
 					/>
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView bind:this={tree} selection multiple>
-	<!-- ... -->
-</TreeView>
+<TreeView bind:this={tree} selection multiple></TreeView>
 			`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
-		<!-- Data-Driven -->
+
+		<hr />
+
+		<!-- Recursive Mode -->
 		<section class="space-y-4">
-			<h2 class="h2">Data driven tree-view</h2>
-			<!-- Simple data driven -->
-			<h3 class="h3">Simple data driven</h3>
+			<h2 class="h2">Recursive Mode</h2>
+			<p>Tree views can be generated using a recursive data-driven method.</p>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
 				<svelte:fragment slot="preview">
 					<TreeView bind:nodes={simpleDD} />
@@ -852,7 +796,7 @@ tree.deselectAll();
 					<CodeBlock
 						language="ts"
 						code={`
-let nodes: TreeViewNode[] = [
+let myTreeViewNodes: TreeViewNode[] = [
 	{
 		content: 'Books',
 		lead: '(icon)',
@@ -870,16 +814,16 @@ let nodes: TreeViewNode[] = [
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView nodes={nodes}/>
+<TreeView nodes={myTreeViewNodes}/>
 						`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
-			<!-- Single data driven -->
-			<h3 class="h3">Single data driven</h3>
+			<!-- Single Selection -->
+			<h3 class="h3">Single Selection</h3>
+			<!-- prettier-ignore -->
 			<p>
-				Note: relational checking is auto applied in <code class="code">Data-Driven</code> mode. This means setting a child as checked in the
-				initial data, won't have effect if the parent wasn't checked too.
+				Relational checking is automatically applied when generating your list in a recursive manner. Setting a child as <code class="code">checked</code> will not automatically affect the parent.
 			</p>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
 				<svelte:fragment slot="preview">
@@ -889,7 +833,7 @@ let nodes: TreeViewNode[] = [
 					<CodeBlock
 						language="ts"
 						code={`
-let nodes: TreeViewNode[] = [
+let myTreeViewNodes: TreeViewNode[] = [
 	{
 		content: 'Books',
 		lead: '(icon)',
@@ -908,14 +852,14 @@ let nodes: TreeViewNode[] = [
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView bind:nodes={nodes} selection/>
+<TreeView bind:nodes={myTreeViewNodes} selection/>
 						`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>
-			<!-- Multiple data driven -->
-			<h3 class="h3">Multiple data driven</h3>
-			<p>Note: relational checking is auto applied in <code class="code">Data-Driven</code> mode.</p>
+			<!-- Multiple Selection -->
+			<h3 class="h3">Multiple Selection</h3>
+			<p>Relational checking is automatically applied when generating your list in a recursive manner.</p>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
 				<svelte:fragment slot="preview">
 					<TreeView bind:nodes={multipleDD} selection multiple />
@@ -924,7 +868,7 @@ let nodes: TreeViewNode[] = [
 					<CodeBlock
 						language="ts"
 						code={`
-let nodes: TreeViewNode[] = [
+let myTreeViewNodes: TreeViewNode[] = [
 	{
 		content: 'Books',
 		lead: '(icon)',
@@ -943,7 +887,7 @@ let nodes: TreeViewNode[] = [
 					<CodeBlock
 						language="html"
 						code={`
-<TreeView bind:nodes={nodes} selection multiple/>
+<TreeView bind:nodes={myTreeViewNodes} selection multiple/>
 						`}
 					/>
 				</svelte:fragment>

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -39,6 +39,14 @@
 					'regionChildren'
 				]
 			}
+		],
+		keyboard: [
+			['<kbd class="kbd">Tab</kbd>', "Focus the next tree-view item or it's input."],
+			['<kbd class="kbd">Shift + Tab</kbd> ', "Focus the previous tree-view item or it's input."],
+			['<kbd class="kbd">Right arrow</kbd>', 'Opens closed tree-view item or move focus to first child of open tree-view item.'],
+			['<kbd class="kbd">Left arrow</kbd>', 'Closes open tree-view item or move focus to parent of closed tree-view item.'],
+			['<kbd class="kbd">Home</kbd>', 'move focus to first tree-view item.'],
+			['<kbd class="kbd">End</kbd>', 'move focus to last tree-view item.']
 		]
 	};
 

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -42,6 +42,7 @@
 	let childrenMultiple: TreeViewItem[] = [];
 
 	let expandTree: TreeView;
+	let selectTree: TreeView;
 
 	let selectMultiple: string[] = [];
 </script>
@@ -677,7 +678,7 @@ tree.collapseAll();
 			<p>Note: These functions are excecuted only in <code class="code">multiple</code> selection mode.</p>
 			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
 				<svelte:fragment slot="preview">
-					<TreeView selection multiple bind:this={expandTree}>
+					<TreeView selection multiple bind:this={selectTree}>
 						<TreeViewItem bind:group={selectMultiple} name="s_medium" value="books">
 							<svelte:fragment slot="lead">
 								<i class="fa-solid fa-book-skull" />
@@ -699,8 +700,8 @@ tree.collapseAll();
 					</TreeView>
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<button class="btn variant-filled-primary" on:click={expandTree.selectAll}> Select all </button>
-					<button class="btn variant-filled-secondary" on:click={expandTree.deselectAll}> Deselect all </button>
+					<button class="btn variant-filled-primary" on:click={selectTree.selectAll}> Select all </button>
+					<button class="btn variant-filled-secondary" on:click={selectTree.deselectAll}> Deselect all </button>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -503,5 +503,79 @@ let children: TreeViewItem[] = [];
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
+		<section class="space-y-4">
+			<h2 class="h2">Disabled</h2>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<TreeView disabled>
+						<TreeViewItem open>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-book-skull" />
+							</svelte:fragment>
+							<p>Books</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem>
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-film" />
+							</svelte:fragment>
+							<p>Movies</p>
+							<svelte:fragment slot="children">
+								<TreeViewItem>
+									<p>Clean Code</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>The Clean Coder</p>
+								</TreeViewItem>
+								<TreeViewItem>
+									<p>The Art of Unix Programming</p>
+								</TreeViewItem>
+							</svelte:fragment>
+						</TreeViewItem>
+						<TreeViewItem>
+							<svelte:fragment slot="lead">
+								<i class="fa-solid fa-tv" />
+							</svelte:fragment>
+							<p>TV</p>
+						</TreeViewItem>
+					</TreeView>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="html"
+						code={`
+<!-- Disable tree -->
+<TreeView disabled>
+	<!-- ... -->
+</TreeView>
+
+<!-- Disable tree items -->
+<TreeView>
+	<TreeViewItem disabled>
+		<!-- ... -->
+	</TreeViewItem>
+	<!-- Opened, disabled Tree item -->
+	<TreeViewItem open disabled>
+		<!-- ... -->
+	</TreeViewItem>
+</TreeView>
+			`}
+					/>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<p>Select children of <code class="code">Books</code> to see relational checking.</p>
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
 	</svelte:fragment>
 </DocsShell>


### PR DESCRIPTION
## Linked Issue

Closes #1773,
Closes #1784,
Closes #1785

## Description

reference the summary bellow.

## Tasks
- [x] Change docs icons example
- [x] Hide default arrow on WebKit-based browsers
- [x] Support Multi/Single select
- [x] Support relational selection
- [x] Non-expanding row should not react to clicks (dash animation)
- [x] Add Disable TreeViewItem
- [x] Add ExpandAll / SelectAll export functions
- [x] Support data-driven tree
- [x] Expand docs to cover recursive tree view (data-driven-docs) -> #1785
- [x] add full a11y support + keyboard

## Changsets

feat: Added `tree-view` single/multi selection mode, Enabled `data-driven` for tree-view.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
