### PR TITLE
bugfix: ignore pointer events for closed `Popup`s

### DIFF
--- a/.changeset/pink-cows-greet.md
+++ b/.changeset/pink-cows-greet.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: ignore pointer events for closed `Popup`s

--- a/packages/skeleton/src/lib/utilities/Popup/popup.ts
+++ b/packages/skeleton/src/lib/utilities/Popup/popup.ts
@@ -123,6 +123,7 @@ export function popup(triggerNode: HTMLElement, args: PopupSettings) {
 			if (args.state) args.state({ state: popupState.open });
 			// Update the DOM
 			elemPopup.style.opacity = '0';
+			elemPopup.style.pointerEvents = 'none';
 			// disable popup interactions
 			elemPopup.setAttribute('inert', '');
 			// Cleanup Floating UI autoUpdate (close only)


### PR DESCRIPTION
## Linked Issue

Closes #1913 

## Description

Set the popup's `pointerEvents` style attribute to `'none'` when closing it to prevent it from being clickable.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
