### PR TITLE
fix: scrollbar-gutter code and docs

### DIFF
--- a/.changeset/modern-chairs-buy.md
+++ b/.changeset/modern-chairs-buy.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": minor
+"skeleton.dev": patch
+---
+
+fixes for the new scrollbarGutter property in AppShell

--- a/packages/skeleton/src/lib/components/AppShell/AppShell.svelte
+++ b/packages/skeleton/src/lib/components/AppShell/AppShell.svelte
@@ -69,7 +69,7 @@
 		{/if}
 
 		<!-- Page -->
-		<div id="page" class="{regionPage} {cPage}" style:scrollbarGutter on:scroll>
+		<div id="page" class="{regionPage} {cPage}" style:scrollbar-gutter={scrollbarGutter} on:scroll>
 			<!-- Slot: Page Header -->
 			{#if $$slots.pageHeader}
 				<header id="page-header" class="flex-none {classesPageHeader}"><slot name="pageHeader">(slot:header)</slot></header>

--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -257,7 +257,7 @@ function scrollHandler(event: ComponentEvents<AppShell>['scroll']) {
 			<p>
 				Use the <a class="anchor" href="https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter" target="_blank">scrollbar gutter</a> property to adjust how the page region scrollbar gutters are handled. View a <a class="anchor" href="https://www.youtube.com/shorts/mg49F9qUs38" target="_blank">quick demo video</a>.
 			</p>
-			<CodeBlock language="ts" code={`<AppShell scrollGutter="auto">...</AppShell>`} />
+			<CodeBlock language="ts" code={`<AppShell scrollbarGutter="auto">...</AppShell>`} />
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Accessibility</h2>


### PR DESCRIPTION
## Description
- docs for scrollbar-gutter in AppShell didn't match the property name
- syntax to apply style seems wrong

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
