### PR TITLE
bugfix: allow unstyled file buttons

### DIFF
--- a/.changeset/soft-tables-wave.md
+++ b/.changeset/soft-tables-wave.md
@@ -1,6 +1,5 @@
 ---
-"skeleton.dev": patch
 "@skeletonlabs/skeleton": patch
 ---
 
-Allow unstyled File Buttons
+Chore: Update file button `button` prop to allow for unstyled buttons

--- a/.changeset/soft-tables-wave.md
+++ b/.changeset/soft-tables-wave.md
@@ -1,0 +1,6 @@
+---
+"skeleton.dev": patch
+"@skeletonlabs/skeleton": patch
+---
+
+Allow unstyled File Buttons

--- a/packages/skeleton/src/lib/components/FileButton/FileButton.svelte
+++ b/packages/skeleton/src/lib/components/FileButton/FileButton.svelte
@@ -14,7 +14,7 @@
 	 */
 	export let name: string;
 	/** Provide classes to set the width. */
-	export let width: CssClasses = 'w-full';
+	export let width: CssClasses = '';
 	/** Provide a button variant or other class styles. */
 	export let button: CssClasses = 'btn variant-filled';
 

--- a/packages/skeleton/src/lib/components/FileButton/FileButton.svelte
+++ b/packages/skeleton/src/lib/components/FileButton/FileButton.svelte
@@ -14,12 +14,9 @@
 	 */
 	export let name: string;
 	/** Provide classes to set the width. */
-	export let width: CssClasses = '';
+	export let width: CssClasses = 'w-full';
 	/** Provide a button variant or other class styles. */
-	export let button: CssClasses = 'variant-filled';
-
-	// Classes
-	const cButton = 'btn';
+	export let button: CssClasses = 'btn variant-filled';
 
 	// Local
 	let elemFileInput: HTMLElement;
@@ -35,7 +32,7 @@
 
 	// Reactive
 	$: classesBase = `${$$props.class ?? ''}`;
-	$: classesButton = `${cButton} ${button} ${width}`;
+	$: classesButton = `${button} ${width}`;
 </script>
 
 <div class="file-button {classesBase}" data-testid="file-button">

--- a/sites/skeleton.dev/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -60,7 +60,7 @@
 					<FileButton name="files" button="btn variant-soft-primary">Upload</FileButton>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<FileButton name="files" button="variant-soft-primary">Upload</FileButton>`} />
+					<CodeBlock language="html" code={`<FileButton name="files" button="btn variant-soft-primary">Upload</FileButton>`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -57,10 +57,27 @@
 			<p>Use the <code class="code">button</code> property to provide classes for the button, such as variant styles.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<FileButton name="files" button="variant-soft-primary">Upload</FileButton>
+					<FileButton name="files" button="btn variant-soft-primary">Upload</FileButton>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock language="html" code={`<FileButton name="files" button="variant-soft-primary">Upload</FileButton>`} />
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
+		<section class="space-y-4">
+			<h2 class="h2">Usage with Button Groups</h2>
+			<p>Button Groups expect the child button elements to be native <code class="code">button</code> elements without styles.</p>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<div class="btn-group-vertical variant-filled">
+						<button>Update</button>
+						<button>Delete</button>
+						<FileButton name="files" button="">Upload</FileButton>
+						<button>Download</button>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock language="html" code={`<FileButton name="files" button="">Upload</FileButton>`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/components/file-buttons/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/file-buttons/+page.svelte
@@ -72,12 +72,22 @@
 					<div class="btn-group-vertical variant-filled">
 						<button>Update</button>
 						<button>Delete</button>
-						<FileButton name="files" button="">Upload</FileButton>
+						<FileButton name="files" button="" width="w-full">Upload</FileButton>
 						<button>Download</button>
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="html" code={`<FileButton name="files" button="">Upload</FileButton>`} />
+					<CodeBlock
+						language="html"
+						code={`
+<div class="btn-group-vertical variant-filled">
+	<button>Update</button>
+	<button>Delete</button>
+	<FileButton name="files" button="" width="w-full">Upload</FileButton>
+	<button>Download</button>
+</div>
+					`}
+					/>
 				</svelte:fragment>
 			</DocsPreview>
 		</section>


### PR DESCRIPTION
## Linked Issue

Closes #1876 

## Description
 
- Moved `.btn` class to `button` prop so it can be customised to render a buton without hardcoded styles.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
