### PR TITLE
bugfix: relational-tree-view indeterminate state

### DIFF
--- a/.changeset/famous-forks-burn.md
+++ b/.changeset/famous-forks-burn.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: TreeView update `group` value on indeterminate state

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -123,6 +123,10 @@
 			// at least one child is indeterminate => indeterminate item
 			if (children.some((c) => c.indeterminate)) {
 				indeterminate = true;
+				if (index >= 0) {
+					group.splice(index, 1);
+					group = group;
+				}
 			}
 			// all children are checked => check item
 			else if (childrenValues.every((c) => Array.isArray(childrenGroup) && childrenGroup.includes(c))) {
@@ -135,6 +139,10 @@
 			// not all children are checked => indeterminate item
 			else if (childrenValues.some((c) => Array.isArray(childrenGroup) && childrenGroup.includes(c))) {
 				indeterminate = true;
+				if (index >= 0) {
+					group.splice(index, 1);
+					group = group;
+				}
 			}
 			// all children are unchecked => uncheck item
 			else {


### PR DESCRIPTION
## Linked Issue

Closes #1949 

## Description

group value was not being updated when parent state change to indeterminate.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
