### PR TITLE
bugfix: fix background color of checkbox in indeterminate state

### DIFF
--- a/packages/plugin/src/styles/components/forms.css
+++ b/packages/plugin/src/styles/components/forms.css
@@ -76,6 +76,7 @@
 		@apply border-token border-surface-400-500-token focus:border-primary-500;
 	}
 	.checkbox:checked,
+	.checkbox:indeterminate,
 	.radio:checked {
 		@apply bg-primary-500 hover:bg-primary-500 focus:bg-primary-500 focus:ring-0;
 	}


### PR DESCRIPTION
## Description
Resolved an issue where the background color of the checkbox was not displaying correctly when in the indeterminate state. Adjusted the styling to ensure consistent and accurate rendering of the checkbox background color, providing a polished user interface.

Before this change:
<img width="431" alt="Screenshot 2023-08-22 at 1 51 23 AM" src="https://github.com/skeletonlabs/skeleton/assets/26350053/fb5f47de-3e85-4894-9a09-c7f8af2dfb82">

After this change:
<img width="407" alt="Screenshot 2023-08-22 at 1 50 56 AM" src="https://github.com/skeletonlabs/skeleton/assets/26350053/4427680a-7e23-4003-bab1-9880bb428d2b">


## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
