### PR TITLE
added missing import statement in appshell docs

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -226,6 +226,8 @@
 			<CodeBlock
 				language="ts"
 				code={`
+import { afterNavigate } from '$app/navigation';
+
 afterNavigate((params: any) => {
     const isNewPage: boolean = params.from && params.to && params.from.route.id !== params.to.route.id;
     const elemPage = document.querySelector('#page');


### PR DESCRIPTION
## Linked Issue

Closes #2040

## Description

Added import statement like suggested by @maehr 

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
