### PR TITLE
v2: Chore/reinstate btn-base

### DIFF
--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -34,6 +34,12 @@
 	.btn-sm {
 		@apply text-sm px-3 py-1.5;
 	}
+	.btn-md,
+	.btn-base {
+		/* NOTE: this is required for responsible styling, ex: */
+		/* <button class="btn btn-sm lg:btn-base">Test</button> */
+		@apply text-base px-5 py-[9px];
+	}
 	.btn-lg {
 		@apply text-lg px-7 py-3;
 	}

--- a/sites/skeleton.dev/src/routes/(inner)/elements/buttons/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/buttons/+page.svelte
@@ -18,8 +18,8 @@
 		classes: [
 			['<code class="code">.btn</code>', '-', 'Creates a text button using a button or anchor.'],
 			['<code class="code">.btn-icon</code>', '-', 'Creates a text icon button using a button or anchor.'],
-			['<code class="code">.btn-[value]</code>', 'sm | base | lg | xl', 'Canned button sizes that define padding and text sizes.'],
-			['<code class="code">.btn-icon-[value]</code>', 'sm | base | lg | xl', 'Canned icon button sizes that define padding and text sizes.']
+			['<code class="code">.btn-[value]</code>', 'sm | md | lg | xl', 'Canned button sizes that define padding and text sizes.'],
+			['<code class="code">.btn-icon-[value]</code>', 'sm | md | lg | xl', 'Canned icon button sizes that define padding and text sizes.']
 		]
 	};
 
@@ -93,13 +93,16 @@
 		</p>
 		<section class="space-y-4">
 			<h2 class="h2">Sizes</h2>
-			<p>A number of canned size presets are available via <code class="code">.btn-[size]</code>.</p>
+			<p>
+				A number of canned size presets are available via <code class="code">.btn-[size]</code>. Default sizing matches
+				<code class="code">btn-md</code>.
+			</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="space-y-4">
 						<div class="flex justify-center items-center gap-4">
 							<button type="button" class="btn btn-sm variant-filled">sm</button>
-							<button type="button" class="btn variant-filled">base</button>
+							<button type="button" class="btn variant-filled">md</button>
 							<button type="button" class="btn btn-lg variant-filled">lg</button>
 							<button type="button" class="btn btn-xl variant-filled">xl</button>
 						</div>
@@ -125,7 +128,7 @@
 						language="html"
 						code={`
 <button type="button" class="btn btn-sm variant-filled">sm</button>
-<button type="button" class="btn variant-filled">base</button>
+<button type="button" class="btn variant-filled">md</button>
 <button type="button" class="btn btn-lg variant-filled">lg</button>
 <button type="button" class="btn btn-xl variant-filled">xl</button>
 `}


### PR DESCRIPTION
## Linked Issue

Closes #1724

## Description

Reinstate the `.btn-base` style, including the alias `.btn-md` to fix issues with responsive styling.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
