### PR TITLE
bugfix: Paginator page set to -1 when empty

### DIFF
--- a/.changeset/spicy-horses-wonder.md
+++ b/.changeset/spicy-horses-wonder.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Fixed an issue where the paginator page would be set to -1 if the size was 0

--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -95,7 +95,7 @@
 		/** @event {{ length: number }} amount - Fires when the amount selection input changes.  */
 		dispatch('amount', settings.limit);
 
-		lastPage = Math.ceil(settings.size / settings.limit - 1);
+		lastPage = Math.max(0, Math.ceil(settings.size / settings.limit - 1));
 
 		// ensure page in limit range
 		if (settings.page > lastPage) {


### PR DESCRIPTION
## Description
Fixed an issue where the paginator page would be set to -1 if the size was 0

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [X] Includes a changeset (if relevant; see above)
