### PR TITLE
bugfix: add styling to the lock icon of the stepper component

### DIFF
--- a/.changeset/fast-pugs-tan.md
+++ b/.changeset/fast-pugs-tan.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: ensure styling is applied properly to the lock icon for the stepper component

--- a/packages/skeleton/src/lib/components/Stepper/Step.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Step.svelte
@@ -143,7 +143,7 @@
 					<!-- Button: Next -->
 					<button type={buttonNextType} class="btn {buttonNext}" on:click={onNext} disabled={locked}>
 						{#if locked}
-							<svg class="w-3 aspect-square" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+							<svg class="w-3 aspect-square fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
 								<path
 									d="M144 144v48H304V144c0-44.2-35.8-80-80-80s-80 35.8-80 80zM80 192V144C80 64.5 144.5 0 224 0s144 64.5 144 144v48h16c35.3 0 64 28.7 64 64V448c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V256c0-35.3 28.7-64 64-64H80z"
 								/>


### PR DESCRIPTION
## Linked Issue

Closes #1975 

## Description

Adds `fill-current` to the lock svg icon so styling from the surrounding item is applied and more visible.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
