### PR TITLE
feat/input-chip-regions

### DIFF
--- a/.changeset/late-cherries-admire.md
+++ b/.changeset/late-cherries-admire.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+breaking: Added missing regions to Input-chip and changed css class `input-chip-interface` to `input-chip-wrapper`.

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -79,12 +79,12 @@
 	export let rounded: CssClasses = 'rounded-container-token';
 
 	// Props (regions)
-	/** Provide arbitrary classes to style the input field region. */
-	export let regionInputField: CssClasses = '';
-	/** Provide arbitrary classes to style the chip list region. */
-	export let regionChipList: CssClasses = '';
 	/** Provide arbitrary classes to style the chip wrapper region. */
 	export let regionChipWrapper: CssClasses = '';
+	/** Provide arbitrary classes to style the chip list region. */
+	export let regionChipList: CssClasses = '';
+	/** Provide arbitrary classes to style the input field region. */
+	export let regionInput: CssClasses = '';
 
 	// Props (transition)
 	/**
@@ -230,7 +230,7 @@
 	$: classesBase = `${cBase} ${padding} ${rounded} ${$$props.class ?? ''} ${classesInvalid}`;
 	$: classesChipWrapper = `${cChipWrapper} ${regionChipWrapper}`;
 	$: classesChipList = `${cChipList} ${regionChipList}`;
-	$: classesInputField = `${cInputField} ${regionInputField}`;
+	$: classesInputField = `${cInputField} ${regionInput}`;
 	$: chipValues =
 		value?.map((val, i) => {
 			if (chipValues[i]?.val === val) return chipValues[i];

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -78,6 +78,14 @@
 	/** Provide classes to set border radius styles. */
 	export let rounded: CssClasses = 'rounded-container-token';
 
+	// Props (regions)
+	/** Provide arbitrary classes to style the input field region. */
+	export let regionInputField: CssClasses = '';
+	/** Provide arbitrary classes to style the chip list region. */
+	export let regionChipList: CssClasses = '';
+	/** Provide arbitrary classes to style the chip list region. */
+	export let regionChipWrapper: CssClasses = '';
+
 	// Props (transition)
 	/**
 	 * Enable/Disable transitions
@@ -127,7 +135,7 @@
 
 	// Classes
 	const cBase = 'textarea cursor-pointer';
-	const cInterface = 'space-y-4';
+	const cChipWrapper = 'space-y-4';
 	const cChipList = 'flex flex-wrap gap-2';
 	const cInputField = 'unstyled bg-transparent border-0 !ring-0 p-0 w-full';
 
@@ -220,9 +228,9 @@
 	$: classesInvalid = inputValid === false ? invalid : '';
 	// Reactive
 	$: classesBase = `${cBase} ${padding} ${rounded} ${$$props.class ?? ''} ${classesInvalid}`;
-	$: classesInterface = `${cInterface}`;
-	$: classesChipList = `${cChipList}`;
-	$: classesInputField = `${cInputField}`;
+	$: classesChipWrapper = `${cChipWrapper} ${regionChipWrapper}`;
+	$: classesChipList = `${cChipList} ${regionChipList}`;
+	$: classesInputField = `${cInputField} ${regionInputField}`;
 	$: chipValues =
 		value?.map((val, i) => {
 			if (chipValues[i]?.val === val) return chipValues[i];
@@ -238,8 +246,8 @@
 			{#each value as option}<option value={option}>{option}</option>{/each}
 		</select>
 	</div>
-	<!-- Interface -->
-	<div class="input-chip-interface {classesInterface}">
+	<!-- Chip Wrapper -->
+	<div class="input-chip-wrapper {classesChipWrapper}">
 		<!-- Input Field -->
 		<form on:submit={addChip}>
 			<input

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -83,7 +83,7 @@
 	export let regionInputField: CssClasses = '';
 	/** Provide arbitrary classes to style the chip list region. */
 	export let regionChipList: CssClasses = '';
-	/** Provide arbitrary classes to style the chip list region. */
+	/** Provide arbitrary classes to style the chip wrapper region. */
 	export let regionChipWrapper: CssClasses = '';
 
 	// Props (transition)

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -230,7 +230,7 @@
 	$: classesBase = `${cBase} ${padding} ${rounded} ${$$props.class ?? ''} ${classesInvalid}`;
 	$: classesChipWrapper = `${cChipWrapper} ${regionChipWrapper}`;
 	$: classesChipList = `${cChipList} ${regionChipList}`;
-	$: classesInputField = `${cInputField} ${regionInput}`;
+	$: classesInput = `${cInputField} ${regionInput}`;
 	$: chipValues =
 		value?.map((val, i) => {
 			if (chipValues[i]?.val === val) return chipValues[i];
@@ -254,7 +254,7 @@
 				type="text"
 				bind:value={input}
 				placeholder={$$restProps.placeholder ?? 'Enter values...'}
-				class="input-chip-field {classesInputField}"
+				class="input-chip-field {classesInput}"
 				on:input={onInputHandler}
 				on:input
 				on:focus


### PR DESCRIPTION
## Linked Issue

Closes #2052

## Description

Added regions to input chip.
Changed css class from `input-chip-interface` to `input-chip-wrapper`.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
