### PR TITLE
feat: ability to lock colors in theme generator

### DIFF
--- a/.changeset/large-donuts-brake.md
+++ b/.changeset/large-donuts-brake.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+feat: ability to lock colors in theme generator

--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
@@ -223,7 +223,7 @@ export const myCustomTheme: CustomThemeConfig = {
 			<hr />
 			<div class="p-4 grid grid-cols-1 gap-4">
 				{#each $storeThemGenForm.colors as colorRow, i}
-					<div class="grid grid-cols-1 lg:grid-cols-[170px_1fr_200px] gap-2 lg:gap-4">
+					<div class="grid grid-cols-1 lg:grid-cols-[185px_1fr_200px] gap-2 lg:gap-4">
 						<label class="label">
 							<span>{colorRow.label}</span>
 							<div class="grid grid-cols-[auto_1fr] gap-4 place-items-end">

--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
@@ -21,13 +21,13 @@
 	// Stores
 	const storeThemGenForm: Writable<FormTheme> = localStorageStore('storeThemGenForm', {
 		colors: [
-			{ key: 'primary', label: 'Primary', hex: '#0FBA81', rgb: '0 0 0', on: '0 0 0' },
-			{ key: 'secondary', label: 'Secondary', hex: '#4F46E5', rgb: '0 0 0', on: '255 255 255' },
-			{ key: 'tertiary', label: 'Tertiary', hex: '#0EA5E9', rgb: '0 0 0', on: '0 0 0' },
-			{ key: 'success', label: 'Success', hex: '#84cc16', rgb: '0 0 0', on: '0 0 0' },
-			{ key: 'warning', label: 'Warning', hex: '#EAB308', rgb: '0 0 0', on: '0 0 0' },
-			{ key: 'error', label: 'Error', hex: '#D41976', rgb: '0 0 0', on: '255 255 255' },
-			{ key: 'surface', label: 'Surface', hex: '#495a8f', rgb: '0 0 0', on: '255 255 255' }
+			{ key: 'primary', label: 'Primary', hex: '#0FBA81', rgb: '0 0 0', on: '0 0 0', locked: false },
+			{ key: 'secondary', label: 'Secondary', hex: '#4F46E5', rgb: '0 0 0', on: '255 255 255', locked: false },
+			{ key: 'tertiary', label: 'Tertiary', hex: '#0EA5E9', rgb: '0 0 0', on: '0 0 0', locked: false },
+			{ key: 'success', label: 'Success', hex: '#84cc16', rgb: '0 0 0', on: '0 0 0', locked: false },
+			{ key: 'warning', label: 'Warning', hex: '#EAB308', rgb: '0 0 0', on: '0 0 0', locked: false },
+			{ key: 'error', label: 'Error', hex: '#D41976', rgb: '0 0 0', on: '255 255 255', locked: false },
+			{ key: 'surface', label: 'Surface', hex: '#495a8f', rgb: '0 0 0', on: '255 255 255', locked: false }
 		],
 		fontBase: 'system',
 		fontHeadings: 'system',
@@ -69,6 +69,7 @@
 
 	function randomize(): void {
 		$storeThemGenForm.colors.forEach((_, i: number) => {
+			if ($storeThemGenForm.colors[i].locked) return;
 			const randomHexCode = '#' + ((Math.random() * 0xffffff) << 0).toString(16).padStart(6, '0');
 			$storeThemGenForm.colors[i].hex = randomHexCode;
 			$storeThemGenForm.colors[i].on = generateA11yOnColor(randomHexCode);
@@ -227,7 +228,22 @@ export const myCustomTheme: CustomThemeConfig = {
 							<span>{colorRow.label}</span>
 							<div class="grid grid-cols-[auto_1fr] gap-4 place-items-end">
 								<input class="input" type="color" bind:value={colorRow.hex} disabled={!$storePreview} />
-								<input class="input" type="text" bind:value={colorRow.hex} placeholder="#BADA55" disabled={!$storePreview} />
+								<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+									<input class="input" type="text" bind:value={colorRow.hex} placeholder="#BADA55" disabled={!$storePreview} />
+									<button
+										class="input-group-shim !p-2"
+										on:click|preventDefault={() => ($storeThemGenForm.colors[i].locked = !$storeThemGenForm.colors[i].locked)}
+										disabled={!$storePreview}
+									>
+										<span>
+											{#if $storeThemGenForm.colors[i].locked}
+												<i class="fa-solid fa-lock" />
+											{:else}
+												<i class="fa-solid fa-lock-open" />
+											{/if}
+										</span>
+									</button>
+								</div>
 							</div>
 						</label>
 						<Swatch color={colorRow.key} />

--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/types.ts
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/types.ts
@@ -6,6 +6,7 @@ export interface ColorSettings {
 	hex: string;
 	rgb: string;
 	on: string;
+	locked: boolean;
 }
 
 export interface FormTheme {


### PR DESCRIPTION
## Linked Issue

Closes #1888 (issue was already closed but not implemented)

## Description

This pull request introduces a new feature that allows users to lock colors from randomization in the theme generator. The purpose of this pull request is to enhance the theme generation process by giving users more control over specific colors.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
