### PR TITLE
Chore/input chip rollback

### DIFF
--- a/.changeset/twelve-carrots-bathe.md
+++ b/.changeset/twelve-carrots-bathe.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+Rollback Input Chip change that introduced reactivity bug

--- a/.changeset/twelve-carrots-bathe.md
+++ b/.changeset/twelve-carrots-bathe.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-Rollback Input Chip change that introduced reactivity bug
+chore: Rollback Input Chip change that introduced reactivity bug

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -223,6 +223,11 @@
 	$: classesInterface = `${cInterface}`;
 	$: classesChipList = `${cChipList}`;
 	$: classesInputField = `${cInputField}`;
+	$: chipValues =
+		value?.map((val, i) => {
+			if (chipValues[i]?.val === val) return chipValues[i];
+			return { id: Math.random(), val: val };
+		}) || [];
 </script>
 
 <div class="input-chip {classesBase}" class:opacity-50={$$restProps.disabled}>


### PR DESCRIPTION
## Linked Issue

Closes #1940

## Description

Roll back a change that introduced a regression in reactivity behavior.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
