### PR TITLE
bugfix/remove-blur-from-form-material

### DIFF
--- a/.changeset/lucky-roses-sip.md
+++ b/.changeset/lucky-roses-sip.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Removed `backdrop-blur` from `variant-form-material` because of high CPU usage on some browsers.

--- a/packages/skeleton/src/lib/styles/elements/forms.css
+++ b/packages/skeleton/src/lib/styles/elements/forms.css
@@ -274,8 +274,8 @@
 		@apply bg-surface-500/10 dark:bg-surface-500/20;
 		/* Border */
 		@apply border-0 border-b-2;
-		/* Blur */
-		@apply backdrop-blur;
+		/* Blur / high CPU usage on some browsers, see https://github.com/skeletonlabs/skeleton/issues/1805 */
+		/* @apply backdrop-blur; */
 	}
 	.variant-form-material[type='file'] {
 		@apply !py-1.5;


### PR DESCRIPTION
## Linked Issue

Closes #1805

## Description

`backdrop-blur` High CPU usage on some browsers.

## Changsets

bugfix: Removed `backdrop-blur` from `variant-form-material` because of high CPU usage on some browsers.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
