### PR TITLE
bugfix: allow different styles in button groups

### DIFF
--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -95,7 +95,7 @@
 	.btn-group a,
 	.btn-group-vertical button,
 	.btn-group-vertical a {
-		@apply  button-base-styles hover:bg-blend-lighten active:bg-blend-darken !border-0;
+		@apply button-base-styles hover:bg-blend-lighten active:bg-blend-darken !border-0;
 		/* Reset Anchor Styles */
 		@apply !no-underline;
 	}
@@ -104,14 +104,14 @@
 	.btn-group button,
 	.btn-group a {
 		/* Handle rounding of first and last button */
-		@apply first:rounded-tl-token first:rounded-bl-token last:rounded-tr-token last:rounded-br-token
+		@apply first:rounded-tl-token first:rounded-bl-token last:rounded-tr-token last:rounded-br-token;
 	}
 
 	/* Vertical Button / Anchors */
 	.btn-group-vertical button,
 	.btn-group-vertical a {
 		/* Handle rounding of first and last button */
-		@apply first:rounded-tl-container-token first:rounded-tr-container-token last:rounded-bl-container-token last:rounded-br-container-token
+		@apply first:rounded-tl-container-token first:rounded-tr-container-token last:rounded-bl-container-token last:rounded-br-container-token;
 	}
 
 	/* Set Neutral Divider */

--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -80,9 +80,9 @@
 	/* === Button Groups === */
 
 	.btn-group {
-		@apply inline-flex overflow-hidden !space-x-0 rounded-token;
+		@apply inline-flex overflow-hidden space-x-0 rounded-token;
 		/* Safari: hover overflow fix for border radius */
-		isolation: isolate;
+		/* isolation: isolate; */
 	}
 	.btn-group-vertical {
 		@apply btn-group flex-col space-y-0 rounded-container-token;
@@ -95,9 +95,23 @@
 	.btn-group a,
 	.btn-group-vertical button,
 	.btn-group-vertical a {
-		@apply button-base-styles hover:bg-blend-lighten active:bg-blend-darken !border-0;
+		@apply  button-base-styles hover:bg-blend-lighten active:bg-blend-darken !border-0;
 		/* Reset Anchor Styles */
 		@apply !no-underline;
+	}
+
+	/* Horizontal Button / Anchors */
+	.btn-group button,
+	.btn-group a {
+		/* Handle rounding of first and last button */
+		@apply first:rounded-tl-token first:rounded-bl-token last:rounded-tr-token last:rounded-br-token
+	}
+	
+	/* Horizontal Button / Anchors */
+	.btn-group-vertical button,
+	.btn-group-vertical a {
+		/* Handle rounding of first and last button */
+		@apply first:rounded-tl-token first:rounded-tr-token last:rounded-bl-token last:rounded-br-token
 	}
 
 	/* Set Neutral Divider */

--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -85,7 +85,7 @@
 		/* isolation: isolate; */
 	}
 	.btn-group-vertical {
-		@apply btn-group flex-col space-y-0 rounded-container-token;
+		@apply inline-flex flex-col overflow-hidden space-0 rounded-container-token;
 		/* Safari: hover overflow fix for border radius */
 		isolation: isolate;
 	}
@@ -106,12 +106,12 @@
 		/* Handle rounding of first and last button */
 		@apply first:rounded-tl-token first:rounded-bl-token last:rounded-tr-token last:rounded-br-token
 	}
-	
-	/* Horizontal Button / Anchors */
+
+	/* Vertical Button / Anchors */
 	.btn-group-vertical button,
 	.btn-group-vertical a {
 		/* Handle rounding of first and last button */
-		@apply first:rounded-tl-token first:rounded-tr-token last:rounded-bl-token last:rounded-br-token
+		@apply first:rounded-tl-container-token first:rounded-tr-container-token last:rounded-bl-container-token last:rounded-br-container-token
 	}
 
 	/* Set Neutral Divider */

