### PR TITLE
Added TestComponents for Modal & Toast to correctly initialize their Stores

### DIFF
--- a/packages/skeleton/src/lib/utilities/Modal/Modal.test.ts
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.test.ts
@@ -1,8 +1,7 @@
 import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 
-import { getModalStore } from '$lib/utilities/Modal/stores.js';
-import type { ModalSettings } from '$lib/utilities/Modal/types.js';
+import type { ModalSettings } from './types.js';
 
 import ModalTest from './ModalTest.svelte';
 

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.test.ts
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 import { getModalStore } from '$lib/utilities/Modal/stores.js';
 import type { ModalSettings } from '$lib/utilities/Modal/types.js';
 
-import Modal from '$lib/utilities/Modal/Modal.svelte';
+import ModalTest from './ModalTest.svelte';
 
 // Modal Payloads
 const modalAlert: ModalSettings = {
@@ -27,25 +27,20 @@ const modalPrompt: ModalSettings = {
 };
 
 describe('Modal.svelte', () => {
-	const modalStore = getModalStore();
-
 	it('Renders modal alert', async () => {
-		modalStore.trigger(modalAlert);
-		const { getByTestId } = render(Modal);
+		const { getByTestId } = render(ModalTest, {props: {modalSetting: modalAlert}});
 		expect(getByTestId('modal-backdrop')).toBeTruthy();
 		expect(getByTestId('modal')).toBeTruthy();
 	});
 
 	it('Renders modal confirm', async () => {
-		modalStore.trigger(modalConfirm);
-		const { getByTestId } = render(Modal);
+		const { getByTestId } = render(ModalTest, {props: {modalSetting: modalConfirm}});
 		expect(getByTestId('modal-backdrop')).toBeTruthy();
 		expect(getByTestId('modal')).toBeTruthy();
 	});
 
 	it('Renders modal prompt', async () => {
-		modalStore.trigger(modalPrompt);
-		const { getByTestId } = render(Modal);
+		const { getByTestId } = render(ModalTest, {props: {modalSetting: modalPrompt}});
 		expect(getByTestId('modal-backdrop')).toBeTruthy();
 		expect(getByTestId('modal')).toBeTruthy();
 	});

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.test.ts
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.test.ts
@@ -28,19 +28,19 @@ const modalPrompt: ModalSettings = {
 
 describe('Modal.svelte', () => {
 	it('Renders modal alert', async () => {
-		const { getByTestId } = render(ModalTest, {props: {modalSetting: modalAlert}});
+		const { getByTestId } = render(ModalTest, { props: { modalSetting: modalAlert } });
 		expect(getByTestId('modal-backdrop')).toBeTruthy();
 		expect(getByTestId('modal')).toBeTruthy();
 	});
 
 	it('Renders modal confirm', async () => {
-		const { getByTestId } = render(ModalTest, {props: {modalSetting: modalConfirm}});
+		const { getByTestId } = render(ModalTest, { props: { modalSetting: modalConfirm } });
 		expect(getByTestId('modal-backdrop')).toBeTruthy();
 		expect(getByTestId('modal')).toBeTruthy();
 	});
 
 	it('Renders modal prompt', async () => {
-		const { getByTestId } = render(ModalTest, {props: {modalSetting: modalPrompt}});
+		const { getByTestId } = render(ModalTest, { props: { modalSetting: modalPrompt } });
 		expect(getByTestId('modal-backdrop')).toBeTruthy();
 		expect(getByTestId('modal')).toBeTruthy();
 	});

--- a/packages/skeleton/src/lib/utilities/Modal/ModalTest.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/ModalTest.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+    import { initializeModalStore, getModalStore } from '$lib/utilities/Modal/stores.js';
+    import Modal from '$lib/utilities/Modal/Modal.svelte';
+    import type { ModalSettings } from '$lib/utilities/Modal/types.js'; 
+    
+    export let modalSetting: ModalSettings;
+
+    initializeModalStore();
+    getModalStore().trigger(modalSetting);
+</script>
+
+<Modal/>
+

--- a/packages/skeleton/src/lib/utilities/Modal/ModalTest.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/ModalTest.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-    import { initializeModalStore, getModalStore } from '$lib/utilities/Modal/stores.js';
-    import Modal from '$lib/utilities/Modal/Modal.svelte';
-    import type { ModalSettings } from '$lib/utilities/Modal/types.js'; 
-    
-    export let modalSetting: ModalSettings;
+	import { initializeModalStore, getModalStore } from '$lib/utilities/Modal/stores.js';
+	import Modal from '$lib/utilities/Modal/Modal.svelte';
+	import type { ModalSettings } from '$lib/utilities/Modal/types.js';
 
-    initializeModalStore();
-    getModalStore().trigger(modalSetting);
+	export let modalSetting: ModalSettings;
+
+	initializeModalStore();
+	getModalStore().trigger(modalSetting);
 </script>
 
-<Modal/>
-
+<Modal />

--- a/packages/skeleton/src/lib/utilities/Modal/ModalTest.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/ModalTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { initializeModalStore, getModalStore } from '$lib/utilities/Modal/stores.js';
-	import Modal from '$lib/utilities/Modal/Modal.svelte';
-	import type { ModalSettings } from '$lib/utilities/Modal/types.js';
+	import { initializeModalStore, getModalStore } from './stores.js';
+	import Modal from './Modal.svelte';
+	import type { ModalSettings } from './types.js';
 
 	export let modalSetting: ModalSettings;
 

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.test.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.test.ts
@@ -17,7 +17,6 @@ const toastMessage: ToastSettings = {
 };
 
 describe('Toast.svelte', () => {
-
 	it('Renders modal alert', async () => {
 		const { getByTestId } = render(ToastTest, { props: { toastSettings: [toastMessage] } });
 		expect(getByTestId('toast')).toBeTruthy();

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.test.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.test.ts
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 
-import { getToastStore } from '$lib/utilities/Toast/stores.js';
 import type { ToastSettings } from './types.js';
 import Toast from '$lib/utilities/Toast/Toast.svelte';
+import ToastTest from './ToastTest.svelte';
 
 // Toast Payload
 const toastMessage: ToastSettings = {
@@ -17,18 +17,14 @@ const toastMessage: ToastSettings = {
 };
 
 describe('Toast.svelte', () => {
-	const toastStore = getToastStore();
 
 	it('Renders modal alert', async () => {
-		toastStore.trigger(toastMessage);
-		const { getByTestId } = render(Toast);
+		const { getByTestId } = render(ToastTest, { props: { toastSettings: [toastMessage] } });
 		expect(getByTestId('toast')).toBeTruthy();
 	});
 
 	it('Renders only the configured max toasts at a time', async () => {
-		toastStore.trigger({ message: '1' });
-		toastStore.trigger({ message: '2' });
-		const { getAllByTestId } = render(Toast, { max: 1 });
+		const { getAllByTestId } = render(ToastTest, { props: { max: 1, toastSettings: [{ message: '1' }, { message: '2' }] } });
 		expect(getAllByTestId('toast').length).toBe(1);
 	});
 });

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.test.ts
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.test.ts
@@ -2,7 +2,6 @@ import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
 
 import type { ToastSettings } from './types.js';
-import Toast from '$lib/utilities/Toast/Toast.svelte';
 import ToastTest from './ToastTest.svelte';
 
 // Toast Payload

--- a/packages/skeleton/src/lib/utilities/Toast/ToastTest.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/ToastTest.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
-    import { initializeToastStore, getToastStore } from '$lib/utilities/Toast/stores.js';
-    import type { ToastSettings } from '$lib/utilities/Toast/types.js';
-    import Toast from '$lib/utilities/Toast/Toast.svelte';
-    
-    export let toastSettings: Array<ToastSettings> = [];
-    export let max: number | undefined = undefined;
+	import { initializeToastStore, getToastStore } from '$lib/utilities/Toast/stores.js';
+	import type { ToastSettings } from '$lib/utilities/Toast/types.js';
+	import Toast from '$lib/utilities/Toast/Toast.svelte';
 
-    initializeToastStore();
-    const toastStore = getToastStore();
+	export let toastSettings: Array<ToastSettings> = [];
+	export let max: number | undefined = undefined;
 
-    toastSettings.forEach(element => {
-        toastStore.trigger(element);
-    });
+	initializeToastStore();
+	const toastStore = getToastStore();
+
+	toastSettings.forEach((element) => {
+		toastStore.trigger(element);
+	});
 </script>
 
-<Toast {max}/>
-
+<Toast {max} />

--- a/packages/skeleton/src/lib/utilities/Toast/ToastTest.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/ToastTest.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { initializeToastStore, getToastStore } from '$lib/utilities/Toast/stores.js';
-	import type { ToastSettings } from '$lib/utilities/Toast/types.js';
-	import Toast from '$lib/utilities/Toast/Toast.svelte';
+	import { initializeToastStore, getToastStore } from './stores.js';
+	import type { ToastSettings } from './types.js';
+	import Toast from './Toast.svelte';
 
 	export let toastSettings: Array<ToastSettings> = [];
 	export let max: number | undefined = undefined;

--- a/packages/skeleton/src/lib/utilities/Toast/ToastTest.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/ToastTest.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    import { initializeToastStore, getToastStore } from '$lib/utilities/Toast/stores.js';
+    import type { ToastSettings } from '$lib/utilities/Toast/types.js';
+    import Toast from '$lib/utilities/Toast/Toast.svelte';
+    
+    export let toastSettings: Array<ToastSettings> = [];
+    export let max: number | undefined = undefined;
+
+    initializeToastStore();
+    const toastStore = getToastStore();
+
+    toastSettings.forEach(element => {
+        toastStore.trigger(element);
+    });
+</script>
+
+<Toast {max}/>
+


### PR DESCRIPTION
## Linked Issue

No issue, just DominikG asking about our failing Tests

## Description

Added a TestComponent wrapping the Modal/Toast and their stores and refactored the tests to utilize them.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
