### PR TITLE
Bugfix: make scrollbar corner background transparent

### DIFF
--- a/.changeset/metal-dots-melt.md
+++ b/.changeset/metal-dots-melt.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/tw-plugin": patch
 ---
 
-bugfix:Scrollbar corners now have a transparent background.
+bugfix: Webkit scrollbars corners now match track background coloring

--- a/.changeset/metal-dots-melt.md
+++ b/.changeset/metal-dots-melt.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": patch
+---
+
+bugfix:Scrollbar corners now have a transparent background.

--- a/packages/plugin/src/styles/base/core.css
+++ b/packages/plugin/src/styles/base/core.css
@@ -37,6 +37,9 @@ html {
 ::-webkit-scrollbar-thumb {
 	@apply rounded-token bg-surface-400-500-token;
 }
+::-webkit-scrollbar-corner {
+	@apply bg-transparent;
+}
 
 /* Firefox */
 /* https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color#browser_compatibility */

--- a/packages/plugin/src/styles/base/core.css
+++ b/packages/plugin/src/styles/base/core.css
@@ -38,7 +38,7 @@ html {
 	@apply rounded-token bg-surface-400-500-token;
 }
 ::-webkit-scrollbar-corner {
-	@apply bg-transparent;
+	@apply !bg-surface-50-900-token;
 }
 
 /* Firefox */


### PR DESCRIPTION
## Linked Issue

Closes #1797

## Description

Makes scrollbar corner background transparent using the `::-webkit-scrollbar-corner` pseudo-element.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
