### PR TITLE
Bugfix/component modal default slot

### DIFF
--- a/.changeset/lemon-ravens-battle.md
+++ b/.changeset/lemon-ravens-battle.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: component modal's default slot is always true

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -284,11 +284,13 @@
 						aria-modal="true"
 						aria-label={$modalStore[0].title ?? ''}
 					>
-						<svelte:component this={currentComponent?.ref} {...currentComponent?.props} {parent}>
-							{#if currentComponent?.slot}
+						{#if currentComponent?.slot}
+							<svelte:component this={currentComponent?.ref} {...currentComponent?.props} {parent}>
 								{@html currentComponent?.slot}
-							{/if}
-						</svelte:component>
+							</svelte:component>
+						{:else}
+							<svelte:component this={currentComponent?.ref} {...currentComponent?.props} {parent} />
+						{/if}
 					</div>
 				{/if}
 			</div>


### PR DESCRIPTION
## Linked Issue

Closes #2053 

## Description

Fixes the issue.

## Changsets

bugfix: component modal's default slot is always true

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
