### PR TITLE
bugfix: Prevent `Paginator` from resetting its offset

### DIFF
--- a/.changeset/dry-rabbits-boil.md
+++ b/.changeset/dry-rabbits-boil.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: `paginator` will not reset the offset when changing length.

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -91,11 +91,16 @@
 	let controlPages: number[] = getNumerals();
 
 	function onChangeLength(): void {
-		settings.offset = 0;
 		/** @event {{ length: number }} amount - Fires when the amount selection input changes.  */
 		dispatch('amount', settings.limit);
 
 		lastPage = Math.max(0, Math.ceil(settings.size / settings.limit - 1));
+
+		// ensure offset in limit range
+		if (settings.offset > lastPage) {
+			settings.offset = lastPage;
+		}
+
 		controlPages = getNumerals();
 	}
 


### PR DESCRIPTION
## Linked Issue

Closes #1818

## Description

paginator will not reset the offset now, instead, it will check if it is bigger than the limit, and if so it will set the offset to the limit.

## Changsets

bugfix: `paginator` will not reset the offset when changing length.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
