### PR TITLE
feat: Added optional dark mode theme properties

### DIFF
--- a/.changeset/five-deers-listen.md
+++ b/.changeset/five-deers-listen.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": minor
+---
+
+feat: Added optional properties that are applied in dark mode

--- a/packages/create-skeleton-app/.prettierignore
+++ b/packages/create-skeleton-app/.prettierignore
@@ -11,3 +11,4 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+CHANGELOG.md

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -23,6 +23,7 @@ const skeleton = plugin.withOptions<ConfigOptions>(
 			options?.themes?.custom?.forEach((theme) => {
 				// it's a custom theme
 				baseStyles[`:root [data-theme='${theme.name}']`] = theme.properties;
+				if (theme.properties_dark) baseStyles[`.dark [data-theme='${theme.name}']`] = theme.properties_dark;
 			});
 
 			// Preset Themes configuration
@@ -32,12 +33,14 @@ const skeleton = plugin.withOptions<ConfigOptions>(
 					const themeName = theme;
 					// we only want the properties
 					baseStyles[`:root [data-theme='${themeName}']`] = themes[themeName].properties;
+					baseStyles[`.dark [data-theme='${themeName}']`] = themes[themeName].properties_dark;
 					return;
 				}
 
 				// it's a preset theme
 				if (!('properties' in theme)) {
 					baseStyles[`:root [data-theme='${theme.name}']`] = themes[theme.name].properties;
+					baseStyles[`.dark [data-theme='${theme.name}']`] = themes[theme.name].properties_dark;
 
 					if (theme.enhancements === true) {
 						// enhancements are opt-in

--- a/packages/plugin/src/tailwind/themes/crimson.ts
+++ b/packages/plugin/src/tailwind/themes/crimson.ts
@@ -88,6 +88,7 @@ const crimson = {
 		'--color-surface-800': '26 28 38',
 		'--color-surface-900': '21 23 31'
 	},
+	properties_dark: {},
 	enhancements: {}
 } satisfies Theme;
 

--- a/packages/plugin/src/tailwind/themes/gold-nouveau.ts
+++ b/packages/plugin/src/tailwind/themes/gold-nouveau.ts
@@ -87,20 +87,20 @@ const goldNouveau = {
 		'--color-surface-800': '35 22 49',
 		'--color-surface-900': '18 11 24'
 	},
+	properties_dark: {
+		'--on-primary': '0 0 0',
+		'--color-primary-50': '251 247 224',
+		'--color-primary-100': '250 244 214',
+		'--color-primary-200': '249 241 204',
+		'--color-primary-300': '245 233 173',
+		'--color-primary-400': '238 217 112',
+		'--color-primary-500': '230 200 51',
+		'--color-primary-600': '207 180 46',
+		'--color-primary-700': '173 150 38',
+		'--color-primary-800': '138 120 31',
+		'--color-primary-900': '113 98 25'
+	},
 	enhancements: {
-		".dark [data-theme='gold-nouveau']": {
-			'--on-primary': '0 0 0',
-			'--color-primary-50': '251 247 224',
-			'--color-primary-100': '250 244 214',
-			'--color-primary-200': '249 241 204',
-			'--color-primary-300': '245 233 173',
-			'--color-primary-400': '238 217 112',
-			'--color-primary-500': '230 200 51',
-			'--color-primary-600': '207 180 46',
-			'--color-primary-700': '173 150 38',
-			'--color-primary-800': '138 120 31',
-			'--color-primary-900': '113 98 25'
-		},
 		"[data-theme='gold-nouveau'] h1,\n[data-theme='gold-nouveau'] h2,\n[data-theme='gold-nouveau'] h3,\n[data-theme='gold-nouveau'] h4,\n[data-theme='gold-nouveau'] h5,\n[data-theme='gold-nouveau'] h6":
 			{ fontWeight: 'bold' },
 		"[data-theme='gold-nouveau']": {

--- a/packages/plugin/src/tailwind/themes/hamlindigo.ts
+++ b/packages/plugin/src/tailwind/themes/hamlindigo.ts
@@ -88,6 +88,7 @@ const hamlindigo = {
 		'--color-surface-800': '59 71 98',
 		'--color-surface-900': '49 58 80'
 	},
+	properties_dark: {},
 	enhancements: {
 		"[data-theme='hamlindigo']": {
 			backgroundImage:

--- a/packages/plugin/src/tailwind/themes/index.ts
+++ b/packages/plugin/src/tailwind/themes/index.ts
@@ -20,7 +20,12 @@ export function getThemeProperties(themeName: PresetTheme) {
 export type ObjectValues<T> = T[keyof T];
 export type ObjectKeys<T> = keyof T;
 
-export type Theme = { properties: ThemeProperties; enhancements: CSSRuleObject };
+export type Theme = {
+	properties: ThemeProperties;
+	properties_dark: Partial<ThemeProperties>;
+	enhancements: CSSRuleObject;
+};
+
 export type ThemeProperties = {
 	/* =~= Theme Properties =~= */
 	'--theme-font-family-base': string;

--- a/packages/plugin/src/tailwind/themes/modern.ts
+++ b/packages/plugin/src/tailwind/themes/modern.ts
@@ -87,6 +87,7 @@ const modern = {
 		'--color-surface-800': '59 61 145',
 		'--color-surface-900': '49 50 118'
 	},
+	properties_dark: {},
 	enhancements: {
 		"[data-theme='modern'] h1,\n[data-theme='modern'] h2,\n[data-theme='modern'] h3,\n[data-theme='modern'] h4,\n[data-theme='modern'] h5,\n[data-theme='modern'] h6,\n[data-theme='modern'] a,\n[data-theme='modern'] button":
 			{ fontWeight: 'bold' },

--- a/packages/plugin/src/tailwind/themes/rocket.ts
+++ b/packages/plugin/src/tailwind/themes/rocket.ts
@@ -87,6 +87,7 @@ const rocket = {
 		'--color-surface-800': '60 70 83',
 		'--color-surface-900': '49 57 68'
 	},
+	properties_dark: {},
 	enhancements: {
 		"[data-theme='rocket'] h1,\n[data-theme='rocket'] h2,\n[data-theme='rocket'] h3,\n[data-theme='rocket'] h4,\n[data-theme='rocket'] h5,\n[data-theme='rocket'] h6":
 			{ fontWeight: 'bold' },

--- a/packages/plugin/src/tailwind/themes/sahara.ts
+++ b/packages/plugin/src/tailwind/themes/sahara.ts
@@ -89,6 +89,7 @@ const sahara = {
 		'--color-surface-800': '131 47 61',
 		'--color-surface-900': '107 38 49'
 	},
+	properties_dark: {},
 	enhancements: {
 		"[data-theme='sahara'] h1,\n[data-theme='sahara'] h2,\n[data-theme='sahara'] h3,\n[data-theme='sahara'] h4,\n[data-theme='sahara'] h5,\n[data-theme='sahara'] h6":
 			{ fontWeight: '600' },

--- a/packages/plugin/src/tailwind/themes/seafoam.ts
+++ b/packages/plugin/src/tailwind/themes/seafoam.ts
@@ -88,6 +88,7 @@ const seafoam = {
 		'--color-surface-800': '22 125 127',
 		'--color-surface-900': '18 102 104'
 	},
+	properties_dark: {},
 	enhancements: {
 		"[data-theme='seafoam'] h1,\n[data-theme='seafoam'] h2,\n[data-theme='seafoam'] h3,\n[data-theme='seafoam'] h4,\n[data-theme='seafoam'] h5,\n[data-theme='seafoam'] h6":
 			{ fontWeight: 'bold', fontStyle: 'italic', letterSpacing: '1px' },

--- a/packages/plugin/src/tailwind/themes/skeleton.ts
+++ b/packages/plugin/src/tailwind/themes/skeleton.ts
@@ -87,6 +87,7 @@ const skeleton = {
 		'--color-surface-800': '44 54 86',
 		'--color-surface-900': '36 44 70'
 	},
+	properties_dark: {},
 	enhancements: {
 		"[data-theme='skeleton'] h1,\n[data-theme='skeleton'] h2,\n[data-theme='skeleton'] h3,\n[data-theme='skeleton'] h4,\n[data-theme='skeleton'] h5,\n[data-theme='skeleton'] h6":
 			{ fontWeight: 'bold' },

--- a/packages/plugin/src/tailwind/themes/vintage.ts
+++ b/packages/plugin/src/tailwind/themes/vintage.ts
@@ -88,6 +88,7 @@ const vintage = {
 		'--color-surface-800': '38 33 29',
 		'--color-surface-900': '31 27 24'
 	},
+	properties_dark: {},
 	enhancements: {
 		"[data-theme='vintage'] h1,\n[data-theme='vintage'] h2,\n[data-theme='vintage'] h3,\n[data-theme='vintage'] h4,\n[data-theme='vintage'] h5,\n[data-theme='vintage'] h6":
 			{ letterSpacing: '1px' },

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -121,6 +121,10 @@ export type CustomThemeConfig = {
 	 * }
 	 */
 	properties: ThemeProperties;
+	/**
+	 * Optional properties that are applied in dark mode.
+	 */
+	properties_dark?: Partial<ThemeProperties>;
 };
 
 export type PresetThemeConfig = {


### PR DESCRIPTION
## Linked Issue

Closes #1893

## Description

Added optional dark mode specific properties for themes.

These properties can be added via the optional `properties_dark` prop for custom themes.

Ex:
```ts
import type { CustomThemeConfig } from '@skeletonlabs/tw-plugin';

export const customTheme = {
	name: "my-custom-theme",
    // base
    properties: {
        '--color-primary-50': '219 245 236',
        '--color-primary-100': '207 241 230',
        '--color-primary-200': '195 238 224',
		// ...
    },
    // applies on dark theme only (optional)
    properties_dark: {
        '--color-primary-50': '219 245 236',
        '--color-primary-100': '207 241 230',
        '--color-primary-200': '195 238 224',
    }
} satisfies CustomThemeConfig;
```
## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
