### PR TITLE
Prepend ToC ids with toc prefix to ensure unique

### DIFF
--- a/packages/skeleton/src/lib/utilities/TableOfContents/crawler.ts
+++ b/packages/skeleton/src/lib/utilities/TableOfContents/crawler.ts
@@ -44,7 +44,7 @@ export function tocCrawler(node: HTMLElement, args?: TOCCrawlerArgs) {
 					.replaceAll(/[^a-zA-Z0-9 ]/g, '')
 					.replaceAll(' ', '-')
 					.toLowerCase();
-				elemHeading.id = newHeadingId || '';
+				elemHeading.id = `toc-${newHeadingId}`;
 			}
 			// Push heading data to the permalink array
 			permalinks.push({

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/table-of-contents/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/table-of-contents/+page.svelte
@@ -79,7 +79,7 @@
 				code={`
 <!-- Before: -->
 <h2 class="h2">Title One</h2>
-<h2 class="h2" id="my-custom-id">Title Two</h2>\n
+<h2 class="h2" id="toc-my-custom-id">Title Two</h2>\n
 <!-- After: -->
 <h2 class="h2" id="title-one">Title One</h2>
 <h2 class="h2" id="my-custom-id">Title Two</h2>


### PR DESCRIPTION
## Linked Issue

Closes #1909

## Description

We now append generated ids to use the `toc-` prefix to ensure they are unique and do no clash with existing IDs on the page.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
