### PR TITLE
bugfix: added missing source code in input group examples

### DIFF
--- a/.changeset/tall-mice-exercise.md
+++ b/.changeset/tall-mice-exercise.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": major
+---
+
+bugfix: added missing source code to tailwind forms example

--- a/.changeset/tall-mice-exercise.md
+++ b/.changeset/tall-mice-exercise.md
@@ -1,5 +1,0 @@
----
-"skeleton.dev": major
----
-
-bugfix: added missing source code to tailwind forms example

--- a/sites/skeleton.dev/src/routes/(inner)/elements/forms/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/forms/+page.svelte
@@ -507,6 +507,7 @@ export default {
 					<CodeBlock
 						language="html"
 						code={`
+<p>Website</p>
 <div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
   <div class="input-group-shim">https://</div>
   <input type="text" placeholder="www.example.com" />
@@ -516,8 +517,9 @@ export default {
 					<CodeBlock
 						language="html"
 						code={`
+<p>Amount</p>
 <div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-  <div class="input-group-shim"><i class="fa-solid fa-dollar-sign" /></div>
+  <div class="input-group-shim">(icon)</div>
   <input type="text" placeholder="Amount" />
   <select>
     <option>USD</option>
@@ -530,19 +532,19 @@ export default {
 					<CodeBlock
 						language="html"
 						code={`
+<p>Username</p>
 <div class="input-group input-group-divider grid-cols-[1fr_auto]">
   <input type="text" placeholder="Enter Username..." />
-  <a href="/elements/forms" title="Username already in use.">
-    <i class="fa-solid fa-circle-exclamation text-warning-500 animate-pulse" />
-  </a>
+  <a href="" title="Username already in use.">(icon)</a>
 </div>
 		`}
 					/>
 					<CodeBlock
 						language="html"
 						code={`
+<p>Search</p>
 <div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
-	<div class="input-group-shim">(segment)</div>
+	<div class="input-group-shim">(icon)</div>
 	<input type="search" placeholder="Search..." />
 	<button class="variant-filled-secondary">Submit</button>
 </div>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/forms/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/forms/+page.svelte
@@ -535,7 +535,7 @@ export default {
 <p>Username</p>
 <div class="input-group input-group-divider grid-cols-[1fr_auto]">
   <input type="text" placeholder="Enter Username..." />
-  <a href="" title="Username already in use.">(icon)</a>
+  <a href="/" title="Username already in use.">(icon)</a>
 </div>
 		`}
 					/>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/forms/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/forms/+page.svelte
@@ -508,6 +508,40 @@ export default {
 						language="html"
 						code={`
 <div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+  <div class="input-group-shim">https://</div>
+  <input type="text" placeholder="www.example.com" />
+</div>
+		`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
+  <div class="input-group-shim"><i class="fa-solid fa-dollar-sign" /></div>
+  <input type="text" placeholder="Amount" />
+  <select>
+    <option>USD</option>
+    <option>CAD</option>
+    <option>EURO</option>
+  </select>
+</div>
+		`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<div class="input-group input-group-divider grid-cols-[1fr_auto]">
+  <input type="text" placeholder="Enter Username..." />
+  <a href="/elements/forms" title="Username already in use.">
+    <i class="fa-solid fa-circle-exclamation text-warning-500 animate-pulse" />
+  </a>
+</div>
+		`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">
 	<div class="input-group-shim">(segment)</div>
 	<input type="search" placeholder="Search..." />
 	<button class="variant-filled-secondary">Submit</button>


### PR DESCRIPTION
## Linked Issue

None

## Description

One of the forms' examples was missing the some stub code. I added that by copying it straight from the page source code.

## Changsets

---
"skeleton.dev": major
---

bugfix: added missing source code to tailwind forms example

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
