### PR TITLE
docs: Adds a note for each store that uses context

### DIFF
--- a/packages/skeleton/src/lib/index.ts
+++ b/packages/skeleton/src/lib/index.ts
@@ -4,9 +4,9 @@
 
 export type { AutocompleteOption } from './components/Autocomplete/types.js';
 export type { ConicStop } from './components/ConicGradient/types.js';
-export type { DrawerSettings } from './utilities/Drawer/types.js';
-export type { ModalSettings, ModalComponent } from './utilities/Modal/types.js';
-export type { ToastSettings } from './utilities/Toast/types.js';
+export type { DrawerSettings, DrawerStore } from './utilities/Drawer/types.js';
+export type { ModalSettings, ModalComponent, ModalStore } from './utilities/Modal/types.js';
+export type { ToastSettings, ToastStore } from './utilities/Toast/types.js';
 export type { TableSource } from './components/Table/types.js';
 export type { PaginationSettings } from './components/Paginator/types.js';
 export type { PopupSettings } from './utilities/Popup/types.js';

--- a/packages/skeleton/src/lib/utilities/Drawer/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Drawer/stores.ts
@@ -9,13 +9,17 @@ const DRAWER_STORE_KEY = 'drawerStore';
 /**
  * Retrieves the `drawerStore`.
  *
+ * This can *ONLY* be called from the **top level** of components!
+ *
  * @example
- * ```ts
- * import { getDrawerStore } from "@skeletonlabs/skeleton";
+ * ```svelte
+ * <script>
+ * 	import { getDrawerStore } from "@skeletonlabs/skeleton";
  *
- * const drawerStore = getDrawerStore();
+ * 	const drawerStore = getDrawerStore();
  *
- * drawerStore.open();
+ * 	drawerStore.open();
+ * </script>
  * ```
  */
 export function getDrawerStore(): DrawerStore {

--- a/packages/skeleton/src/lib/utilities/Drawer/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Drawer/stores.ts
@@ -38,7 +38,7 @@ export function initializeDrawerStore(): DrawerStore {
 	return setContext(DRAWER_STORE_KEY, drawerStore);
 }
 
-type DrawerStore = ReturnType<typeof drawerService>;
+export type DrawerStore = ReturnType<typeof drawerService>;
 function drawerService() {
 	const { subscribe, set, update } = writable<DrawerSettings>({});
 	return {

--- a/packages/skeleton/src/lib/utilities/Drawer/types.ts
+++ b/packages/skeleton/src/lib/utilities/Drawer/types.ts
@@ -1,5 +1,7 @@
 // Drawer Types
 
+export type { DrawerStore } from './stores.js';
+
 export interface DrawerSettings {
 	open?: boolean;
 	/** A unique identifier, useful for setting contents. */

--- a/packages/skeleton/src/lib/utilities/Modal/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Modal/stores.ts
@@ -9,13 +9,17 @@ const MODAL_STORE_KEY = 'modalStore';
 /**
  * Retrieves the `modalStore`.
  *
+ * This can *ONLY* be called from the **top level** of components!
+ *
  * @example
- * ```ts
- * import { getmodalStore } from "@skeletonlabs/skeleton";
+ * ```svelte
+ * <script>
+ * 	import { getmodalStore } from "@skeletonlabs/skeleton";
  *
- * const modalStore = getModalStore();
+ * 	const modalStore = getModalStore();
  *
- * modalStore.trigger({ type: "alert", title: "Welcome!" });
+ * 	modalStore.trigger({ type: "alert", title: "Welcome!" });
+ * </script>
  * ```
  */
 export function getModalStore(): ModalStore {

--- a/packages/skeleton/src/lib/utilities/Modal/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Modal/stores.ts
@@ -38,7 +38,7 @@ export function initializeModalStore(): ModalStore {
 	return setContext(MODAL_STORE_KEY, modalStore);
 }
 
-type ModalStore = ReturnType<typeof modalService>;
+export type ModalStore = ReturnType<typeof modalService>;
 function modalService() {
 	const { subscribe, set, update } = writable<ModalSettings[]>([]);
 	return {

--- a/packages/skeleton/src/lib/utilities/Modal/types.ts
+++ b/packages/skeleton/src/lib/utilities/Modal/types.ts
@@ -1,5 +1,7 @@
 // Modal Types
 
+export type { ModalStore } from './stores.js';
+
 export interface ModalComponent {
 	/** Import and provide your component reference. */
 	ref: any;

--- a/packages/skeleton/src/lib/utilities/Toast/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/stores.ts
@@ -11,13 +11,17 @@ const TOAST_STORE_KEY = 'toastStore';
 /**
  * Retrieves the `toastStore`.
  *
+ * This can *ONLY* be called from the **top level** of components!
+ *
  * @example
- * ```ts
- * import { getToastStore } from "@skeletonlabs/skeleton";
+ * ```svelte
+ * <script>
+ * 	import { getToastStore } from "@skeletonlabs/skeleton";
  *
- * const toastStore = getToastStore();
+ * 	const toastStore = getToastStore();
  *
- * toastStore.open({ message: "Welcome!" });
+ * 	toastStore.open({ message: "Welcome!" });
+ * </script>
  * ```
  */
 export function getToastStore(): ToastStore {

--- a/packages/skeleton/src/lib/utilities/Toast/stores.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/stores.ts
@@ -46,7 +46,7 @@ function randomUUID(): string {
 	return Number(random).toString(32);
 }
 
-type ToastStore = ReturnType<typeof toastService>;
+export type ToastStore = ReturnType<typeof toastService>;
 function toastService() {
 	const { subscribe, set, update } = writable<Toast[]>([]);
 

--- a/packages/skeleton/src/lib/utilities/Toast/types.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/types.ts
@@ -1,5 +1,7 @@
 // Toast interface types
 
+export type { ToastStore } from './stores.js';
+
 export interface ToastSettings {
 	/** Provide the toast message. Supports HTML. */
 	message: string;

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
@@ -115,7 +115,10 @@
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Drawer Store</h2>
-			<p>Import this anywhere you wish to control the Drawer. Provides an interface to control the drawer component.</p>
+			<p>Provides an interface to control the drawer component.</p>
+			<blockquote class="blockquote">
+				NOTE: To retrieve the store, <code class="code">getDrawerStore</code> must be invoked at the <u>top level</u> of your component!
+			</blockquote>
 			<CodeBlock language="ts" code={`import { getDrawerStore } from "@skeletonlabs/skeleton";\n\nconst drawerStore = getDrawerStore();`} />
 			<h3 class="h3">Open</h3>
 			<CodeBlock language="ts" code={`drawerStore.open();`} />

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
@@ -79,14 +79,7 @@
 					</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<!-- prettier-ignore -->
-				<p>
-					Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, or Toast features, and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
-				</p>
-				<CodeBlock language="ts" code={`import { initializeStores } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
-				<p>Implement a single instance of the drawer component in your app's root layout, above the App Shell (if present).</p>
-				<CodeBlock language="html" code={`<Drawer />\n\n<!-- <AppShell>...</AppShell> -->`} />
-				<p>We'll cover triggering this feature on-demand in the documentation below.</p>
+				<p>There are a several steps involved to utilize this feature. Please refer to the documented instruction below.</p>
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -100,18 +93,17 @@
 				and reusable via a Svelte writable store. Do not reimplement this component for each route page.
 			</p>
 		</aside>
-		<!-- Drawer Component -->
 		<section class="space-y-4">
-			<h2 class="h2">Drawer Component</h2>
+			<h2 class="h2">Prerequisites</h2>
+			<h3 class="h3">Initialize Stores</h3>
+			<!-- prettier-ignore -->
+			<p>
+				Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, and Toast stores and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
+			</p>
+			<CodeBlock language="ts" code={`import { initializeStores } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
+			<h3 class="h3">Drawer Component</h3>
 			<p>Implement a single instance of the drawer component in your app's root layout, above the App Shell (if present).</p>
-			<CodeBlock
-				language="html"
-				code={`
-<Drawer>(contents)</Drawer>
-
-<!-- <AppShell>...</AppShell> -->
-				`}
-			/>
+			<CodeBlock language="html" code={`<Drawer />\n\n<!-- <AppShell>...</AppShell> -->`} />
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Drawer Store</h2>

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
@@ -17,7 +17,7 @@
 		name: 'Drawers',
 		description: 'Displays an overlay panel that attaches to any side of the screen.',
 		imports: ['Drawer', 'getDrawerStore'],
-		types: ['DrawerSettings'],
+		types: ['DrawerSettings', 'DrawerStore'],
 		source: 'utilities/Drawer',
 		aria: 'https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/',
 		components: [{ sveld: sveldDrawer }],

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/modals/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/modals/+page.svelte
@@ -106,7 +106,7 @@
 			component: c,
 			title: 'Custom Form Component',
 			body: 'Complete the form below and then press submit.',
-			response: (r: any) => console.log('response:', r)
+			response: (r) => console.log('response:', r)
 		};
 		modalStore.trigger(modal);
 	}
@@ -117,7 +117,7 @@
 			component: 'exampleList',
 			title: 'Custom List Component',
 			body: 'Make your selection then press submit.',
-			response: (r: any) => console.log('response:', r)
+			response: (r) => console.log('response:', r)
 		};
 		modalStore.trigger(modal);
 	}
@@ -197,6 +197,9 @@ initializeStores();
 				When you wish to trigger a modal, import the <code class="code">getModalStore</code> function and invoke it to retrieve the
 				<code class="code">modalStore</code>, which is a Svelte store that acts as the modal queue.
 			</p>
+			<blockquote class="blockquote">
+				NOTE: To retrieve the store, <code class="code">getModalStore</code> must be invoked at the <u>top level</u> of your component!
+			</blockquote>
 			<CodeBlock
 				language="ts"
 				code={`

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/modals/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/modals/+page.svelte
@@ -26,7 +26,7 @@
 		name: 'Modals',
 		description: 'High priority dialogs and modals using a dynamic queue system.',
 		imports: ['Modal', 'getModalStore'],
-		types: ['ModalSettings', 'ModalComponent'],
+		types: ['ModalSettings', 'ModalComponent', 'ModalStore'],
 		source: 'utilities/Modal',
 		aria: 'https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/',
 		components: [{ sveld: sveldModal }],

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/modals/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/modals/+page.svelte
@@ -149,21 +149,7 @@
 				<button class="btn variant-filled" on:click={modalDemo}>Show Modal</button>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<!-- prettier-ignore -->
-				<p>
-					Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, or Toast features, and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
-				</p>
-				<CodeBlock
-					language="typescript"
-					code={`
-import { Modal, initializeStores } from "@skeletonlabs/skeleton";
-
-initializeStores();
-`}
-				/>
-				<p>Implement a single instance of the modal component in your app's root layout, above the App Shell (if present).</p>
-				<CodeBlock language="html" code={`<Modal />\n\n<!-- <AppShell>...</AppShell> -->`} />
-				<p>We'll cover triggering this feature on-demand in the documentation below.</p>
+				<p>There are a several steps involved to utilize this feature. Please refer to the documented instruction below.</p>
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -180,16 +166,16 @@ initializeStores();
 			</p>
 		</aside>
 		<section class="space-y-4">
-			<h2 class="h2">Modal Component</h2>
+			<h2 class="h2">Prerequisites</h2>
+			<h3 class="h3">Initialize Stores</h3>
+			<!-- prettier-ignore -->
+			<p>
+				Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, and Toast stores and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
+			</p>
+			<CodeBlock language="ts" code={`import { initializeStores } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
+			<h3 class="h3">Modal Component</h3>
 			<p>Implement a single instance of the modal component in your app's root layout, above the App Shell (if present).</p>
-			<CodeBlock
-				language="html"
-				code={`
-<Modal />
-
-<!-- <AppShell>...</AppShell> -->
-				`}
-			/>
+			<CodeBlock language="html" code={`<Modal />\n\n<!-- <AppShell>...</AppShell> -->`} />
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Modal Store</h2>

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -179,6 +179,9 @@
 		<section class="space-y-4">
 			<h2 class="h2">Toast Store</h2>
 			<p>The Toast Store acts as a queue for your toast messages.</p>
+			<blockquote class="blockquote">
+				NOTE: To retrieve the store, <code class="code">getToastStore</code> must be invoked at the <u>top level</u> of your component!
+			</blockquote>
 			<CodeBlock
 				language="ts"
 				code={`import { getToastStore } from '@skeletonlabs/skeleton';\n\nconst toastStore = getToastStore();

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -17,7 +17,7 @@
 		name: 'Toasts',
 		description: 'Simple notifications utilizing a dynamic queue system.',
 		imports: ['Toast', 'getToastStore'],
-		types: ['ToastSettings'],
+		types: ['ToastSettings', 'ToastStore'],
 		source: 'utilities/Toast',
 		components: [{ sveld: sveldToast }],
 		transitionIn: 'fly',

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -141,14 +141,7 @@
 				</div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<!-- prettier-ignore -->
-				<p>
-					Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, or Toast features, and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
-				</p>
-				<CodeBlock language="ts" code={`import { initializeStores } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
-				<p>Implement a single instance of the toast component in your app's root layout, above the App Shell (if present).</p>
-				<CodeBlock language="html" code={`<Toast />\n\n<!-- <AppShell>...</AppShell> -->`} />
-				<p>We'll cover triggering this feature on-demand in the documentation below.</p>
+				<p>There are a several steps involved to utilize this feature. Please refer to the documented instruction below.</p>
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>
@@ -162,18 +155,18 @@
 				and reusable via a Svelte writable store. Do not reimplement this component for each route page.
 			</p>
 		</aside>
-		<!-- Toast Component -->
 		<section class="space-y-4">
-			<h2 class="h2">Toast Component</h2>
+			<h2 class="h2">Prerequisites</h2>
+			<h3 class="h3">Initialize Stores</h3>
+			<!-- prettier-ignore -->
+			<p>
+				Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, and Toast stores and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
+			</p>
+			<CodeBlock language="ts" code={`import { initializeStores } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
+			<h3 class="h3">Toast Component</h3>
 			<p>Implement a single instance of the toast component in your app's root layout, above the App Shell (if present).</p>
-			<CodeBlock
-				language="html"
-				code={`
-<Toast />
-
-<!-- <AppShell>...</AppShell> -->
-				`}
-			/>
+			<CodeBlock language="html" code={`<Toast />\n\n<!-- <AppShell>...</AppShell> -->`} />
+			<p>We'll cover triggering this feature on-demand in the documentation below.</p>
 		</section>
 		<!-- Toast Store -->
 		<section class="space-y-4">


### PR DESCRIPTION
This PR simply adds a note to each of the stores stating that their respective store getter functions must be invoked at the top level of a component. 

I also noticed that we weren't exposing the type for each of the stores, so I went ahead and added that with this PR.

### Changes
- Exposed the following type: `ToastStore`, `DrawerStore`, and `ModalStore`
- Added those newly exposed type to their respective pages in the docs
- Improved the JSDoc comment for each getter function, such that it specifies that the function _must_ be invoked from the top level of a component:
![img](https://i.imgur.com/uicFwB3.png)
- Added this note for each store:
![img](https://i.imgur.com/ukJJ8jm.png)
---

Copying over the original message from Discord here too:

I think this is another topic worth bringing up. Looking into this, the introduction of using contexts to store our `toastStore`, `modalStore`, and `drawerStore` has 1 apparent limitation. In order to retrieve the stores with contexts, **we have to call these functions at the top level of components**.

For instance, this is valid code:
```html
<script>
  // SomeComponent.svelte
  import { getToastStore } from "@skeletonlabs/skeleton";

  const toastStore = getToastStore();

  toastStore.trigger(...); // this is fine

  // or
  function addToast() {
    toastStore.trigger(...); // this is fine too
  }
</script>
```

So, in order to use the `toastStore` (and the others), the store must first be retrieved at the top levels of components to be used.

This means that we can't do something like this:
```html
<script>
  // SomeComponent.svelte
  import { getToastStore } from "@skeletonlabs/skeleton";

  function addToast() {
    // this will throw a "Component Initialization" error as 
    // getting and setting contexts must be done at the top level of components
    const toastStore = getToastStore();
    toastStore.trigger(...)
    
    // this will also throw the same error for the same reason
    getToastStore().trigger(...)
  }
</script>
```

As we haven't seen many reports of this as part of v2, I figure the usage of calling the `getToastStore` outside of the top level of a component is fairly uncommon. But for someone who is trying to refactor their code, a reasonable person could assume that they can take `getToastStore` outside of a component into it's own module, like a `toast.ts` file.

```ts
// toast.ts
import { getToastStore } from "@skeletonlabs/skeleton";

// This will error out for the same reason as the code above.
export function addToast() {
  const toastStore = getToastStore();
  toastStore.trigger(...);
}
```

If a user want's to create a module for reusable triggers, they'll have to do it like this:
```ts
// toast.ts
export function addToast(toastStore, message) {
  toastStore.trigger(message);
}
```
Where they pass the `toastStore` to the reusable function. It's a tradeoff, but something that is probably worth documenting