### PR TITLE
bugfix: added a disabled style for the btn-icon class

### DIFF
--- a/.changeset/cuddly-zebras-eat.md
+++ b/.changeset/cuddly-zebras-eat.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": patch
+---
+
+bugfix: added a disabled style for the btn-icon class

--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -66,7 +66,7 @@
 	.btn-icon:disabled {
 		@apply !opacity-50 !cursor-not-allowed active:scale-100 hover:brightness-100;
 	}
-	
+
 	/* Icon Button: Size */
 	.btn-icon-sm {
 		@apply text-sm aspect-square w-[33px];

--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -63,6 +63,10 @@
 		@apply active:scale-[95%] active:brightness-90;
 	}
 
+	.btn-icon:disabled {
+		@apply !opacity-50 !cursor-not-allowed active:scale-100 hover:brightness-100;
+	}
+	
 	/* Icon Button: Size */
 	.btn-icon-sm {
 		@apply text-sm aspect-square w-[33px];

--- a/packages/plugin/src/styles/components/buttons.css
+++ b/packages/plugin/src/styles/components/buttons.css
@@ -25,7 +25,8 @@
 		@apply button-base-styles rounded-token active:scale-[95%] active:brightness-90;
 	}
 
-	.btn:disabled {
+	.btn:disabled,
+	.btn-icon:disabled {
 		@apply !opacity-50 !cursor-not-allowed active:scale-100 hover:brightness-100;
 	}
 
@@ -61,10 +62,6 @@
 		@apply rounded-full;
 		/* Active */
 		@apply active:scale-[95%] active:brightness-90;
-	}
-
-	.btn-icon:disabled {
-		@apply !opacity-50 !cursor-not-allowed active:scale-100 hover:brightness-100;
 	}
 
 	/* Icon Button: Size */


### PR DESCRIPTION
## Linked Issue

Closes #2058 

## Description

added disabled styling for the btn-icon class

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
- [x] Ensure Prettier linting is current - run pnpm format
