### PR TITLE
Updated AppShell docs for auto-scroll top on navigate

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -217,6 +217,26 @@
 			</aside>
 		</section>
 		<section class="space-y-4">
+			<h2 class="h2">Scroll to Top on Navigation</h2>
+			<p>
+				If you wish to have the App Shell page region auto-scroll to the top when navigating, add the following to your root layout in <code
+					class="code">/src/routes/+layout.svelte</code
+				>.
+			</p>
+			<CodeBlock
+				language="ts"
+				code={`
+afterNavigate((params: any) => {
+    const isNewPage: boolean = params.from && params.to && params.from.route.id !== params.to.route.id;
+    const elemPage = document.querySelector('#page');
+    if (isNewPage && elemPage !== null) {
+        elemPage.scrollTop = 0;
+    }
+});
+`}
+			/>
+		</section>
+		<section class="space-y-4">
 			<h2 class="h2">Tracking Scroll Position</h2>
 			<p>Use the <code class="code">on:scroll</code> event to detect when the page region is scrolled vertically.</p>
 			<CodeBlock


### PR DESCRIPTION
## Linked Issue

Closes #1936

## Description

Updates the App Shell docs to explain how to auto-scroll the page region to the top on navigation.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
