### PR TITLE
Updated theme docs to new root data-theme structure

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -61,7 +61,8 @@
 		<CodeBlock
 			language="css"
 			code={`
-:root {
+/* NOTE: set your target theme name (ex: skeleton, wintry, modern, etc) */\n
+:root [data-theme='skeleton'] {
 	--theme-rounded-base: 20px;
 	--theme-rounded-container: 4px;
 }
@@ -71,7 +72,8 @@
 		<CodeBlock
 			language="css"
 			code={`
-:root {
+/* NOTE: set your target theme name (ex: skeleton, wintry, modern, etc) */\n
+:root [data-theme='skeleton'] {
     --theme-font-family-base: 'MyCustomFont', sans-serif;
     --theme-font-family-heading: 'MyCustomFont', sans-serif;
 }
@@ -296,7 +298,8 @@ body {
 						<CodeBlock
 							language="css"
 							code={`
-:root {
+/* NOTE: set your target theme name (ex: skeleton, wintry, modern, etc) */\n
+:root [data-theme='skeleton'] {
     --theme-font-family-base: '${f.name}', sans-serif;
     --theme-font-family-heading: '${f.name}', sans-serif;
     /* ... */
@@ -345,7 +348,8 @@ body {
 					</div>
 					<h3 class="h3" data-toc-ignore>2. Set the Import</h3>
 					<p>
-						Open your global stylesheet in <code class="code">/src/app.postcss</code> and paste the import statement at the top of the file.
+						Open your global stylesheet in <code class="code">/src/app.postcss</code> and paste the import statement at the top of the file,
+						above all <code class="code">@tailwind</code> directives.
 					</p>
 					{#each activeFonts as f}
 						<CodeBlock language="css" code={`@import url('${f.import}');`} />
@@ -360,7 +364,8 @@ body {
 						<CodeBlock
 							language="css"
 							code={`
-:root {
+/* NOTE: set your target theme name (ex: skeleton, wintry, modern, etc) */\n
+:root [data-theme='skeleton'] {
     --theme-font-family-base: '${f.name}', sans-serif;
     --theme-font-family-heading: '${f.name}', sans-serif;
     /* ... */


### PR DESCRIPTION
## Linked Issue

Closes #2008

## Description

Resolved a number of theme doc issue in regards to the v2 `:root [data-theme='skeleton'] {}` selector structure.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
