### PR TITLE
bugfix/tree-view-recursive-events

### DIFF
--- a/.changeset/curvy-bananas-help.md
+++ b/.changeset/curvy-bananas-help.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: fixed tree-view recursive-mode event bugs

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewDataDrivenItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewDataDrivenItem.svelte
@@ -80,6 +80,15 @@
 				node.checked = node.value === group;
 			});
 		}
+		nodes = nodes;
+	}
+
+	// trigger reactivity on toggle only when node has children.
+	function onToggleChange(e: CustomEvent<{ open: boolean }>, node: TreeViewNode) {
+		if (node.children && node.children.length > 0) {
+			node.open = e.detail.open;
+			nodes = nodes;
+		}
 	}
 
 	// important to pass children up to items (recursively)
@@ -91,7 +100,7 @@
 	{#each nodes as node, i}
 		<TreeViewItem
 			bind:this={treeItems[i]}
-			bind:open={node.open}
+			open={node.open}
 			hideLead={!node.lead}
 			hideChildren={!node.children || node.children.length === 0}
 			bind:disabled={node.disabled}
@@ -103,6 +112,7 @@
 			on:change={onGroupChange}
 			on:change
 			on:click
+			on:toggle={(e) => onToggleChange(e, node)}
 			on:toggle
 			on:keydown
 			on:keyup

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -204,7 +204,7 @@
 	// events
 	const dispatch = createEventDispatcher();
 	/** @event {{ open: boolean }} toggle - Fires on open or close. */
-	$: dispatch('toggle', { open: open });
+	$: if ($$slots.children && !hideChildren) dispatch('toggle', { open: open });
 
 	// whenever children are changed, reassign on:change events.
 	$: children.forEach((child) => {


### PR DESCRIPTION
## Linked Issue

Closes #1943

## Description

> Unless a change also changes it's parents value the bind value does not trigger an update (reactivity).

this is solved by triggering reactivity when the group change

> clicking on a node with no children will trigger reactivity (the value of node's open prop is changing even if it doesn't have children)

Since svelte doesn't have conditional binding, I had to create a separate function that triggers reactivity only when the node has no children.

## Changsets

bugfix: fixed tree-view recursive-mode event bugs

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
