### PR TITLE
V2 Theme generator and doc updates

### DIFF
--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
@@ -354,7 +354,7 @@ export const myCustomTheme: CustomThemeConfig = {
 			<div class="card variant-glass p-4 text-center">
 				<!-- prettier-ignore -->
 				<button class="btn btn-lg variant-filled-primary font-bold" on:click={() => { showThemeCSS = !showThemeCSS; }} disabled={!$storePreview}>
-					{!showThemeCSS ? 'Show' : 'Hide'} Theme CSS
+					{!showThemeCSS ? 'Show' : 'Hide'} Theme Source
 				</button>
 			</div>
 		</footer>

--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
@@ -40,6 +40,7 @@
 
 	// Local
 	let cssOutput = '';
+	let cssInJsOutput = '';
 	let showThemeCSS = false;
 	let conReports: ContrastReport[] = getContrastReports();
 
@@ -51,6 +52,7 @@
 		});
 	}
 
+	// CSS output (for live preview)
 	function generateColorCSS(): string {
 		let newCSS = '';
 		const newPalette: Record<string, Palette> = {};
@@ -67,6 +69,25 @@
 			}
 		});
 		return newCSS;
+	}
+
+	// CSS-in-JS output (for theme file)
+	function generateColorCssInJS(): string {
+		let newCssInJs = '';
+		const newPalette: Record<string, Palette> = {};
+		// Loop store colors
+		$storeThemGenForm.colors.forEach((color: ColorSettings, i: number) => {
+			const colorKey = color.key;
+			// Generate the new color palette hex/rgb/on values
+			newPalette[color.key] = generatePalette($storeThemGenForm.colors[i].hex);
+			// The color set comment
+			newCssInJs += `// ${colorKey} | ${newPalette[colorKey][500].hex} \n\t\t`;
+			// CSS props for shade 50-900 per each color
+			for (let [k, v] of Object.entries(newPalette[colorKey])) {
+				newCssInJs += `"--color-${colorKey}-${k}": "${v.rgb}", // ${v.hex}\n\t\t`;
+			}
+		});
+		return newCssInJs;
 	}
 
 	function onPreviewToggle(): void {
@@ -104,6 +125,7 @@
 	}
 
 	$: if ($storeThemGenForm && hexValuesAreValid($storeThemGenForm.colors)) {
+		// CSS output (for live preview)
 		cssOutput = `
 :root {
 	/* =~= Theme Properties =~= */
@@ -124,6 +146,32 @@
 	--on-surface: ${$storeThemGenForm.colors[6]?.on};
 	/* =~= Theme Colors  =~= */
 	${generateColorCSS()}
+}`;
+		// CSS-in-JS output (for theme file)
+		cssInJsOutput = `
+import type { CustomThemeConfig } from '@skeletonlabs/tw-plugin';\n
+export const myCustomTheme: CustomThemeConfig = {
+    name: 'my-custom-theme',
+    properties: {
+		// =~= Theme Properties =~=
+		"--theme-font-family-base": "${fontSettings[$storeThemGenForm.fontBase]}",
+		"--theme-font-family-heading": "${fontSettings[$storeThemGenForm.fontHeadings]}",
+		"--theme-font-color-base": "${$storeThemGenForm.textColorLight}",
+		"--theme-font-color-dark": "${$storeThemGenForm.textColorDark}",
+		"--theme-rounded-base": "${$storeThemGenForm.roundedBase}",
+		"--theme-rounded-container": "${$storeThemGenForm.roundedContainer}",
+		"--theme-border-base": "${$storeThemGenForm.borderBase}",
+		// =~= Theme On-X Colors =~=
+		"--on-primary": "${$storeThemGenForm.colors[0]?.on}",
+		"--on-secondary": "${$storeThemGenForm.colors[1]?.on}",
+		"--on-tertiary": "${$storeThemGenForm.colors[2]?.on}",
+		"--on-success": "${$storeThemGenForm.colors[3]?.on}",
+		"--on-warning": "${$storeThemGenForm.colors[4]?.on}",
+		"--on-error": "${$storeThemGenForm.colors[5]?.on}",
+		"--on-surface": "${$storeThemGenForm.colors[6]?.on}",
+		// =~= Theme Colors  =~=
+		${generateColorCssInJS()}
+	}
 }`;
 	}
 
@@ -302,7 +350,7 @@
 
 		<!-- CSS Output -->
 		<footer class="col-span-2 space-y-4">
