### PR TITLE
v2: version picker for doc site App Bar

### DIFF
--- a/sites/skeleton.dev/src/lib/components/DocsAppBar/DocsAppBar.svelte
+++ b/sites/skeleton.dev/src/lib/components/DocsAppBar/DocsAppBar.svelte
@@ -204,7 +204,8 @@
 		<div>
 			<!-- trigger -->
 			<button class="btn hover:variant-soft-primary" use:popup={{ event: 'click', target: 'sponsor' }}>
-				<span>Sponsor</span>
+				<i class="fa-solid fa-heart text-lg md:!hidden" />
+				<span class="hidden md:inline-block">Sponsor</span>
 				<i class="fa-solid fa-caret-down opacity-50" />
 			</button>
 			<!-- popup -->
@@ -262,7 +263,7 @@
 		<div class="md:inline md:ml-4">
 			<button class="btn space-x-4 variant-soft hover:variant-soft-primary" on:click={triggerSearch}>
 				<i class="fa-solid fa-magnifying-glass text-sm" />
-				<small>{isOsMac ? '⌘' : 'Ctrl'}+K</small>
+				<small class="hidden md:inline-block">{isOsMac ? '⌘' : 'Ctrl'}+K</small>
 			</button>
 		</div>
 

--- a/sites/skeleton.dev/src/lib/components/DocsAppBar/DocsAppBar.svelte
+++ b/sites/skeleton.dev/src/lib/components/DocsAppBar/DocsAppBar.svelte
@@ -81,7 +81,7 @@
 <!-- NOTE: using stopPropagation to override Chrome for Windows search shortcut -->
 <svelte:window on:keydown|stopPropagation={onWindowKeydown} />
 
-<AppBar shadow="shadow-xl">
+<AppBar shadow="shadow-2xl" slotTrail="!space-x-2">
 	<svelte:fragment slot="lead">
 		<div class="flex items-center space-x-4">
 			<!-- Hamburger Menu -->
@@ -151,7 +151,7 @@
 						</li>
 					</ul>
 				</nav>
-				<div class="arrow bg-surface-100-800-token" />
+				<!-- <div class="arrow bg-surface-100-800-token" /> -->
 			</div>
 		</div>
 
@@ -196,38 +196,16 @@
 						<a class="btn variant-filled w-full" href="/docs/generator">Create a Theme</a>
 					</div>
 				</div>
-				<div class="arrow bg-surface-100-800-token" />
+				<!-- <div class="arrow bg-surface-100-800-token" /> -->
 			</div>
-		</div>
-
-		<!-- Social -->
-		<!-- prettier-ignore -->
-		<section class="hidden sm:inline-flex space-x-4">
-			<a class="btn-icon btn-icon-sm hover:variant-soft-primary" href="https://discord.gg/EXqV7W8MtY" target="_blank" rel="noreferrer">
-				<i class="fa-brands fa-discord text-lg" />
-			</a>
-			<a class="btn-icon btn-icon-sm hover:variant-soft-primary" href="https://github.com/skeletonlabs/skeleton" target="_blank" rel="noreferrer">
-				<i class="fa-brands fa-github text-lg" />
-			</a>
-		</section>
-
-		<!-- Search -->
-		<div class="md:inline md:ml-4">
-			<button class="btn p-2 px-4 space-x-4 variant-soft hover:variant-soft-primary" on:click={triggerSearch}>
-				<i class="fa-solid fa-magnifying-glass" />
-				<span class="hidden md:inline-block badge variant-soft">{isOsMac ? '⌘' : 'Ctrl'}+K</span>
-			</button>
 		</div>
 
 		<!-- Sponsor -->
 		<div>
 			<!-- trigger -->
-			<button
-				class="btn py-1.5 variant-soft hover:variant-soft-primary hidden sm:inline-block"
-				use:popup={{ event: 'click', target: 'sponsor' }}
-			>
-				<i class="fa-solid fa-heart" />
-				<span class="hidden md:inline-block">Sponsor</span>
+			<button class="btn hover:variant-soft-primary" use:popup={{ event: 'click', target: 'sponsor' }}>
+				<span>Sponsor</span>
+				<i class="fa-solid fa-caret-down opacity-50" />
 			</button>
 			<!-- popup -->
 			<div class="card p-4 w-60 shadow-xl" data-popup="sponsor">
@@ -253,8 +231,49 @@
 						</li>
 					</ul>
 				</nav>
-				<div class="arrow bg-surface-100-800-token" />
+				<!-- <div class="arrow bg-surface-100-800-token" /> -->
 			</div>
 		</div>
+
+		<!-- Version -->
+		<div class="relative hidden lg:block">
+			<!-- trigger -->
+			<button class="btn hover:variant-soft-primary" use:popup={{ event: 'click', target: 'version' }}>
+				<span>Version</span>
+				<i class="fa-solid fa-caret-down opacity-50" />
+			</button>
+			<!-- popup -->
+			<div class="card p-4 w-60 shadow-xl" data-popup="version">
+				<nav class="list-nav">
+					<ul>
+						<li>
+							<a href="https://v1.skeleton.dev/" target="_blank">
+								<span>Skeleton v1 Docs</span>
+								<span class="w-6 text-center"><i class="fa-solid fa-arrow-up-right-from-square opacity-50" /></span>
+							</a>
+						</li>
+					</ul>
+				</nav>
+				<!-- <div class="arrow bg-surface-100-800-token" /> -->
+			</div>
+		</div>
+
+		<!-- Search -->
+		<div class="md:inline md:ml-4">
+			<button class="btn space-x-4 variant-soft hover:variant-soft-primary" on:click={triggerSearch}>
+				<i class="fa-solid fa-magnifying-glass text-sm" />
+				<small>{isOsMac ? '⌘' : 'Ctrl'}+K</small>
+			</button>
+		</div>
+
+		<!-- Social -->
+		<section class="hidden sm:inline-flex space-x-1">
+			<a class="btn-icon hover:variant-soft-primary" href="https://github.com/skeletonlabs/skeleton" target="_blank" rel="noreferrer">
+				<i class="fa-brands fa-github text-lg" />
+			</a>
+			<a class="btn-icon hover:variant-soft-primary" href="https://discord.gg/EXqV7W8MtY" target="_blank" rel="noreferrer">
+				<i class="fa-brands fa-discord text-lg" />
+			</a>
+		</section>
 	</svelte:fragment>
 </AppBar>


### PR DESCRIPTION
## Linked Issue

Closes #1895

## Description

Update the doc site app bar to include a Versions drop down. This includes links to prior version, which include only v1 at this point.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
