### PR TITLE
docs: Fixed theme generator's `mono` font

### DIFF
--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/DocsThemer.svelte
@@ -177,8 +177,8 @@ export const myCustomTheme: CustomThemeConfig = {
     name: 'my-custom-theme',
     properties: {
 		// =~= Theme Properties =~=
-		"--theme-font-family-base": "${fontSettings[$storeThemGenForm.fontBase]}",
-		"--theme-font-family-heading": "${fontSettings[$storeThemGenForm.fontHeadings]}",
+		"--theme-font-family-base": \`${fontSettings[$storeThemGenForm.fontBase]}\`,
+		"--theme-font-family-heading": \`${fontSettings[$storeThemGenForm.fontHeadings]}\`,
 		"--theme-font-color-base": "${$storeThemGenForm.textColorLight}",
 		"--theme-font-color-dark": "${$storeThemGenForm.textColorDark}",
 		"--theme-rounded-base": "${$storeThemGenForm.roundedBase}",

--- a/sites/skeleton.dev/src/lib/layouts/DocsThemer/settings.ts
+++ b/sites/skeleton.dev/src/lib/layouts/DocsThemer/settings.ts
@@ -37,7 +37,7 @@ export const fontSettings: Record<string, string> = {
 	// Tailwind Serif
 	serif: `ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif`,
 	// Tailwind Mono
-	mono: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', "Courier New", monospace`,
+	mono: `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace`,
 	// System UI
 	system: `system-ui`
 };


### PR DESCRIPTION
`Courier New` was using a double quote instead of a single, so that's been changed.

I also made the output string for fonts use template literals instead of either a single or double quotes so that we can avoid the above issue entirely.