### PR TITLE
feat: export initialize stores for Modal, Toast and Drawer

### DIFF
--- a/.changeset/swift-turtles-compete.md
+++ b/.changeset/swift-turtles-compete.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: export initialize stores for Modal, Toast and Drawer

--- a/packages/skeleton/src/lib/index.ts
+++ b/packages/skeleton/src/lib/index.ts
@@ -18,9 +18,9 @@ export type { CssClasses, SvelteEvent } from './types.js';
 export { storeHighlightJs } from './utilities/CodeBlock/stores.js';
 export { storePopup } from './utilities/Popup/popup.js';
 export { tocStore } from './utilities/TableOfContents/stores.js';
-export { getDrawerStore } from './utilities/Drawer/stores.js';
-export { getModalStore } from './utilities/Modal/stores.js';
-export { getToastStore } from './utilities/Toast/stores.js';
+export { initializeDrawerStore, getDrawerStore } from './utilities/Drawer/stores.js';
+export { initializeModalStore, getModalStore } from './utilities/Modal/stores.js';
+export { initializeToastStore, getToastStore } from './utilities/Toast/stores.js';
 export { initializeStores } from './utilities/index.js';
 
 // Lightswitch


### PR DESCRIPTION
## Linked Issue

Closes #{issueNumber}

## Description

Export initialize stores for Modal, Toast and Drawer

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
