### PR TITLE
Clipboard Action: Added secure context check 

### DIFF
--- a/.changeset/spotty-seas-end.md
+++ b/.changeset/spotty-seas-end.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix:Added secure context check and error message to clipboard action when used outside secure context

--- a/packages/skeleton/src/lib/actions/Clipboard/clipboard.ts
+++ b/packages/skeleton/src/lib/actions/Clipboard/clipboard.ts
@@ -1,6 +1,12 @@
 // Action: Clipboard
 type ClipboardArgs = string | { element: string } | { input: string };
 export function clipboard(node: HTMLElement, args: ClipboardArgs) {
+	if (!window.isSecureContext) {
+		console.error(
+			'Clipboard action failed: app not running in secure context, see: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard'
+		);
+		return;
+	}
 	const fireCopyCompleteEvent = () => {
 		node.dispatchEvent(new CustomEvent('copyComplete'));
 	};

--- a/sites/skeleton.dev/src/routes/(inner)/actions/clipboard/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/actions/clipboard/+page.svelte
@@ -107,5 +107,10 @@
 				</svelte:fragment>
 			</DocsPreview>
 		</div>
+		<section class="space-y-4">
+			<h2 class="h2">Secure Context</h2>
+			<!-- prettier-ignore -->
+			<p>This action utilizes the <a class="anchor" href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard" target="_blank">Clipboard API </a> which means it can only function properly inside <a class="anchor" href="https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts" target="_blank">Secure Context</a>. To prevent your app from throwing errors Skeleton detects when this action is used outside of Secure Context and informs you by logging an error message to the console. You can learn how to prevent this from happening by visiting the website provided by the links.</p>
+		</section>
 	</svelte:fragment>
 </DocsShell>


### PR DESCRIPTION
## Linked Issue

Closes #2030
Resubmission of: #2031

## Description

Implemented a check to check wether the app is running in secure context or not, if not, it will now give a clear error message rather than throwing an error.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
