### PR TITLE
bugfix/background-hover-token-color

### DIFF
--- a/.changeset/fresh-crews-drum.md
+++ b/.changeset/fresh-crews-drum.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Fixed `.bg-hover-primary-token` color in dark mode.

--- a/packages/skeleton/src/lib/tailwind/tokens/backgrounds.cjs
+++ b/packages/skeleton/src/lib/tailwind/tokens/backgrounds.cjs
@@ -18,7 +18,7 @@ module.exports = () => {
 		// Hover
 		// Example: .bg-primary-hover-token
 		classes[`.bg-${n}-hover-token:hover`] = { 'background-color': `rgb(var(--color-${n}-500) / ${hoverAlpha})` };
-		classes[`.dark .bg-${n}-hover-token:hover`] = { 'background-color': `rgb(var(--color-${n}-200) / ${hoverAlpha})` };
+		classes[`.dark .bg-${n}-hover-token:hover`] = { 'background-color': `rgb(var(--color-${n}-500) / ${hoverAlpha})` };
 
 		// Active
 		// Example: .bg-primary-active-token


### PR DESCRIPTION
## Linked Issue

Closes #1718

## Description
It seems like this is an issue known in TailwindCSS but they are not considering it as a bug🥲, see https://github.com/tailwindlabs/tailwindcss/issues/10855#issuecomment-1482626801 and https://github.com/tailwindlabs/tailwindcss/issues/10855#issuecomment-1483262954

as a workaround, I duplicated the class with `.dark` in #1577 (I didn't know this was a bug in `:hover`) but changed the value of the color thinking it should be different, so I just updated the color value to match light mode for now.

## Changsets

bugfix: Fixed `.bg-hover-primary-token` color in dark mode.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
