### PR TITLE
docs(Autocomplete): update Autocomplete event typing

### DIFF
--- a/.changeset/beige-boats-heal.md
+++ b/.changeset/beige-boats-heal.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+chore: update event typing for Autocomplete component

--- a/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
@@ -54,30 +54,30 @@
 	let inputChip = '';
 	let inputChipList: string[] = ['vanilla', 'chocolate'];
 
-	function onDemoSelection(event: any): void {
+	function onDemoSelection(event: CustomEvent<AutocompleteOption>): void {
 		console.log(event.detail);
 		inputDemo = event.detail.label;
 	}
 
-	function onAllowedlistSelect(event: any): void {
+	function onAllowedlistSelect(event: CustomEvent<AutocompleteOption>): void {
 		console.log(event.detail);
 		inputAllowlist = event.detail.label;
 	}
 
-	function onDeniedlistSelect(event: any): void {
+	function onDeniedlistSelect(event: CustomEvent<AutocompleteOption>): void {
 		console.log(event.detail);
-		flavorDenylist = [event.detail.value];
+		flavorDenylist = [event.detail.value as string];
 	}
 
-	function onInputChipSelect(event: any): void {
+	function onInputChipSelect(event: CustomEvent<AutocompleteOption>): void {
 		console.log('onInputChipSelect', event.detail);
-		if (inputChipList.includes(event.detail.value) === false) {
-			inputChipList = [...inputChipList, event.detail.value];
+		if (inputChipList.includes(event.detail.value as string) === false) {
+			inputChipList = [...inputChipList, event.detail.value as string];
 			inputChip = '';
 		}
 	}
 
-	function onPopupDemoSelect(event: any): void {
+	function onPopupDemoSelect(event: CustomEvent<AutocompleteOption>): void {
 		inputPopupDemo = event.detail.label;
 	}
 </script>
@@ -115,7 +115,7 @@ const flavorOptions: AutocompleteOption[] = [
 				<CodeBlock
 					language="ts"
 					code={`
-function onFlavorSelection(event: any): void {
+function onFlavorSelection(event: CustomEvent<AutocompleteOption>): void {
 	inputDemo = event.detail.label;
 }
 				`}


### PR DESCRIPTION
## Description

This PR updates the event type for the Autocomplete component from `any` to `CustomEvent<AutocompleteOption>`.

The problem, though, is that the user needs to manually cast the values as e.g. string, since value is `unknown` in `AutocompleteOption`. Should there be a generic type `AutocompleteOption<T>` to let the user define what values look like?

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
