### PR TITLE
ToC optional prefix/suffice params added

### DIFF
--- a/.changeset/tall-jobs-wait.md
+++ b/.changeset/tall-jobs-wait.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: Update Table of Contents to include optional `prefix` and `suffix` parameters

--- a/packages/skeleton/src/lib/utilities/TableOfContents/crawler.ts
+++ b/packages/skeleton/src/lib/utilities/TableOfContents/crawler.ts
@@ -12,6 +12,10 @@ interface TOCCrawlerArgs {
 	scrollTarget?: string;
 	/** Reload the action when this key value changes. */
 	key?: unknown;
+	/* Provide a prefix for ToC links, to help keep them unique. */
+	prefix?: string;
+	/* Provide a suffix for ToC links, to help keep them unique. */
+	suffix?: string;
 }
 
 export function tocCrawler(node: HTMLElement, args?: TOCCrawlerArgs) {
@@ -44,7 +48,9 @@ export function tocCrawler(node: HTMLElement, args?: TOCCrawlerArgs) {
 					.replaceAll(/[^a-zA-Z0-9 ]/g, '')
 					.replaceAll(' ', '-')
 					.toLowerCase();
-				elemHeading.id = `toc-${newHeadingId}`;
+				const prefix = args.prefix ? `${args.prefix}-` : '';
+				const suffix = args.suffix ? `${args.suffix}-` : '';
+				elemHeading.id = prefix + newHeadingId + suffix;
 			}
 			// Push heading data to the permalink array
 			permalinks.push({

--- a/packages/skeleton/src/lib/utilities/TableOfContents/crawler.ts
+++ b/packages/skeleton/src/lib/utilities/TableOfContents/crawler.ts
@@ -49,7 +49,7 @@ export function tocCrawler(node: HTMLElement, args?: TOCCrawlerArgs) {
 					.replaceAll(' ', '-')
 					.toLowerCase();
 				const prefix = args.prefix ? `${args.prefix}-` : '';
-				const suffix = args.suffix ? `${args.suffix}-` : '';
+				const suffix = args.suffix ? `-${args.suffix}` : '';
 				elemHeading.id = prefix + newHeadingId + suffix;
 			}
 			// Push heading data to the permalink array

--- a/sites/skeleton.dev/src/routes/(inner)/elements/chat/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/chat/+page.svelte
@@ -473,7 +473,8 @@ let messageFeed = [
 		</section>
 
 		<section class="space-y-4">
-			<h2 class="h2">Prompt</h2>
+			<!-- NOTE: id provided to avoid ToC conflict -->
+			<h2 class="h2" id="prompt-field">Prompt</h2>
 			<p>
 				We can utilize a Skeleton <a class="anchor" href="/elements/forms">Input Group</a> to create a custom text prompt.
 			</p>

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/table-of-contents/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/table-of-contents/+page.svelte
@@ -79,10 +79,24 @@
 				code={`
 <!-- Before: -->
 <h2 class="h2">Title One</h2>
-<h2 class="h2" id="toc-my-custom-id">Title Two</h2>\n
+<h2 class="h2" id="my-custom-id">Title Two</h2>\n
 <!-- After: -->
 <h2 class="h2" id="title-one">Title One</h2>
 <h2 class="h2" id="my-custom-id">Title Two</h2>
+			`}
+			/>
+			<!-- Prefixes and Suffixes -->
+			<h3 class="h3">Prefixes and Suffixes</h3>
+			<!-- prettier-ignore -->
+			<p>
+				We recommend setting a custom heading (per the instruction above) if a conflict is found within your page. However, you may also hardcode a <code class="code">prefix</code> or <code class="code">suffix</code> to all generated IDs as follows:
+			</p>
+			<CodeBlock
+				language="html"
+				code={`
+<div use:tocCrawler={{ mode: 'generate', prefix: 'foo', suffix: 'bar' }}>\n
+<!-- Ex: foo-title-one-bar -->
+<!-- Ex: foo-title-two-bar -->
 			`}
 			/>
 			<!-- Ignore Headings -->


### PR DESCRIPTION
## Linked Issue

Closes #1915

## Description

Instead of hardcoding a `toc-` prefix to all Table of Content hash links, we now recommend supplying a custom heading ID when a conflict arises. However, I've also implement a means to manually set your own prefix/suffix in case this is required.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
