### PR TITLE
Bugfix/paginator-prevent-page-reset

### DIFF
--- a/.changeset/real-plums-collect.md
+++ b/.changeset/real-plums-collect.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: prevent `Paginator` from resetting it's page on length change.

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -90,11 +90,16 @@
 	let controlPages: number[] = getNumerals();
 
 	function onChangeLength(): void {
-		settings.page = 0;
 		/** @event {{ length: number }} amount - Fires when the amount selection input changes.  */
 		dispatch('amount', settings.limit);
 
 		lastPage = Math.ceil(settings.size / settings.limit - 1);
+
+		// ensure page in limit range
+		if (settings.page > lastPage) {
+			settings.page = lastPage;
+		}
+
 		controlPages = getNumerals();
 	}
 


### PR DESCRIPTION
## Linked Issue

Closes #1818 

## Description

paginator will not reset the page now, instead, it will check if it is bigger than the limit, and if so it will set the page to the limit.

## Changsets

bugfix: prevent `Paginator` from resetting it's page on length change.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
