### PR TITLE
bugfix: theme generator use selected theme colors

### DIFF
--- a/.changeset/spotty-kings-tease.md
+++ b/.changeset/spotty-kings-tease.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+Use current theme colors for Theme generator

--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
@@ -17,6 +17,7 @@
 	import { inputSettings, fontSettings } from './settings';
 	import { type Palette, generatePalette, generateA11yOnColor, hexValueIsValid, getPassReport } from './colors';
 	import type { PopupSettings } from '@skeletonlabs/skeleton';
+	import { themes } from '$lib/themes';
 
 	// Stores
 	const storeThemGenForm: Writable<FormTheme> = localStorageStore('storeThemGenForm', {
@@ -38,6 +39,19 @@
 		borderBase: '1px'
 	});
 	resetColorOnInvalidHex();
+
+	function setCurrentThemeColors(currentTheme: string) {
+		const currentThemeConfig = themes.find((t) => t.file === currentTheme);
+		if (!currentThemeConfig) return;
+		currentThemeConfig.colors.forEach((hex: string, i: number) => {
+			$storeThemGenForm.colors[i].hex = hex;
+			$storeThemGenForm.colors[i].on = generateA11yOnColor(hex);
+		});
+		$storeThemGenForm.colors[$storeThemGenForm.colors.length - 1].hex = currentThemeConfig.surface;
+		$storeThemGenForm.colors[$storeThemGenForm.colors.length - 1].hex = generateA11yOnColor(currentThemeConfig.surface);
+	}
+
+	$: setCurrentThemeColors($storeTheme);
 
 	// Local
 	let cssOutput = '';


### PR DESCRIPTION
## Linked Issue

Closes #1179 
Issue was closed but not implemented as it was moved to #1142 

## Description

Theme generator will use the current selected theme colors as well as `text-on` color.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
