### PR TITLE
Improved safety of clipboard function when running outside a secure context or with very outdated browsers.

### DIFF
--- a/.changeset/quick-kings-trade.md
+++ b/.changeset/quick-kings-trade.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: added try-catch to clipboard to be secure window aware

--- a/packages/skeleton/src/lib/actions/Clipboard/clipboard.ts
+++ b/packages/skeleton/src/lib/actions/Clipboard/clipboard.ts
@@ -40,21 +40,25 @@ export function clipboard(node: HTMLElement, args: ClipboardArgs) {
 
 // Shared copy method
 async function copyToClipboard(data: BlobPart, mimeType = 'text/plain') {
-	if (navigator.clipboard.write) {
-		await navigator.clipboard.write([
-			new ClipboardItem({
-				[mimeType]: new Blob([data], {
-					type: mimeType
-				}),
-				['text/plain']: new Blob([data], {
-					type: 'text/plain'
+	try {
+		if (navigator.clipboard.write) {
+			await navigator.clipboard.write([
+				new ClipboardItem({
+					[mimeType]: new Blob([data], {
+						type: mimeType
+					}),
+					['text/plain']: new Blob([data], {
+						type: 'text/plain'
+					})
 				})
-			})
-		]);
-	} else {
-		// fallback since .writeText has wider browser support
-		await new Promise((resolve) => {
-			resolve(navigator.clipboard.writeText(String(data)));
-		});
+			]);
+		} else {
+			// fallback since .writeText has wider browser support
+			await new Promise((resolve) => {
+				resolve(navigator.clipboard.writeText(String(data)));
+			});
+		}
+	} catch (exception) {
+		console.log('Could not write to clipboard because of: ', exception);
 	}
 }


### PR DESCRIPTION
## Linked Issue

https://discord.com/channels/1003691521280856084/1151104710850383972

## Description

Added a try catch block to be able to handle insecure contexts or very, very outdated browsers. Or extensions breaking things.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