-			{#if showThemeCSS}<CodeBlock language="css" code={cssOutput} />{/if}
+			{#if showThemeCSS}<CodeBlock language="ts" code={cssInJsOutput} />{/if}
 			<div class="card variant-glass p-4 text-center">
 				<!-- prettier-ignore -->
 				<button class="btn btn-lg variant-filled-primary font-bold" on:click={() => { showThemeCSS = !showThemeCSS; }} disabled={!$storePreview}>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/generator/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/generator/+page.svelte
@@ -29,7 +29,7 @@
 			Generate your theme above, copy the source, then paste this into a new file in the root of your project with a distinct name, such as: <code class="code">my-custom-theme.[ts|js]</code>. Make sure to strip out the Typescript type information within your theme if you opt for the Javascript format.
 		</p>
 		<p>Open <code class="code">tailwind.config.[cjs|js|ts]</code> found in the root of your project, and import your custom theme.</p>
-		<CodeBlock language="ts" code={`import myCustomTheme from './my-custom-theme'`} />
+		<CodeBlock language="ts" code={`import { myCustomTheme } from './my-custom-theme'`} />
 		<p>Within this same file, register your custom theme via the Skeleton Tailwind plugin settings as shown below.</p>
 		<CodeBlock
 			language="ts"

--- a/sites/skeleton.dev/src/routes/(inner)/docs/generator/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/generator/+page.svelte
@@ -21,16 +21,17 @@
 
 	<hr />
 
-	<!-- Instructions (v2) -->
+	<!-- Implement (v2) -->
 	<section class="space-y-4">
-		<h2 class="h2">Implement Your Theme</h2>
+		<h2 class="h2">How to Implement</h2>
 		<!-- prettier-ignore -->
 		<p>
-			Generate your theme above, copy the source, then paste this into a new file in the root of your project with a distinct name, such as: <code class="code">my-custom-theme.[ts|js]</code>. Make sure to strip out the Typescript type information within your theme if you opt for the Javascript format.
+			Generate your theme above, copy the source code, then paste this into a new file in the root of your project with a distinct name, such as: <code class="code">my-custom-theme.[ts|js]</code>. If you opt for the Javascript format, make sure to strip out any Typescript type information.
 		</p>
+		<!-- Instruction -->
 		<p>Open <code class="code">tailwind.config.[cjs|js|ts]</code> found in the root of your project, and import your custom theme.</p>
 		<CodeBlock language="ts" code={`import { myCustomTheme } from './my-custom-theme'`} />
-		<p>Within this same file, register your custom theme via the Skeleton Tailwind plugin settings as shown below.</p>
+		<p>Within this file, register your custom theme via the Skeleton Tailwind plugin settings.</p>
 		<CodeBlock
 			language="ts"
 			code={`
@@ -48,11 +49,30 @@ plugins: [
 		/>
 		<p>
 			Open <code class="code">/src/app.html</code> and define your theme using the <code class="code">data-theme</code>
-			attribute. The value should match the <code class="code">name</code> field set within your theme source code.
+			attribute. The value should match the <code class="code">name</code> field set within your theme's source code.
 		</p>
 		<CodeBlock language="html" code={`<body data-theme="my-custom-theme">`} />
 		<!-- prettier-ignore -->
-		<p>Note that custom themes can be registered alongside <a href="/docs/themes#register-themes" class="anchor">Skeleton's preset themes</a>, allowing you to switch between these as desired.</p>
+		<p>Note that custom themes can be registered along with <a href="/docs/themes#register-themes" class="anchor">Skeleton's preset themes</a>, allowing you to switch between these as desired.</p>
+	</section>
+
+	<hr />
+
+	<section class="space-y-4">
+		<h2 class="h2">Migrate from v1 to v2</h2>
+		<!-- Alert -->
+		<aside class="alert variant-ghost">
+			<div class="alert-message">
+				<p>
+					Need help migrating your theme from the <strong>v1 CSS format</strong> to the <strong>v2 CSS-in-JS format</strong>? Try this handy
+					conversion tool.
+				</p>
+			</div>
+			<div class="alert-actions">
+				<!-- <a class="btn variant-soft" href="/" target="_blank">View Guide</a> -->
+				<a class="btn variant-filled" href="https://transform.tools/css-to-js" target="_blank">Conversion Tool &rarr;</a>
+			</div>
+		</aside>
 	</section>
 
 	<hr />

--- a/sites/skeleton.dev/src/routes/(inner)/docs/generator/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/generator/+page.svelte
@@ -21,37 +21,16 @@
 
 	<hr />
 
-	<!-- Instructions -->
-	<!-- <section class="space-y-4">
-		<h2 class="h2">Importing Your Theme</h2>
-		<p>
-			Copy and paste your theme CSS into <code class="code">/src/theme.postcss</code>, then import the theme into your root layout in
-			<code class="code">/src/routes/+layout.svelte</code> instead of a premade Skeleton theme. Keep the order as shown.
-		</p>
-		<CodeBlock
-			language="ts"
-			code={`
-// Your custom Skeleton theme:
-import '../theme.postcss';\n
-// This contains the bulk of Skeletons required styles:
-import '@skeletonlabs/skeleton/styles/skeleton.css';\n
-// Finally, your application's global stylesheet (sometimes labeled 'app.css')
-import '../app.postcss';
-						`}
-		/>
-	</section> -->
-
 	<!-- Instructions (v2) -->
 	<section class="space-y-4">
 		<h2 class="h2">Implement Your Theme</h2>
-		<!-- pretiter-ignore -->
+		<!-- prettier-ignore -->
 		<p>
-			Generate your theme above, copy the source, then paste this into a new file in the root of your project with a disticting name, such
-			as: <code class="code">my-custom-theme.[ts|js]</code>.
+			Generate your theme above, copy the source, then paste this into a new file in the root of your project with a distinct name, such as: <code class="code">my-custom-theme.[ts|js]</code>. Make sure to strip out the Typescript type information within your theme if you opt for the Javascript format.
 		</p>
-		<p>Open <code class="code">tailwind.config.[js,cjs,ts]</code>, found in the root of your project, and import your custom theme.</p>
+		<p>Open <code class="code">tailwind.config.[cjs|js|ts]</code> found in the root of your project, and import your custom theme.</p>
 		<CodeBlock language="ts" code={`import myCustomTheme from './my-custom-theme'`} />
-		<p>Within this same file, register your new theme via the Skeleton Tailwind plugin settings as shown below.</p>
+		<p>Within this same file, register your custom theme via the Skeleton Tailwind plugin settings as shown below.</p>
 		<CodeBlock
 			language="ts"
 			code={`
@@ -73,7 +52,7 @@ plugins: [
 		</p>
 		<CodeBlock language="html" code={`<body data-theme="my-custom-theme">`} />
 		<!-- prettier-ignore -->
-		<p>Note that custom themes can be registered and used with <a href="/docs/themes#register-themes" class="anchor">Skeleton preset themes</a>.</p>
+		<p>Note that custom themes can be registered alongside <a href="/docs/themes#register-themes" class="anchor">Skeleton's preset themes</a>, allowing you to switch between these as desired.</p>
 	</section>
 
 	<hr />

--- a/sites/skeleton.dev/src/routes/(inner)/docs/generator/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/generator/+page.svelte
@@ -22,7 +22,7 @@
 	<hr />
 
 	<!-- Instructions -->
-	<section class="space-y-4">
+	<!-- <section class="space-y-4">
 		<h2 class="h2">Importing Your Theme</h2>
 		<p>
 			Copy and paste your theme CSS into <code class="code">/src/theme.postcss</code>, then import the theme into your root layout in
@@ -39,6 +39,41 @@ import '@skeletonlabs/skeleton/styles/skeleton.css';\n
 import '../app.postcss';
 						`}
 		/>
+	</section> -->
+
+	<!-- Instructions (v2) -->
+	<section class="space-y-4">
+		<h2 class="h2">Implement Your Theme</h2>
+		<!-- pretiter-ignore -->
+		<p>
+			Generate your theme above, copy the source, then paste this into a new file in the root of your project with a disticting name, such
+			as: <code class="code">my-custom-theme.[ts|js]</code>.
+		</p>
+		<p>Open <code class="code">tailwind.config.[js,cjs,ts]</code>, found in the root of your project, and import your custom theme.</p>
+		<CodeBlock language="ts" code={`import myCustomTheme from './my-custom-theme'`} />
+		<p>Within this same file, register your new theme via the Skeleton Tailwind plugin settings as shown below.</p>
+		<CodeBlock
+			language="ts"
+			code={`
+
+plugins: [
+	skeleton({
+		themes: {
+			custom: [
+				myCustomTheme
+			]
+		}
+	})
+]
+				`}
+		/>
+		<p>
+			Open <code class="code">/src/app.html</code> and define your theme using the <code class="code">data-theme</code>
+			attribute. The value should match the <code class="code">name</code> field set within your theme source code.
+		</p>
+		<CodeBlock language="html" code={`<body data-theme="my-custom-theme">`} />
+		<!-- prettier-ignore -->
+		<p>Note that custom themes can be registered and used with <a href="/docs/themes#register-themes" class="anchor">Skeleton preset themes</a>.</p>
 	</section>
 
 	<hr />

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/+page.svelte
@@ -4,7 +4,7 @@
 	import SectionInstall from './SectionInstall.svelte';
 	import SectionTailwind from './SectionTailwind.svelte';
 	import SectionThemes from './SectionThemes.svelte';
-	import SectionStylesheets from './SectionStylesheets.svelte';
+	// import SectionStylesheets from './SectionStylesheets.svelte';
 </script>
 
 <LayoutPage>
@@ -18,6 +18,6 @@
 	<hr />
 	<SectionInstall />
 	<SectionTailwind />
-	<SectionStylesheets />
+	<!-- <SectionStylesheets /> -->
 	<SectionThemes />
 </LayoutPage>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionInstall.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionInstall.svelte
@@ -28,7 +28,7 @@ cd my-skeleton-app
 			{:else if $storeOnboardMethod === 'manual'}
 				<!-- prettier-ignore -->
 				<p>
-					If you have an existing SvelteKit application, skip to the next step. Otherwise let's let's create a <a class="anchor" href="https://kit.svelte.dev/docs/creating-a-project" target="_blank" rel="noreferrer">SvelteKit project</a>.
+					If you have an existing SvelteKit application, skip to the next step. Otherwise let's create a <a class="anchor" href="https://kit.svelte.dev/docs/creating-a-project" target="_blank" rel="noreferrer">SvelteKit project</a>.
 				</p>
 				<CodeBlock
 					language="console"

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionInstall.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionInstall.svelte
@@ -28,7 +28,7 @@ cd my-skeleton-app
 			{:else if $storeOnboardMethod === 'manual'}
 				<!-- prettier-ignore -->
 				<p>
-					If you have an existing SvelteKit application, skip to installing the Skeleton package from NPM. Otherwise let's begin by creating a new <a class="anchor" href="https://kit.svelte.dev/docs/creating-a-project" target="_blank" rel="noreferrer">SvelteKit project</a>.
+					If you have an existing SvelteKit application, skip to the next step. Otherwise let's let's create a <a class="anchor" href="https://kit.svelte.dev/docs/creating-a-project" target="_blank" rel="noreferrer">SvelteKit project</a>.
 				</p>
 				<CodeBlock
 					language="console"
@@ -39,12 +39,11 @@ npm install
 		`}
 				/>
 				<!-- Install NPM Package -->
+				<!-- prettier-ignore -->
 				<p>
-					Install the <a class="anchor" href="https://www.npmjs.com/package/@skeletonlabs/skeleton" target="_blank" rel="noreferrer"
-						>Skeleton package</a
-					> from NPM.
+					Install the packages for <a class="anchor" href="https://www.npmjs.com/package/@skeletonlabs/skeleton" target="_blank" rel="noreferrer">Skeleton</a> and the <a class="anchor" href="https://www.npmjs.com/package/@skeletonlabs/tw-plugin" target="_blank" rel="noreferrer">Skeleton Tailwind plugin</a>.
 				</p>
-				<CodeBlock language="console" code={`npm i @skeletonlabs/skeleton --save-dev`} />
+				<CodeBlock language="console" code={`npm i -D @skeletonlabs/skeleton @skeletonlabs/tw-plugin`} />
 			{/if}
 		</svelte:fragment>
 	</TabGroup>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
@@ -108,7 +108,7 @@ export default {
 	content: [
 		'./src/**/*.{html,js,svelte,ts}',
 		// 3. Append the path to the Skeleton package
-		require('path').join(require.resolve(
+		join(require.resolve(
 			'@skeletonlabs/skeleton'),
 			'../**/*.{html,js,svelte,ts}'
 		)
@@ -139,7 +139,7 @@ const config = {
 	content: [
 		'./src/**/*.{html,js,svelte,ts}',
 		// 3. Append the path to the Skeleton package
-		require('path').join(require.resolve(
+		join(require.resolve(
 			'@skeletonlabs/skeleton'),
 			'../**/*.{html,js,svelte,ts}'
 		)

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
@@ -50,8 +50,7 @@
 				</div>
 				<h3 class="h3">Tailwind Configuration</h3>
 				<p>
-					Apply these following three changes to your <code class="code">tailwind.config.[cjs|js|ts]</code>, found in the root of your
-					project.
+					Apply the following changes to your <code class="code">tailwind.config.[cjs|js|ts]</code>, found in the root of your project.
 				</p>
 				<CodeBlock
 					language="js"

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
@@ -2,6 +2,9 @@
 	import { storeOnboardMethod } from '$lib/stores/stores';
 	// Components
 	import { Tab, TabGroup, CodeBlock } from '@skeletonlabs/skeleton';
+
+	// Local
+	let tabConfigFormat = 'cjs';
 </script>
 
 <!-- Header -->
@@ -49,12 +52,20 @@
 					/>
 				</div>
 				<h3 class="h3">Tailwind Configuration</h3>
-				<p>
-					Apply the following changes to your <code class="code">tailwind.config.[cjs|js|ts]</code>, found in the root of your project.
-				</p>
-				<CodeBlock
-					language="js"
-					code={`
+				<p>Apply the following changes to your <code class="code">tailwind.config.[cjs|js|ts]</code>, found in the root of your project.</p>
+				<TabGroup regionPanel="space-y-4">
+					<!-- Tabs -->
+					<Tab bind:group={tabConfigFormat} name="cjs" value="cjs">CommonJS (.cjs)</Tab>
+					<Tab bind:group={tabConfigFormat} name="js" value="js">Javascript (.js)</Tab>
+					<Tab bind:group={tabConfigFormat} name="ts" value="ts">Typescript (.ts)</Tab>
+					<!-- Panel -->
+					<svelte:fragment slot="panel">
+						{#if tabConfigFormat === 'cjs'}
+							<CodeBlock
+								language="cjs"
+								code={`
+// @ts-check
+
 // 1. Import the Skeleton plugin
 const { skeleton } = require('@skeletonlabs/tw-plugin');
 
@@ -78,8 +89,77 @@ module.exports = {
 		skeleton
 	]
 }
-`}
-				/>
+						`}
+							/>
+						{:else if tabConfigFormat === 'js'}
+							<CodeBlock
+								language="js"
+								code={`
+// @ts-check
+import { join } from 'path';
+
+// 1. Import the Skeleton plugin
+import { skeleton } from '@skeletonlabs/tw-plugin';
+
+/** @type {import('tailwindcss').Config} */
+export default {
+	// 2. Opt for dark mode to be handled via the class method
+	darkMode: 'class',
+	content: [
+		'./src/**/*.{html,js,svelte,ts}',
+		// 3. Append the path to the Skeleton package
+		require('path').join(require.resolve(
+			'@skeletonlabs/skeleton'),
+			'../**/*.{html,js,svelte,ts}'
+		)
+	],
+	theme: {
+		extend: {},
+	},
+	plugins: [
+		// 4. Append the Skeleton plugin (after other plugins)
+		skeleton
+	]
+}
+						`}
+							/>
+						{:else}
+							<CodeBlock
+								language="ts"
+								code={`
+import { join } from 'path';
+import type { Config } from 'tailwindcss';
+
+// 1. Import the Skeleton plugin
+import { skeleton } from '@skeletonlabs/tw-plugin';
+
+const config = {
+	// 2. Opt for dark mode to be handled via the class method
+	darkMode: 'class',
+	content: [
+		'./src/**/*.{html,js,svelte,ts}',
+		// 3. Append the path to the Skeleton package
+		require('path').join(require.resolve(
+			'@skeletonlabs/skeleton'),
+			'../**/*.{html,js,svelte,ts}'
+		)
+	],
+	theme: {
+		extend: {},
+	},
+	plugins: [
+		// 4. Append the Skeleton plugin (after other plugins)
+		skeleton
+	]
+} satisfies Config;
+
+export default config;
+						`}
+							/>
+						{/if}
+					</svelte:fragment>
+				</TabGroup>
+
 				<!-- <aside class="alert variant-ghost-warning">
 					<i class="fa-solid fa-triangle-exclamation text-2xl" />
 					<div class="alert-message">

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
@@ -33,24 +33,39 @@
 					</p>
 					<CodeBlock language="console" code={`npx svelte-add@latest tailwindcss\nnpm install`} />
 					<!-- prettier-ignore -->
-					<p>Then open your global stylesheet in <code class="code">/src/app.postcss</code> and remove the following three <a class="anchor" href="https://tailwindcss.com/docs/functions-and-directives" target="_blank" rel="noreferrer">@tailwind directives</a> introduced by Svelte-Add. These are redundant as Skeleton automatically handles these in our stylesheets for you.</p>
-					<div class="space-y-[1px]">
-						<del class="del">@tailwind base;</del>
-						<del class="del">@tailwind components;</del>
-						<del class="del">@tailwind utilities;</del>
-					</div>
+					<p>
+						Then open your global stylesheet in <code class="code">/src/app.postcss</code> and ensure the following
+						<a class="anchor" href="https://tailwindcss.com/docs/functions-and-directives" target="_blank" rel="noreferrer">@tailwind directives</a> are present. Svelte-Add will implement this for you automatically.
+					</p>
+					<CodeBlock
+						language="css"
+						code={`
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+@tailwind variants;\n
+/* (your custom styles here) */
+					`}
+					/>
 				</div>
-				<p>Apply these following three changes to your <code class="code">tailwind.config.cjs</code>, found in the root of your project.</p>
+				<h3 class="h3">Tailwind Configuration</h3>
+				<p>
+					Apply these following three changes to your <code class="code">tailwind.config.[cjs|js|ts]</code>, found in the root of your
+					project.
+				</p>
 				<CodeBlock
 					language="js"
 					code={`
+// 1. Import the Skeleton plugin
+const { skeleton } = require('@skeletonlabs/tw-plugin');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-	// 1. Apply the dark mode class setting:
+	// 2. Opt for dark mode to be handled via the class method
 	darkMode: 'class',
 	content: [
 		'./src/**/*.{html,js,svelte,ts}',
-		// 2. Append the path for the Skeleton NPM package and files:
+		// 3. Append the path to the Skeleton package
 		require('path').join(require.resolve(
 			'@skeletonlabs/skeleton'),
 			'../**/*.{html,js,svelte,ts}'
@@ -60,28 +75,29 @@ module.exports = {
 		extend: {},
 	},
 	plugins: [
-		// 3. Append the Skeleton plugin to the end of this list
-		...require('@skeletonlabs/skeleton/tailwind/skeleton.cjs')()
+		// 4. Append the Skeleton plugin (after other plugins)
+		skeleton
 	]
 }
 `}
 				/>
-				<aside class="alert variant-ghost-warning">
+				<!-- <aside class="alert variant-ghost-warning">
 					<i class="fa-solid fa-triangle-exclamation text-2xl" />
 					<div class="alert-message">
 						Skeleton's Tailwind plugin cannot operate alongside plugins from other UI libraries, such as <strong>Flowbite</strong> or
 						<strong>Daisy</strong>. All three plugins modify similar settings, which means they will conflict.
 					</div>
-				</aside>
+				</aside> -->
+				<h3 class="h3">Dark Mode Support</h3>
 				<p>
-					Note that your app will default to light mode. To manually set dark mode, append the following class to the HTML element within <code
-						class="code">/src/app.html</code
-					>.
+					Note that your app will default to light mode. If you wish to default to dark mode, append the following class to the HTML element
+					within <code class="code">/src/app.html</code>. View
+					<a class="anchor" href="https://tailwindcss.com/docs/dark-mode" target="_blank">Tailwind's documentation</a> for more information.
 				</p>
 				<CodeBlock language="html" code={`<html class="dark">`} />
 				<p>
-					If you wish to be able to toggle dark mode, review the <a class="anchor" href="/utilities/lightswitches">Lightswitch</a> utility features
-					when you complete this setup process.
+					Skeleton also provides a <a class="anchor" href="/utilities/lightswitches" target="_blank">Lightswitch</a> utility if you wish toggle
+					between light and dark modes.
 				</p>
 			{/if}
 		</svelte:fragment>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
@@ -57,12 +57,11 @@ plugins: [
 			{/each}
 		</nav>
 		<p>
-			First, enable the theme in your <code class="code">tailwind.config.[cjs|js|ts]</code>
-			found in the root of your project.
+			First, register your desired theme in <code class="code">tailwind.config.[cjs|js|ts]</code>, found in the root of your project.
 		</p>
 		<CodeBlock language="ts" code={activeThemeStylesheet} />
 		<p>
-			Next, open <code class="code">/src/app.html</code> and define the theme active theme using the <code class="code">data-theme</code> attribute.
+			Next, open <code class="code">/src/app.html</code> and define the active theme via the <code class="code">data-theme</code> attribute.
 		</p>
 		<CodeBlock language="html" code={`<body data-theme="${activeTheme.file}">`} />
 	</div>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
@@ -28,10 +28,10 @@ plugins: [
 	<h2 class="h2">Themes</h2>
 	<!-- prettier-ignore -->
 	<p>
-		Themes <a class="anchor" href="https://tailwindcss.com/docs/customizing-colors#using-css-variables" target="_blank" rel="noreferrer">integrate with Tailwind</a> to support <a class="anchor" href="https://tailwindcss.com/docs/background-color#changing-the-opacity" target="_blank" rel="noreferrer">color opacity</a> and <a class="anchor" href="https://tailwindcss.com/docs/dark-mode" target="_blank" rel="noreferrer">dark mode</a>, as well as Skeleton's <a class="anchor" href="/docs/tokens">design tokens</a>.
+		Skeleton leans into <a class="anchor" href="https://tailwindcss.com/docs/customizing-colors#using-css-variables" target="_blank" rel="noreferrer">Tailwind's best practices</a> when implementing themes. This includes support for <a class="anchor" href="https://tailwindcss.com/docs/background-color#changing-the-opacity" target="_blank" rel="noreferrer">color opacity</a> and <a class="anchor" href="https://tailwindcss.com/docs/dark-mode" target="_blank" rel="noreferrer">dark mode</a>. Themes also enable Skeleton's <a class="anchor" href="/docs/tokens" target="_blank">design tokens</a> system.
 	</p>
 	<h3 class="h3">Preset Themes</h3>
-	<p>Skeleton provides a number of preset themes out of the box. Select a theme to update the instruction below.</p>
+	<p>Skeleton provides a number of preset themes out of the box. Choose a theme below for specific instruction.</p>
 	<!-- Presets -->
 	<div class="card variant-glass p-4 space-y-4">
 		<nav class="grid grid-cols-1 md:grid-cols-3 gap-5">
@@ -57,11 +57,13 @@ plugins: [
 			{/each}
 		</nav>
 		<p>
-			First, register your desired theme in <code class="code">tailwind.config.[cjs|js|ts]</code>, found in the root of your project.
+			First, register your desired theme in <code class="code">tailwind.config.[cjs|js|ts]</code>, found in the root of your project. This
+			will ensure it's loaded and available.
 		</p>
 		<CodeBlock language="ts" code={activeThemeStylesheet} />
 		<p>
-			Next, open <code class="code">/src/app.html</code> and define the active theme via the <code class="code">data-theme</code> attribute.
+			Next, open <code class="code">/src/app.html</code> and define the active theme to display via the <code class="code">data-theme</code>
+			attribute.
 		</p>
 		<CodeBlock language="html" code={`<body data-theme="${activeTheme.file}">`} />
 	</div>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
@@ -2,11 +2,20 @@
 	import { storeOnboardMethod } from '$lib/stores/stores';
 	import { themes } from '$lib/themes';
 	// Components
-	import { TabGroup, Tab, CodeBlock } from '@skeletonlabs/skeleton';
+	import { CodeBlock } from '@skeletonlabs/skeleton';
 
 	// Local
 	let activeTheme = themes[1];
-	$: activeThemeStylesheet = `import '@skeletonlabs/skeleton/themes/theme-${activeTheme.file}.css';`;
+	// $: activeThemeStylesheet = `import '@skeletonlabs/skeleton/themes/theme-${activeTheme.file}.css';`;
+	$: activeThemeStylesheet = `
+plugins: [
+	skeleton({
+		themes: {
+			preset: [ "${activeTheme.file}" ]
+		}
+	})
+]\n
+`;
 
 	// Copy Theme Import to Clipboard
 	function setActiveTheme(theme: any): void {
@@ -19,25 +28,13 @@
 	<h2 class="h2">Themes</h2>
 	<!-- prettier-ignore -->
 	<p>
-		Skeleton themes <a class="anchor" href="https://tailwindcss.com/docs/customizing-colors#using-css-variables" target="_blank" rel="noreferrer">integrate with Tailwind</a> and support <a class="anchor" href="https://tailwindcss.com/docs/background-color#changing-the-opacity" target="_blank" rel="noreferrer">color opacity</a>, <a class="anchor" href="https://tailwindcss.com/docs/dark-mode" target="_blank" rel="noreferrer">dark mode</a>, and our powerful <a class="anchor" href="/docs/tokens">design tokens system</a>.
+		Themes <a class="anchor" href="https://tailwindcss.com/docs/customizing-colors#using-css-variables" target="_blank" rel="noreferrer">integrate with Tailwind</a> to support <a class="anchor" href="https://tailwindcss.com/docs/background-color#changing-the-opacity" target="_blank" rel="noreferrer">color opacity</a> and <a class="anchor" href="https://tailwindcss.com/docs/dark-mode" target="_blank" rel="noreferrer">dark mode</a>, as well as Skeleton's <a class="anchor" href="/docs/tokens">design tokens</a>.
 	</p>
-
-	<TabGroup regionPanel="space-y-4">
-		<Tab bind:group={$storeOnboardMethod} name="cli" value="cli">Skeleton CLI</Tab>
-		<Tab bind:group={$storeOnboardMethod} name="manual" value="manual">Manual Install</Tab>
-	</TabGroup>
-	{#if $storeOnboardMethod === 'cli'}
-		<p>
-			The CLI will automatically import your preferred preset theme in <code class="code">src/routes/+layout.svelte</code>. You may change
-			this at any time.
-		</p>
-	{:else if $storeOnboardMethod === 'manual'}
-		<!-- prettier-ignore -->
-		<p>
-			If you wish to use another preset theme, select it from the list below to reveal the import statement. Import it in your root layout in <code class="code">/src/routes/+layout.svelte</code>. Take care to replace any existing theme.
-		</p>
-	{/if}
-
+	<h3 class="h3">Preset Themes</h3>
+	<p>
+		Skeleton provides a number of preset themes out of the box. To switch themes, open <code class="code">tailwind.config.[cjs|js|ts]</code>
+		found in the root of your project, then modify the settings as shown below. Select a theme to update the code snippet.
+	</p>
 	<!-- Presets -->
 	<div class="card variant-glass p-4 space-y-4">
 		<nav class="grid grid-cols-1 md:grid-cols-3 gap-5">

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
@@ -31,10 +31,7 @@ plugins: [
 		Themes <a class="anchor" href="https://tailwindcss.com/docs/customizing-colors#using-css-variables" target="_blank" rel="noreferrer">integrate with Tailwind</a> to support <a class="anchor" href="https://tailwindcss.com/docs/background-color#changing-the-opacity" target="_blank" rel="noreferrer">color opacity</a> and <a class="anchor" href="https://tailwindcss.com/docs/dark-mode" target="_blank" rel="noreferrer">dark mode</a>, as well as Skeleton's <a class="anchor" href="/docs/tokens">design tokens</a>.
 	</p>
 	<h3 class="h3">Preset Themes</h3>
-	<p>
-		Skeleton provides a number of preset themes out of the box. To switch themes, open <code class="code">tailwind.config.[cjs|js|ts]</code>
-		found in the root of your project, then modify the settings as shown below. Select a theme to update the code snippet.
-	</p>
+	<p>Skeleton provides a number of preset themes out of the box. Select a theme to update the instruction below.</p>
 	<!-- Presets -->
 	<div class="card variant-glass p-4 space-y-4">
 		<nav class="grid grid-cols-1 md:grid-cols-3 gap-5">
@@ -59,13 +56,21 @@ plugins: [
 				</div>
 			{/each}
 		</nav>
+		<p>
+			First, enable the theme in your <code class="code">tailwind.config.[cjs|js|ts]</code>
+			found in the root of your project.
+		</p>
 		<CodeBlock language="ts" code={activeThemeStylesheet} />
+		<p>
+			Next, open <code class="code">/src/app.html</code> and define the theme active theme using the <code class="code">data-theme</code> attribute.
+		</p>
+		<CodeBlock language="html" code={`<body data-theme="${activeTheme.file}">`} />
 	</div>
 
 	<!-- Theme Customization -->
 	<div class="card variant-glass p-4">
 		<div class="!flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0 md:space-x-4">
-			<p>Learn how extend preset themes, customize backgrounds, and add custom fonts.</p>
+			<p>Learn more about Skeleton themes in this comprehensive guide.</p>
 			<a class="btn variant-filled-secondary" href="/docs/themes">Themes &rarr;</a>
 		</div>
 	</div>
@@ -73,7 +78,7 @@ plugins: [
 	<!-- Generator -->
 	<div class="card variant-glass p-4">
 		<div class="!flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0 md:space-x-4">
-			<p>Interested in creating your own custom theme? Try the Skeleton theme generator.</p>
+			<p>Ready to create a custom theme? Try the Theme Generator.</p>
 			<a class="btn variant-filled-secondary" href="/docs/generator">Generator &rarr;</a>
 		</div>
 	</div>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -15,11 +15,11 @@
 		['<code class="code">--theme-font-family-heading</code>', 'Set the font family for your heading text.'],
 		['<code class="code">--theme-font-color-base</code>', 'Set the default text color for light mode.'],
 		['<code class="code">--theme-font-color-dark</code>', 'Set the default text color for dark mode.'],
-		['<code class="code">--theme-rounded-base</code>', 'Set the border radius size for small elements, such as buttons, inputs, etc.'],
-		['<code class="code">--theme-rounded-container</code>', 'Set the border radicus for large elements, such as cards and textfields'],
-		['<code class="code">--theme-border-base</code>', 'Set the default border size for various elements, including inputs.'],
+		['<code class="code">--theme-rounded-base</code>', 'Set the border radius for small elements, such as buttons, inputs, etc.'],
+		['<code class="code">--theme-rounded-container</code>', 'Set the border radius for large elements, such as cards, textfields, etc.'],
+		['<code class="code">--theme-border-base</code>', 'Set the default border size for elements, including inputs.'],
 		// Theme On-X Colors
-		['<code class="code">--on-[color]</code>', 'Set the accessible overlapping text or fill color.'],
+		['<code class="code">--on-[color]</code>', 'Set an accessible overlapping text or fill color per each theme color.'],
 		['<code class="code">--color-[color]-[shade]</code>', 'Defines each color and shade value for your theme.']
 	];
 	const tableCssProperties: TableSource = {
@@ -53,7 +53,7 @@
 		<h3 class="h3">Overwriting Properties</h3>
 		<!-- prettier-ignore -->
 		<p>
-			Similar to variables in other languages, these can be modified and overwritten as desired. By adding the following snippet in <code class="code">/src/app.postcss</code>, you can overwrite the <em>base</em> and <em>container</em> border radius styles for your active theme.
+			Similar to variables in other languages, CSS properties can be overwritten. By adding the following snippet in <code class="code">/src/app.postcss</code>, you can overwrite the <em>base</em> and <em>container</em> border radius styles for your active theme.
 		</p>
 		<CodeBlock
 			language="css"
@@ -64,7 +64,7 @@
 }
 		`}
 		/>
-		<p>Likewise, you can override font family settings for your <em>base</em> and <em>heading</em> text settings as shown below.</p>
+		<p>Likewise, you can override <em>base</em> and <em>heading</em> font family settings as shown below.</p>
 		<CodeBlock
 			language="css"
 			code={`
@@ -76,7 +76,7 @@
 		/>
 		<!-- prettier-ignore -->
 		<p>
-			For heavy modifications, consider cloning Skeleton's preset themes and implementing as a custom theme. Follow the guide provide on our <a class="anchor" href="/docs/generator">theme generator</a> documentation for more information.
+			For deeper customization, consider cloning Skeleton's preset themes, modifying each as desired, then implementing as a custom theme. Follow the <a class="anchor" href="/docs/generator">theme generator implementation guide</a> for more information.
 		</p>
 	</section>
 
@@ -88,8 +88,8 @@
 			<span class="badge variant-filled-warning">New in v2</span>
 		</div>
 		<p>
-			Skeleton now defines theme settings via CSS-in-JS format. This allows themes to be easily injected into the Skeleton Tailwind plugin
-			rather than requiring additional CSS stylesheet imports.
+			Skeleton now defines theme settings via the CSS-in-JS format. This allows themes to be easily registered within the Skeleton Tailwind
+			plugin, rather than relying on additional stylesheet imports.
 		</p>
 	</section>
 
@@ -106,8 +106,8 @@
 		</p>
 		<h3 class="h3">Register Themes</h3>
 		<p>
-			Skeleton provides a number of <a class="anchor" href="/docs/get-started#preset-themes">preset themes</a> out of the box. Register one or
-			more within your Tailwind plugin settings.
+			Skeleton provides a number of <a class="anchor" href="/docs/get-started#preset-themes">preset themes</a> out of the box. You'll need to
+			register at least one theme to load them and make them available to use.
 		</p>
 		<CodeBlock
 			language="ts"
@@ -115,24 +115,22 @@
 plugins: [
 	skeleton({
 		themes: {
-			// Register a single theme:
-			preset: [ "skeleton" ]\n
-			// Register multiple themes:
-			// preset: [ "skeleton", "modern", "crimson" ] 
+			// Register each theme within this array:
+			preset: [ "skeleton", "modern", "crimson" ] 
 		}
 	})
 ]
 	`}
 		/>
 		<p>
-			Open <code class="code">/src/app.html</code> and define the active theme using the <code class="code">data-theme</code> attribute. You
-			can modify this attribute to dynamically switch between themes.
+			Open <code class="code">/src/app.html</code> and define the active theme to display using the <code class="code">data-theme</code> attribute.
+			You can modify this attribute to dynamically switch between any registered theme.
 		</p>
 		<CodeBlock language="html" code={`<body data-theme="skeleton">`} />
 		<h3 class="h3">Enhancements</h3>
 		<p>
-			Preset themes may implement additional optional features for your theme, including: setting font weights, background mesh gradients,
-			and more. To enable these settings, use <code class="code">enhancements</code> as shown below.
+			Preset themes may sometimes include additional optional features, such as: heading font weights, background mesh gradients, and more.
+			To enable these settings, include <code class="code">enhancements</code> as shown below.
 		</p>
 		<CodeBlock
 			language="ts"
@@ -140,8 +138,8 @@ plugins: [
 plugins: [
 	skeleton({
 		themes: {
-			// Enable 'enhancements' as shown below:
 			preset: [
+				// Enable 'enhancements' per each registered theme:
 				{ name: "skeleton", enhancements: true }
 			] 
 		}
@@ -151,7 +149,8 @@ plugins: [
 		/>
 		<h3 class="h3">Custom Themes</h3>
 		<p>
-			View the <a class="anchor" href="/docs/generator">theme generator</a> for more information about custom themes.
+			View the <a class="anchor" href="/docs/generator">theme generator</a> for more information about implementing custom themes. Note that
+			it is possible to mix and match preset and custom themes.
 		</p>
 	</section>
 
@@ -161,8 +160,7 @@ plugins: [
 		<h2 class="h2">Backgrounds</h2>
 		<!-- prettier-ignore -->
 		<p>
-			The background color of your application is set automatically using one of Skeleton's <a class="anchor" href="https://www.skeleton.dev/docs/tokens">design token</a> styles.
-			This utilizes <code class="code">--color-surface-50</code> for light mode and <code class="code">--color-surface-900</code> for dark mode by default. See the examples below to learn how to modify this in your <code class="code">app.postcss</code>:
+			The background color of your application is automatically set using one of Skeleton's <a class="anchor" href="https://www.skeleton.dev/docs/tokens">design token</a> styles. By default, this utilizes <code class="code">--color-surface-50</code> for light mode and <code class="code">--color-surface-900</code> for dark mode. Use your global stylesheet <code class="code">app.postcss</code> to modify this.
 		</p>
 		<CodeBlock
 			language="css"
@@ -170,13 +168,15 @@ plugins: [
 /* Default setting: */
 body { @apply bg-surface-50-900-token; }
 
-/* Example: modified to the primary color via a design token: */
+/* --- */
+
+/* Example: primary color via a design token: */
 body { @apply bg-primary-50-900-token; }
 
-/* Example: modified to the secondary color via Tailwind: */
+/* Example: secondary color via Tailwind: */
 body { @apply bg-secondary-50 dark:bg-secondary-900; }
 
-/* Example: modified using vanilla CSS: */
+/* Example: using vanilla CSS: */
 body { background: red; }
 .dark body { background: blue; }
 		`}
@@ -185,8 +185,8 @@ body { background: red; }
 			<div class="space-y-4">
 				<h3 class="h3">Images and Gradients</h3>
 				<p>
-					You may optionally provide a background image, including the use of a CSS mesh gradient. Mix in theme color properties to create
-					fully adaptive gradient backgrounds.
+					You may optionally provide a background image, including the use of a CSS mesh gradient. Replace the static color values with
+					theme color properties to create a fully adaptive gradient background.
 				</p>
 			</div>
 			<div>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -96,11 +96,70 @@
 	<hr />
 
 	<section class="space-y-4">
+		<h2 class="h2">Tailwind Plugin Settings</h2>
+		<p>
+			Themes are configured via Skeleton's Tailwind plugin in your <code class="code">tailwind.config.[js,cjs,ts]</code>, found in your
+			project root.
+		</p>
+		<h3 class="h3">Register Themes</h3>
+		<p>
+			Skeleton provides a number of <a class="anchor" href="/docs/get-started#preset-themes">preset themes</a> out of the box. Register one or
+			more within your Tailwind plugin settings.
+		</p>
+		<CodeBlock
+			language="ts"
+			code={`
+plugins: [
+	skeleton({
+		themes: {
+			// Register a single theme:
+			preset: [ "skeleton" ]\n
+			// Register multiple themes:
+			// preset: [ "skeleton", "modern", "crimson" ] 
+		}
+	})
+]
+	`}
+		/>
+		<p>
+			Open <code class="code">/src/app.html</code> and define the theme active theme using the <code class="code">data-theme</code> attribute.
+			You can modify this attribute to dynamically switch between themes as desired.
+		</p>
+		<CodeBlock language="html" code={`<body data-theme="skeleton">`} />
+		<h3 class="h3">Enhancements</h3>
+		<p>
+			Preset themes may implement additional optional features for your theme, including: setting font weights, background mesh gradients,
+			and more. To enable these settings use <code class="code">enhancements</code> as shown below.
+		</p>
+		<CodeBlock
+			language="ts"
+			code={`
+plugins: [
+	skeleton({
+		themes: {
+			// Enable 'enhancements' as shown below:
+			preset: [
+				{ name: "skeleton", enhancements: true }
+			] 
+		}
+	})
+]
+	`}
+		/>
+		<h3 class="h3">Custom Themes</h3>
+		<p>
+			View the <a class="anchor" href="/docs/generator">theme generator</a> for more information about custom themes.
+		</p>
+	</section>
+
+	<hr />
+
+	<section class="space-y-4">
 		<h2 class="h2">Backgrounds</h2>
 		<!-- prettier-ignore -->
 		<p>
-			Your app's background color is set automatically via a <a class="anchor" href="https://www.skeleton.dev/docs/tokens">design token</a>.
-			This utilizes <code class="code">--color-surface-50</code> for light mode and <code class="code">--color-surface-900</code> for dark mode by default. Here's a few examples illustrating how to modify this in <code class="code">app.postcss</code>:
+			The background color of your application is set automatically using one of Skeleton's <a class="anchor" href="https://www.skeleton.dev/docs/tokens">design token</a> styles.
+			This utilizes <code class="code">--color-surface-50</code> for light mode and <code class="code">--color-surface-900</code> for dark mode by default. See the examples below to learn how to modify this in your <code class="code">app.postcss</code>:
 		</p>
 		<CodeBlock
 			language="css"

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -96,7 +96,10 @@
 	<hr />
 
 	<section class="space-y-4">
-		<h2 class="h2">Tailwind Plugin Settings</h2>
+		<div class="h2 flex items-center gap-2">
+			<h2 class="h2">Tailwind Plugin Settings</h2>
+			<span class="badge variant-filled-warning">New in v2</span>
+		</div>
 		<p>
 			Themes are configured via Skeleton's Tailwind plugin in your <code class="code">tailwind.config.[cjs|js|ts]</code>, found in your
 			project root.

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -98,7 +98,7 @@
 	<section class="space-y-4">
 		<h2 class="h2">Tailwind Plugin Settings</h2>
 		<p>
-			Themes are configured via Skeleton's Tailwind plugin in your <code class="code">tailwind.config.[js,cjs,ts]</code>, found in your
+			Themes are configured via Skeleton's Tailwind plugin in your <code class="code">tailwind.config.[cjs|js|ts]</code>, found in your
 			project root.
 		</p>
 		<h3 class="h3">Register Themes</h3>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -221,22 +221,6 @@ body {
 		<p>
             Fonts may be installed from a local or remote source. For <a class="anchor" href="https://gdpr.eu/" target="_blank" rel="noreferrer">GDPR compliance</a> and optimal performance we recommend installing the fonts locally. For this guide we'll demonstrate this process using free fonts from <a class="anchor" href="https://fonts.google.com/" target="_blank" rel="noreferrer">Google Fonts</a>.
 		</p>
-		{#if activeTheme.fonts.length && activeTheme.file !== 'custom'}
-			<aside class="alert variant-ghost-warning">
-				<i class="fa-solid fa-circle-exclamation" />
-				<div class="alert-message">
-					<p>
-						The <code class="code">{activeTheme.name}</code> theme makes use of custom fonts. We recommend you follow the instruction below.
-					</p>
-				</div>
-			</aside>
-		{:else if activeTheme.file !== 'custom'}
-			<aside class="alert variant-ghost">
-				<div class="alert-message">
-					<p>The <code class="code">{activeTheme.name}</code> theme does not make use of a custom font.</p>
-				</div>
-			</aside>
-		{/if}
 		<TabGroup regionPanel="space-y-4">
 			<Tab bind:group={tabsFontImport} name="tab1" value={0}>Local (recommended)</Tab>
 			<Tab bind:group={tabsFontImport} name="tab2" value={1}>Remote</Tab>

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -88,8 +88,8 @@
 			<span class="badge variant-filled-warning">New in v2</span>
 		</div>
 		<p>
-			Skeleton now defines theme settings via CSS-in-JS format. This allows means themes can be easily injected into the Skeleton Tailwind
-			plugin rather than requiring additional CSS stylesheet imports.
+			Skeleton now defines theme settings via CSS-in-JS format. This allows themes to be easily injected into the Skeleton Tailwind plugin
+			rather than requiring additional CSS stylesheet imports.
 		</p>
 	</section>
 
@@ -125,14 +125,14 @@ plugins: [
 	`}
 		/>
 		<p>
-			Open <code class="code">/src/app.html</code> and define the theme active theme using the <code class="code">data-theme</code> attribute.
-			You can modify this attribute to dynamically switch between themes as desired.
+			Open <code class="code">/src/app.html</code> and define the active theme using the <code class="code">data-theme</code> attribute. You
+			can modify this attribute to dynamically switch between themes.
 		</p>
 		<CodeBlock language="html" code={`<body data-theme="skeleton">`} />
 		<h3 class="h3">Enhancements</h3>
 		<p>
 			Preset themes may implement additional optional features for your theme, including: setting font weights, background mesh gradients,
-			and more. To enable these settings use <code class="code">enhancements</code> as shown below.
+			and more. To enable these settings, use <code class="code">enhancements</code> as shown below.
 		</p>
 		<CodeBlock
 			language="ts"

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -3,11 +3,31 @@
 	// Docs
 	import LayoutPage from '$lib/layouts/LayoutPage/LayoutPage.svelte';
 	// Components
-	import { Tab, TabGroup, CodeBlock } from '@skeletonlabs/skeleton';
+	import { Tab, TabGroup, CodeBlock, type TableSource, Table } from '@skeletonlabs/skeleton';
 
 	// Local
 	let activeTheme = themes[1];
 	let tabsFontImport = 0;
+
+	// Table
+	const sourceCssProperties = [
+		['<code class="code">--theme-font-family-base</code>', 'Set the font family for your default base text.'],
+		['<code class="code">--theme-font-family-heading</code>', 'Set the font family for your heading text.'],
+		['<code class="code">--theme-font-color-base</code>', 'Set the default text color for light mode.'],
+		['<code class="code">--theme-font-color-dark</code>', 'Set the default text color for dark mode.'],
+		['<code class="code">--theme-rounded-base</code>', 'Set the border radius size for small elements, such as buttons, inputs, etc.'],
+		['<code class="code">--theme-rounded-container</code>', 'Set the border radicus for large elements, such as cards and textfields'],
+		['<code class="code">--theme-border-base</code>', 'Set the default border size for various elements, including inputs.'],
+		// Theme On-X Colors
+		['<code class="code">--on-[color]</code>', 'Set the accessible overlapping text or fill color.'],
+		['<code class="code">--color-[color]-[shade]</code>', 'Defines each color and shade value for your theme.']
+	];
+	const tableCssProperties: TableSource = {
+		// A list of heading labels.
+		head: ['CSS Property', 'Description'],
+		// The data visibly shown in your table body UI.
+		body: sourceCssProperties
+	};
 
 	// Reactive
 	$: activeFonts = activeTheme.fonts.length ? activeTheme.fonts : themes[0].fonts;
@@ -17,46 +37,93 @@
 	<header class="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-4">
 		<div class="space-y-4">
 			<h1 class="h1">Themes</h1>
-			<p>Learn more about customizing Skeleton themes.</p>
+			<p>Learn more about Skeleton themes and customizing.</p>
 		</div>
 	</header>
 
-	<section class="sticky top-4 z-[1] card variant-glass p-4 space-y-4">
-		<p class="!text-center">Select your current theme to tailor the instructions below.</p>
-		<label class="max-w-md mx-auto">
-			<select class="select" bind:value={activeTheme}>
-				{#each themes as theme}
-					<option value={theme}>{theme.name}</option>
-				{/each}
-			</select>
-		</label>
+	<hr />
+
+	<section class="space-y-4">
+		<h2 class="h2">CSS Custom Properties</h2>
+		<!-- prettier-ignore -->
+		<p>
+			Skeleton themes are generated using a number of <a class="anchor" href="https://developer.mozilla.org/en-US/docs/Web/CSS/--*" target="_blank" rel="noreferrer">CSS Custom Properties</a>, also known as as CSS variables.
+		</p>
+		<Table source={tableCssProperties} />
+		<h3 class="h3">Overwriting Properties</h3>
+		<!-- prettier-ignore -->
+		<p>
+			Similar to variables in other languages, these can be modified and overwritten as desired. By adding the following snippet in <code class="code">/src/app.postcss</code>, you can overwrite the <em>base</em> and <em>container</em> border radius styles for your active theme.
+		</p>
+		<CodeBlock
+			language="css"
+			code={`
+:root {
+	--theme-rounded-base: 20px;
+	--theme-rounded-container: 4px;
+}
+		`}
+		/>
+		<p>Likewise, you can override font family settings for your <em>base</em> and <em>heading</em> text settings as shown below.</p>
+		<CodeBlock
+			language="css"
+			code={`
+:root {
+    --theme-font-family-base: 'MyCustomFont', sans-serif;
+    --theme-font-family-heading: 'MyCustomFont', sans-serif;
+}
+		`}
+		/>
+		<!-- prettier-ignore -->
+		<p>
+			For heavy modifications, consider cloning Skeleton's preset themes and implementing as a custom theme. Follow the guide provide on our <a class="anchor" href="/docs/generator">theme generator</a> documentation for more information.
+		</p>
 	</section>
 
-	{#if activeTheme.file !== 'custom'}
-		<section class="space-y-4">
-			<h2 class="h2">Preset Extras</h2>
-			<p>
-				When using preset themes provided by Skeleton, consider implementing the <code class="code">data-theme</code> attribute on the
-				<em>body</em>
-				tag in <code class="code">app.html</code>. This implements additional settings such as background gradients, header font weights,
-				and more.
-			</p>
-			<CodeBlock language="html" code={`<body data-theme="` + activeTheme.file + `">`} />
-		</section>
-	{/if}
+	<hr />
+
+	<section class="space-y-4">
+		<div class="h2 flex items-center gap-2">
+			<h2>CSS-in-JS Format</h2>
+			<span class="badge variant-filled-warning">New in v2</span>
+		</div>
+		<p>
+			Skeleton now defines theme settings via CSS-in-JS format. This allows means themes can be easily injected into the Skeleton Tailwind
+			plugin rather than requiring additional CSS stylesheet imports.
+		</p>
+	</section>
+
+	<hr />
 
 	<section class="space-y-4">
 		<h2 class="h2">Backgrounds</h2>
+		<!-- prettier-ignore -->
 		<p>
-			Your app's background is automatically set via a <a class="anchor" href="https://www.skeleton.dev/docs/tokens">design token</a> class.
-			Adjust your theme's color scheme to customize. This affects both light and dark mode.
+			Your app's background color is set automatically via a <a class="anchor" href="https://www.skeleton.dev/docs/tokens">design token</a>.
+			This utilizes <code class="code">--color-surface-50</code> for light mode and <code class="code">--color-surface-900</code> for dark mode by default. Here's a few examples illustrating how to modify this in <code class="code">app.postcss</code>:
 		</p>
-		<CodeBlock language="css" code={`body { @apply bg-surface-50-900-token; }`} />
+		<CodeBlock
+			language="css"
+			code={`
+/* Default setting: */
+body { @apply bg-surface-50-900-token; }
+
+/* Example: modified to the primary color via a design token: */
+body { @apply bg-primary-50-900-token; }
+
+/* Example: modified to the secondary color via Tailwind: */
+body { @apply bg-secondary-50 dark:bg-secondary-900; }
+
+/* Example: modified using vanilla CSS: */
+body { background: red; }
+.dark body { background: blue; }
+		`}
+		/>
 		<div class="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-4 items-center">
 			<div class="space-y-4">
-				<h3 class="h3">Background Images</h3>
+				<h3 class="h3">Images and Gradients</h3>
 				<p>
-					You may optionally provide a background image, including the use of CSS mesh gradients. Mix in theme color properties to create
+					You may optionally provide a background image, including the use of a CSS mesh gradient. Mix in theme color properties to create
 					fully adaptive gradient backgrounds.
 				</p>
 			</div>
@@ -84,40 +151,7 @@ body {
 		/>
 	</section>
 
-	<section class="space-y-4">
-		<h2 class="h2">CSS Properties</h2>
-		<!-- prettier-ignore -->
-		<p>
-			If you open any existing theme, you can see they are made up of a number of <a class="anchor" href="https://developer.mozilla.org/en-US/docs/Web/CSS/--*" target="_blank" rel="noreferrer">CSS Custom Properties</a> (aka CSS Variables). Similar to Javascript variables these can be modified and overwritten as desired. For example, if you add the following snippet to your global stylesheet in <code class="code">/src/app.postcss</code>, you can overwrite the <em>base</em> and <em>container</em> rounding styles for your current theme.
-		</p>
-		<CodeBlock
-			language="css"
-			code={`
-:root {
-	--theme-rounded-base: 20px;
-	--theme-rounded-container: 4px;
-}
-		`}
-		/>
-		<p>
-			Likewise, if you wish to implement a custom font family for a preset theme, you can modify the <em>base</em> and
-			<em>heading</em>
-			properties as shown below.
-		</p>
-		<CodeBlock
-			language="css"
-			code={`
-:root {
-    --theme-font-family-base: 'MyCustomFont', sans-serif;
-    --theme-font-family-heading: 'MyCustomFont', sans-serif;
-}
-		`}
-		/>
-		<!-- prettier-ignore -->
-		<p>
-			<a class="anchor" href="https://github.com/skeletonlabs/skeleton/tree/master/packages/skeleton/src/lib/themes" target="_blank" rel="noreferrer">View any existing theme</a> for a full list of available CSS custom properties. For heavy modifications to preset themes, consider copying the theme to your local project and use it like any other custom theme.
-		</p>
-	</section>
+	<hr />
 
 	<section class="space-y-4">
 		<h2 class="h2">Custom Fonts</h2>


### PR DESCRIPTION
## Linked Issue

Closes #1781

## Description

- [x] Updates the getting started instruction @ `/docs/get-started` (manual tab)
- [x] Updates the Themes documentation @ `/docs/themes`
- [x] Updates the theme generator install documentation @ `/docs/generator`
- [x] Updates the theme generator to output the v2 CSS-in-JS format

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
