### PR TITLE
Fixed selectors and added changeset

### DIFF
--- a/.changeset/hungry-months-yawn.md
+++ b/.changeset/hungry-months-yawn.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": patch
+---
+
+bugfix:Fixed `btn-group` styles affecting children of its children

--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -101,10 +101,10 @@
 	}
 
 	/* Set Neutral Divider */
-	.btn-group * + * {
+	.btn-group > * + * {
 		@apply border-t-0 border-l border-surface-500/20;
 	}
-	.btn-group-vertical * + * {
+	.btn-group-vertical > * + * {
 		@apply border-t border-l-0 border-surface-500/20;
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #2037 

## Description

Added ``>`` selector to only affect direct children of ``btn-group`` and not any deeper

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
