### PR TITLE
fix: `CustomThemeConfig` shouldn't require `properties_dark` to be defined

### DIFF
--- a/.changeset/fluffy-garlics-carry.md
+++ b/.changeset/fluffy-garlics-carry.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": patch
+---
+
+fix: `properties_dark` for `CustomThemeConfig` is now optional

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -74,7 +74,7 @@ export type ThemeConfig = {
 	preset?: Array<PresetThemeConfig | PresetThemeName>;
 };
 
-export type CustomThemeConfig = BaseTheme & {
+export type CustomThemeConfig = {
 	/**
 	 * The name of your custom theme.
 	 *


### PR DESCRIPTION
Fixed the type for `CustomThemeConfig`. The intersection for `BaseTheme` was causing the custom config to require `properties_dark` to be defined.
