### PR TITLE
bugfix/tree-view-relational-updates

### DIFF
--- a/.changeset/cool-glasses-grow.md
+++ b/.changeset/cool-glasses-grow.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Tree-view relational updates are now working as expected.

--- a/packages/create-skeleton-app/CHANGELOG.md
+++ b/packages/create-skeleton-app/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Patch Changes
 
-- Fixed @rc pinning ([#1882](https://github.com/skeletonlabs/skeleton/pull/1882))
+-   Fixed @rc pinning ([#1882](https://github.com/skeletonlabs/skeleton/pull/1882))
 
 ## 0.0.46-rc.2
 
 ### Patch Changes
 
-- CSA updates for V2 ([#1859](https://github.com/skeletonlabs/skeleton/pull/1859))
-  - Install vite-plugin-tailwind-purgecss to enable purging of unused component CSS
-  - mdsvex is an optional install
-  - No longer installs packages by default
-  - Templates can now specify additional packages to be installed
-  - Bug fixes and improvements all over
+-   CSA updates for V2 ([#1859](https://github.com/skeletonlabs/skeleton/pull/1859))
+    -   Install vite-plugin-tailwind-purgecss to enable purging of unused component CSS
+    -   mdsvex is an optional install
+    -   No longer installs packages by default
+    -   Templates can now specify additional packages to be installed
+    -   Bug fixes and improvements all over

--- a/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeView.svelte
@@ -81,40 +81,6 @@
 			}
 		});
 	}
-	/**
-	 * select all tree view items. Only available in Multiple selection mode.
-	 * @type {() => void}
-	 */
-	export function selectAll(): void {
-		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach((details) => {
-			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
-			if (!input) return;
-			if (!input.checked) {
-				// needs delay
-				setTimeout(() => {
-					input.click();
-				}, 5);
-			}
-		});
-	}
-	/**
-	 * deselect all tree view items. Only available in Multiple selection mode.
-	 * @type {() => void}
-	 */
-	export function deselectAll(): void {
-		const detailsElements = [...tree.querySelectorAll('details.tree-item')] as HTMLDetailsElement[];
-		detailsElements.forEach((details) => {
-			const input: HTMLInputElement | null = details.querySelector('input[type="checkbox"].tree-item-checkbox');
-			if (!input) return;
-			if (input.checked) {
-				// needs delay
-				setTimeout(() => {
-					input.click();
-				}, 5);
-			}
-		});
-	}
 
 	// Context API
 	setContext('open', open);
@@ -149,7 +115,7 @@
 	aria-disabled={disabled}
 >
 	{#if nodes && nodes.length > 0}
-		<TreeViewDataDrivenItem bind:nodes />
+		<TreeViewDataDrivenItem bind:nodes on:change on:click on:toggle on:keydown on:keyup />
 	{:else}
 		<slot />
 	{/if}

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewDataDrivenItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewDataDrivenItem.svelte
@@ -2,13 +2,10 @@
 	/**
 	 * This component is only in Data-driven tree-view to add children recursively.
 	 */
-	import { createEventDispatcher, getContext, onMount } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 	import TreeViewDataDrivenItem from './TreeViewDataDrivenItem.svelte';
 	import TreeViewItem from './TreeViewItem.svelte';
 	import type { TreeViewNode } from './types.js';
-
-	// events
-	const dispatch = createEventDispatcher();
 
 	// this can't be passed using context, since we have to pass it to recursive children.
 	/** Provide data-driven nodes. */
@@ -32,42 +29,66 @@
 		if (selection) {
 			group = multiple ? [] : '';
 			// manage group (checking) on initialization.
-			nodes.forEach((node) => {
-				if (!node.checked) return;
-
-				if (multiple) {
+			if (multiple) {
+				nodes.forEach((node) => {
 					if (!Array.isArray(group)) return;
-					group.push(node.value);
-				} else {
+					// handle relations
+					if (node.children && node.children.length > 0) {
+						// at least one child is indeterminate => indeterminate item
+						if (node.children.some((c) => c.indeterminate)) {
+							node.indeterminate = true;
+						}
+						// all children are checked => check item
+						else if (node.children.every((c) => c.checked)) {
+							node.indeterminate = false;
+							node.checked = true;
+						}
+						// not all children are checked => indeterminate item
+						else if (node.children.some((c) => c.checked)) {
+							node.indeterminate = true;
+						}
+						// all children are unchecked => uncheck item
+						else {
+							node.indeterminate = false;
+							node.checked = false;
+						}
+					} else if (node.checked) {
+						group = [...group, node.value];
+					}
+				});
+				// single selection mode
+			} else {
+				nodes.forEach((node) => {
+					if (!node.checked) return;
 					group = node.value;
-				}
-			});
+				});
+			}
 		}
 	});
 
-	// Functionality
-	function onCheckChange() {
-		nodes.forEach((node) => {
-			if (multiple) {
+	// update nodes when the group change
+	$: if (group) {
+		if (multiple) {
+			nodes.forEach((node) => {
 				if (!Array.isArray(group)) return;
 				node.checked = group.includes(node.value);
-			} else {
-				node.checked = group === node.value;
-			}
-		});
-		nodes = nodes;
-		// notify parent to update values. Important to recursively update parents.
-		dispatch('change');
+			});
+		} else {
+			nodes.forEach((node) => {
+				node.checked = node.value === group;
+			});
+		}
 	}
 
-	export let parents: TreeViewItem[] = [];
+	// important to pass children up to items (recursively)
+	export let treeItems: TreeViewItem[] = [];
 	let children: TreeViewItem[][] = [];
 </script>
 
 {#if nodes && nodes.length > 0}
 	{#each nodes as node, i}
 		<TreeViewItem
-			bind:this={parents[i]}
+			bind:this={treeItems[i]}
 			bind:open={node.open}
 			hideLead={!node.lead}
 			hideChildren={!node.children || node.children.length === 0}
@@ -77,16 +98,18 @@
 			bind:indeterminate={node.indeterminate}
 			bind:value={node.value}
 			bind:children={children[i]}
-			on:change={onCheckChange}
+			on:change
 			on:click
 			on:toggle
+			on:keydown
+			on:keyup
 		>
 			{@html node.content}
 			<svelte:fragment slot="lead">
 				{@html node.lead}
 			</svelte:fragment>
 			<svelte:fragment slot="children">
-				<TreeViewDataDrivenItem nodes={node.children} on:change={onCheckChange} bind:parents={children[i]} />
+				<TreeViewDataDrivenItem bind:nodes={node.children} bind:treeItems={children[i]} />
 			</svelte:fragment>
 		</TreeViewItem>
 	{/each}

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -98,7 +98,6 @@
 	}
 	function updateGroup(checked: boolean) {
 		if (!Array.isArray(group)) return;
-
 		const index = group.indexOf(value);
 		if (checked) {
 			if (index < 0) {
@@ -113,78 +112,92 @@
 	}
 
 	// called when a child's value is changed
-	function onChildValueChange(event: SvelteEvent<Event, HTMLInputElement>, child: TreeViewItem) {
+	function onChildValueChange() {
 		if (multiple) {
 			// all groups must be arrays in multiple mode
 			if (!Array.isArray(group)) return;
 			const childrenValues = children.map((c) => c.value);
+			const childrenGroup = children[0].group;
 			const index = group.indexOf(value);
-
-			// all children are checked => check parent
-			if (childrenValues.every((c) => Array.isArray(child.group) && child.group.includes(c))) {
+			// at least one child is indeterminate => indeterminate item
+			if (children.some((c) => c.indeterminate)) {
+				indeterminate = true;
+			}
+			// all children are checked => check item
+			else if (childrenValues.every((c) => Array.isArray(childrenGroup) && childrenGroup.includes(c))) {
+				indeterminate = false;
 				if (index < 0) {
-					indeterminate = false;
 					group = [...group, value];
 				}
-				// not all children are checked => uncheck parent
-			} else {
+			}
+			// not all children are checked => indeterminate item
+			else if (childrenValues.some((c) => Array.isArray(childrenGroup) && childrenGroup.includes(c))) {
+				indeterminate = true;
+			}
+			// all children are unchecked => uncheck item
+			else {
+				indeterminate = false;
 				if (index >= 0) {
 					group.splice(index, 1);
 					group = group;
 				}
-				// set parent to indeterminate if some of the children are checked
-				indeterminate = childrenValues.some((c) => Array.isArray(child.group) && child.group.includes(c));
 			}
-			// single selection mode
-		} else {
-			// child is checked, but parent isn't checked
-			if (event.currentTarget.checked && group !== value) {
-				// check parent
+		}
+		// single selection mode
+		else {
+			if (group !== value) {
+				// check item
 				group = value;
 			}
 		}
+		// important to notify parent of item
+		dispatch('change');
 	}
 
-	// called every time the group's value changes
-	function onGroupValueChange(_group: unknown) {
-		// don't override children groups when parent is set to indeterminate
-		if (!children || children.length === 0 || indeterminate) return;
-		if (multiple) {
-			// group must by array in multiple mode
-			if (!Array.isArray(_group)) return;
-			const index = _group.indexOf(value);
+	// used to update children of item when checked / unchecked in multiple mode
+	export function onParentChange() {
+		if (!multiple || !children || children.length === 0) return;
 
-			const checkChild = (child: TreeViewItem) => {
-				if (!child || !Array.isArray(child.group)) return;
-				if (child.group.indexOf(child.value) < 0) {
-					// child.group = [...child.group, child.value] won't work here.
-					child.group.push(child.value);
-					child.group = child.group;
-				}
-			};
-			const uncheckChild = (child: TreeViewItem) => {
-				if (!child || !Array.isArray(child.group)) return;
-				const childIndex = child.group.indexOf(child.value);
-				if (childIndex >= 0) {
-					child.group.splice(childIndex, 1);
-					child.group = child.group;
-				}
-			};
+		// group must by array in multiple mode
+		if (!Array.isArray(group)) return;
+		const index = group.indexOf(value);
 
-			// if parent is checked, check all children, else uncheck all children
-			children.forEach(index >= 0 ? checkChild : uncheckChild);
-			// single selection mode
-		} else {
-			// parent is not checked
-			if (_group !== value) {
-				// uncheck all children
-				children.forEach((child) => {
-					child.group = [];
-				});
+		const checkChild = (child: TreeViewItem) => {
+			if (!child || !Array.isArray(child.group)) return;
+			child.indeterminate = false;
+			if (child.group.indexOf(child.value) < 0) {
+				// child.group = [...child.group, child.value] won't work here.
+				child.group.push(child.value);
+				child.group = child.group;
 			}
+		};
+		const uncheckChild = (child: TreeViewItem) => {
+			if (!child || !Array.isArray(child.group)) return;
+			child.indeterminate = false;
+			const childIndex = child.group.indexOf(child.value);
+			if (childIndex >= 0) {
+				child.group.splice(childIndex, 1);
+				child.group = child.group;
+			}
+		};
+
+		children.forEach((child) => {
+			// if parent is checked, check all children, else uncheck all children
+			index >= 0 ? checkChild(child) : uncheckChild(child);
+			// notify children to update values
+			child.onParentChange();
+		});
+	}
+
+	// used to update children of item when checked / unchecked in single mode
+	$: if (!multiple && group) {
+		if (group !== value) {
+			// uncheck all children
+			children.forEach((child) => {
+				if (child) child.group = [];
+			});
 		}
 	}
-	$: onGroupValueChange(group);
 
 	// events
 	const dispatch = createEventDispatcher();
@@ -193,7 +206,7 @@
 
 	// whenever children are changed, reassign on:change events.
 	$: children.forEach((child) => {
-		if (child) child.$on('change', (event) => onChildValueChange(event as SvelteEvent<Event, HTMLInputElement>, child));
+		if (child) child.$on('change', () => onChildValueChange());
 	});
 
 	// A11y Key Down Handler
@@ -315,7 +328,17 @@
 		<!-- Selection -->
 		{#if selection && name && group !== undefined}
 			{#if multiple}
-				<input class="checkbox tree-item-checkbox" type="checkbox" {name} {value} bind:checked bind:indeterminate on:click on:change />
+				<input
+					class="checkbox tree-item-checkbox"
+					type="checkbox"
+					{name}
+					{value}
+					bind:checked
+					bind:indeterminate
+					on:click
+					on:change
+					on:change={onParentChange}
+				/>
 			{:else}
 				<input class="radio tree-item-radio" type="radio" bind:group {name} {value} on:click on:change />
 			{/if}

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -730,56 +730,6 @@ let booksChildren: TreeViewItem[] = [];
 					/>
 				</svelte:fragment>
 			</DocsPreview>
-			<!-- Toggle All -->
-			<h3 class="h3">Toggle All</h3>
-			<p>By binding to the tree view component we can then toggle selection for all items.</p>
-			<blockquote class="blockquote">
-				Note: Available only when using <code class="code">multiple</code> selection mode.
-			</blockquote>
-			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
-				<svelte:fragment slot="preview">
-					<TreeView selection multiple bind:this={selectTree}>
-						<TreeViewItem bind:group={selectMultiple} name="s_medium" value="books">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-book-skull" />
-							</svelte:fragment>
-							<p>Books</p>
-						</TreeViewItem>
-						<TreeViewItem bind:group={selectMultiple} name="s_medium" value="movies">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-film" />
-							</svelte:fragment>
-							<p>Movies</p>
-						</TreeViewItem>
-						<TreeViewItem bind:group={selectMultiple} name="s_medium" value="tv">
-							<svelte:fragment slot="lead">
-								<i class="fa-solid fa-tv" />
-							</svelte:fragment>
-							<p>TV</p>
-						</TreeViewItem>
-					</TreeView>
-				</svelte:fragment>
-				<svelte:fragment slot="footer">
-					<button class="btn variant-filled" on:click={selectTree.selectAll}> Select </button>
-					<button class="btn variant-filled" on:click={selectTree.deselectAll}> Deselect </button>
-				</svelte:fragment>
-				<svelte:fragment slot="source">
-					<CodeBlock
-						language="ts"
-						code={`
-let tree: TreeView;\n
-tree.selectAll();
-tree.deselectAll();
-					`}
-					/>
-					<CodeBlock
-						language="html"
-						code={`
-<TreeView bind:this={tree} selection multiple></TreeView>
-			`}
-					/>
-				</svelte:fragment>
-			</DocsPreview>
 		</section>
 
 		<hr />


### PR DESCRIPTION
## Linked Issue

Closes #1885

## Needs to be done
we are now using export functions to handle part of the relations, but it is displayed in the props table. we need a way to hide it.
![image](https://github.com/skeletonlabs/skeleton/assets/74062808/afd7534a-d805-41c8-af3e-2a22024b8e96)

## Description

fixed relational updates for both recursive and non-recursive modes.

This is a basic diagram of how the tree-view relations behave:
![Untitled Diagram drawio](https://github.com/skeletonlabs/skeleton/assets/74062808/cd28a447-4977-4094-8f56-ef875a742220)

### Extra changes
1. Forward all events triggered in recursive mode to tree-view.
2. deleted the toggleAll functions (to handle all possible setups `selectAll`, `deselectAll` will need extreme effort for such a tiny feature -_-)


## Changsets

bugfix: Tree-view relational updates are now working as expected.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