--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -80,7 +80,7 @@
 	/* === Button Groups === */
 
 	.btn-group {
-		@apply inline-flex flex-row space-x-0 overflow-hidden rounded-token;
+		@apply inline-flex overflow-hidden !space-x-0 rounded-token;
 		/* Safari: hover overflow fix for border radius */
 		isolation: isolate;
 	}
@@ -95,9 +95,9 @@
 	.btn-group a,
 	.btn-group-vertical button,
 	.btn-group-vertical a {
-		@apply button-base-styles hover:bg-surface-50/[3%] active:bg-surface-900/[3%];
+		@apply button-base-styles hover:bg-blend-lighten active:bg-blend-darken !border-0;
 		/* Reset Anchor Styles */
-		@apply !no-underline !text-inherit;
+		@apply !no-underline;
 	}
 
 	/* Set Neutral Divider */

--- a/sites/skeleton.dev/src/routes/(inner)/elements/buttons/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/buttons/+page.svelte
@@ -193,6 +193,44 @@
 					/>
 				</svelte:fragment>
 			</DocsPreview>
+			<p>Button groups with different styles</p>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<div class="flex flex-col gap-8">
+						<div class="btn-group">
+							<button class="variant-filled-primary">Create</button>
+							<button class="variant-filled-success">Read</button>
+							<button class="variant-filled-warning">Update</button>
+							<button class="variant-filled-error">Delete</button>
+						</div>
+						<div class="btn-group">
+							<button class="variant-ghost-primary">Create</button>
+							<button class="variant-ghost-success">Read</button>
+							<button class="variant-ghost-warning">Update</button>
+							<button class="variant-ghost-error">Delete</button>
+						</div>
+						<div class="btn-group">
+							<button class="variant-soft-primary">Create</button>
+							<button class="variant-soft-success">Read</button>
+							<button class="variant-soft-warning">Update</button>
+							<button class="variant-soft-error">Delete</button>
+						</div>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="html"
+						code={`
+<div class="btn-group">
+	<button class="variant-filled-primary">Create</button>
+	<button class="variant-filled-success">Read</button>
+	<button class="variant-filled-warning">Update</button>
+	<button class="variant-filled-error">Delete</button>
+</div>
+`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">SvelteKit Link Options</h2>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/buttons/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/buttons/+page.svelte
@@ -231,6 +231,43 @@
 					/>
 				</svelte:fragment>
 			</DocsPreview>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<div class="flex gap-8">
+						<div class="btn-group-vertical">
+							<button class="variant-filled-primary">Create</button>
+							<button class="variant-filled-success">Read</button>
+							<button class="variant-filled-warning">Update</button>
+							<button class="variant-filled-error">Delete</button>
+						</div>
+						<div class="btn-group-vertical">
+							<button class="variant-ghost-primary">Create</button>
+							<button class="variant-ghost-success">Read</button>
+							<button class="variant-ghost-warning">Update</button>
+							<button class="variant-ghost-error">Delete</button>
+						</div>
+						<div class="btn-group-vertical">
+							<button class="variant-soft-primary">Create</button>
+							<button class="variant-soft-success">Read</button>
+							<button class="variant-soft-warning">Update</button>
+							<button class="variant-soft-error">Delete</button>
+						</div>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="html"
+						code={`
+<div class="btn-group-vertical">
+	<button class="variant-filled-primary">Create</button>
+	<button class="variant-filled-success">Read</button>
+	<button class="variant-filled-warning">Update</button>
+	<button class="variant-filled-error">Delete</button>
+</div>
+`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">SvelteKit Link Options</h2>


### PR DESCRIPTION
## Linked Issue

Closes #1725 

## Description

Allow different styles /. variants of buttons inside button groups.
Needs some more improvements, the first and last elements gets cut-off, I am playing with tailwindcss `first:` and `last:` child directive to try to get it working.

Here's how it looks currently:
<img width="751" alt="Screenshot 2023-08-22 at 11 36 56 AM" src="https://github.com/skeletonlabs/skeleton/assets/26350053/a5b26680-9187-47d6-b1b9-95267a1f4ccd">

https://github.com/skeletonlabs/skeleton/assets/26350053/03d6d3e7-7659-45a6-9556-830f28bc242b

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
