### PR TITLE
bugfix/autocomplete-denyallow-lists-reactive-update

### DIFF
--- a/.changeset/clean-tables-boil.md
+++ b/.changeset/clean-tables-boil.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: `autocomplete` fixed reactive update when allow and deny lists are empty.

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -61,7 +61,7 @@
 	// Local
 	$: listedOptions = options;
 
-	function filterByAllowDeny() {
+	function filterByAllowDeny(allowlist: unknown[], denylist: unknown[]) {
 		let _options = [...options];
 		// Allowed Options
 		if (allowlist.length) {
@@ -102,7 +102,7 @@
 	}
 
 	// State
-	$: if (allowlist.length || denylist.length) filterByAllowDeny();
+	$: filterByAllowDeny(allowlist, denylist);
 	$: optionsFiltered = input ? filterOptions() : listedOptions;
 	$: sliceLimit = limit !== undefined ? limit : optionsFiltered.length;
 	// Reactive


### PR DESCRIPTION
## Linked Issue

Closes #1812

## Description

see https://github.com/skeletonlabs/skeleton/issues/1812#issuecomment-1666532898 and https://github.com/skeletonlabs/skeleton/issues/1812#issuecomment-1666537700

## Changsets

bugfix: `autocomplete` fixed reactive update when allow and deny lists are empty.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
