### PR TITLE
bugfix: fix theme color lock button css

### DIFF
--- a/.changeset/fair-pigs-lick.md
+++ b/.changeset/fair-pigs-lick.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+bugfix: theme color lock button was not visible on firefox

--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
@@ -228,7 +228,7 @@ export const myCustomTheme: CustomThemeConfig = {
 							<span>{colorRow.label}</span>
 							<div class="grid grid-cols-[auto_1fr] gap-4 place-items-end">
 								<input class="input" type="color" bind:value={colorRow.hex} disabled={!$storePreview} />
-								<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+								<div class="input-group grid-cols-[auto_1fr]">
 									<input class="input" type="text" bind:value={colorRow.hex} placeholder="#BADA55" disabled={!$storePreview} />
 									<button
 										class="input-group-shim !p-2"
@@ -259,7 +259,7 @@ export const myCustomTheme: CustomThemeConfig = {
 									<!-- Badge -->
 									{#if $storePreview}
 										<div
-											class="input-group-shim !px-3"
+											class="input-group-shim !px-2"
 											use:popup={{ ...tooltipSettings, ...{ target: 'popup-' + i } }}
 											class:!text-stone-900={conReports[i].contrastReport.fails}
 											class:!bg-red-500={conReports[i].contrastReport.fails}


### PR DESCRIPTION
## Linked Issue

Issue reported [here](https://github.com/skeletonlabs/skeleton/pull/1927#issuecomment-1689731301) https://github.com/skeletonlabs/skeleton/pull/1927#issuecomment-1689731301

## Description

Theme color lock icon was not visible on firefox prior to this pul request.

Firefox
<img width="197" alt="Screenshot 2023-08-23 at 6 08 04 PM" src="https://github.com/skeletonlabs/skeleton/assets/26350053/33759961-49d1-4e64-8e0b-c5e69809bf93">

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
