### PR TITLE
Bugfix/focustrap-on-listbox

### DIFF
--- a/.changeset/empty-trees-fetch.md
+++ b/.changeset/empty-trees-fetch.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: fixed focus trap escaping hidden inputs

--- a/.changeset/empty-trees-fetch.md
+++ b/.changeset/empty-trees-fetch.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: fixed focus trap escaping hidden inputs
+bugfix: fixed focusTrap escaping hidden inputs

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -1,6 +1,7 @@
 // Action: Focus Trap
 export function focusTrap(node: HTMLElement, enabled: boolean) {
-	const elemWhitelist = 'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
+	const elemWhitelist =
+		'a[href]:not([tabindex="-1"]), button:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), details:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
 	let elemFirst: HTMLElement;
 	let elemLast: HTMLElement;
 
@@ -14,6 +15,7 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 
 	// When the last item selected, tab pressed, jump to the first selectable item.
 	function onLastElemKeydown(e: KeyboardEvent): void {
+		console.log;
 		if (!e.shiftKey && e.code === 'Tab') {
 			e.preventDefault();
 			elemFirst.focus();

--- a/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
+++ b/packages/skeleton/src/lib/actions/FocusTrap/focusTrap.ts
@@ -15,7 +15,6 @@ export function focusTrap(node: HTMLElement, enabled: boolean) {
 
 	// When the last item selected, tab pressed, jump to the first selectable item.
 	function onLastElemKeydown(e: KeyboardEvent): void {
-		console.log;
 		if (!e.shiftKey && e.code === 'Tab') {
 			e.preventDefault();
 			elemFirst.focus();


### PR DESCRIPTION
## Linked Issue

Closes #1973

## Description

edited query to exclude all elements with `tabindex="-1"`


## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
