### PR TITLE
Feat/improve progress radial

### DIFF
--- a/.changeset/little-dingos-repeat.md
+++ b/.changeset/little-dingos-repeat.md
@@ -1,6 +1,5 @@
 ---
-"skeleton.dev": patch
 "@skeletonlabs/skeleton": patch
 ---
 
-add roundedLineCap prop to progress radial
+feat: Added a `strokeLinecap` property to to Progress Radials, enabling rounded styling

--- a/.changeset/little-dingos-repeat.md
+++ b/.changeset/little-dingos-repeat.md
@@ -1,0 +1,6 @@
+---
+"skeleton.dev": patch
+"@skeletonlabs/skeleton": patch
+---
+
+add roundedLineCap prop to progress radial

--- a/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
+++ b/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
@@ -75,13 +75,13 @@
 	<!-- Draw SVG -->
 	<svg viewBox="0 0 {baseSize} {baseSize}" class="rounded-full" class:animate-spin={value === undefined}>
 		<!-- Track -->
-		<circle class="progress-radial-track {cBaseTrack} {track}" stroke-width={stroke} r={baseSize / 2} cx="50%" cy="50%" />
+		<circle class="progress-radial-track {cBaseTrack} {track}" stroke-width={stroke} r={baseSize / 2 - stroke / 2} cx="50%" cy="50%" />
 
 		<!-- Meter -->
 		<circle
 			class="progress-radial-meter {cBaseMeter} {meter}"
 			stroke-width={stroke}
-			r={baseSize / 2}
+			r={baseSize / 2 - stroke / 2}
 			cx="50%"
 			cy="50%"
 			style:stroke-dasharray="{circumference}

--- a/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
+++ b/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
@@ -15,6 +15,8 @@
 	export let stroke = 40; // px
 	/** Sets the base font size. Scales responsively. */
 	export let font = 56; // px
+	/** Sets whether the stoke-linecap of the radial is rounded or not */
+	export let roundedLineCap: boolean = false;
 
 	// Props (styles)
 	/** Provide classes to set the width. */
@@ -85,6 +87,7 @@
 			style:stroke-dasharray="{circumference}
 			{circumference}"
 			style:stroke-dashoffset={dashoffset}
+			stroke-linecap={roundedLineCap ? 'round' : 'butt'}
 		/>
 
 		<!-- Center Text -->

--- a/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
+++ b/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
@@ -39,7 +39,7 @@
 
 	// Calculated Values
 	const baseSize = 512; // px
-	const radius: number = baseSize / 2;
+	const radius: number = baseSize / 2 - stroke / 2;
 	let circumference: number = radius;
 	let dashoffset: number;
 
@@ -75,13 +75,13 @@
 	<!-- Draw SVG -->
 	<svg viewBox="0 0 {baseSize} {baseSize}" class="rounded-full" class:animate-spin={value === undefined}>
 		<!-- Track -->
-		<circle class="progress-radial-track {cBaseTrack} {track}" stroke-width={stroke} r={baseSize / 2 - stroke / 2} cx="50%" cy="50%" />
+		<circle class="progress-radial-track {cBaseTrack} {track}" stroke-width={stroke} r={radius} cx="50%" cy="50%" />
 
 		<!-- Meter -->
 		<circle
 			class="progress-radial-meter {cBaseMeter} {meter}"
 			stroke-width={stroke}
-			r={baseSize / 2 - stroke / 2}
+			r={radius}
 			cx="50%"
 			cy="50%"
 			style:stroke-dasharray="{circumference}

--- a/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
+++ b/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.svelte
@@ -15,8 +15,8 @@
 	export let stroke = 40; // px
 	/** Sets the base font size. Scales responsively. */
 	export let font = 56; // px
-	/** Sets whether the stoke-linecap of the radial is rounded or not */
-	export let roundedLineCap: boolean = false;
+	/** Sets the stoke-linecap value */
+	export let strokeLinecap: 'butt' | 'round' | 'square' = 'butt';
 
 	// Props (styles)
 	/** Provide classes to set the width. */
@@ -87,7 +87,7 @@
 			style:stroke-dasharray="{circumference}
 			{circumference}"
 			style:stroke-dashoffset={dashoffset}
-			stroke-linecap={roundedLineCap ? 'round' : 'butt'}
+			stroke-linecap={strokeLinecap}
 		/>
 
 		<!-- Center Text -->

--- a/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.test.ts
+++ b/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.test.ts
@@ -18,7 +18,8 @@ describe('ProgressRadial.svelte', () => {
 				meter: 'stroke-black dark:stroke-white',
 				color: 'fill-black dark:fill-white',
 				font: 56,
-				label: 'testProgressRadial1'
+				label: 'testProgressRadial1',
+				roundedLineCap: true,
 			}
 		});
 		expect(getByTestId('progress-radial')).toBeTruthy();

--- a/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.test.ts
+++ b/packages/skeleton/src/lib/components/ProgressRadial/ProgressRadial.test.ts
@@ -19,7 +19,7 @@ describe('ProgressRadial.svelte', () => {
 				color: 'fill-black dark:fill-white',
 				font: 56,
 				label: 'testProgressRadial1',
-				roundedLineCap: true,
+				roundedLineCap: true
 			}
 		});
 		expect(getByTestId('progress-radial')).toBeTruthy();

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -3,7 +3,7 @@
 	import { DocsFeature, type DocsShellSettings } from '$lib/layouts/DocsShell/types';
 	import DocsPreview from '$lib/components/DocsPreview/DocsPreview.svelte';
 	// Components
-	import { ProgressRadial, CodeBlock } from '@skeletonlabs/skeleton';
+	import { ProgressRadial, CodeBlock, SlideToggle } from '@skeletonlabs/skeleton';
 	// Sveld
 	import sveldProgressRadial from '@skeletonlabs/skeleton/components/ProgressRadial/ProgressRadial.svelte?raw&sveld';
 
@@ -20,7 +20,7 @@
 
 	// Reactive
 	$: props = { value: 50, max: 100, step: 10 };
-	$: strokeProps = { value: 100, max: 400, step: 20 };
+	$: strokeProps = { value: 100, max: 400, step: 20, roundedLineCap: true };
 </script>
 
 <DocsShell {settings}>
@@ -45,47 +45,48 @@
 		<section class="space-y-4">
 			<h2 class="h2">Styling</h2>
 			<p>
-				Use the <code class="code">stroke</code> <code class="code">meter</code> or <code class="code">track</code>properties to style the
+				Use the <code class="code">stroke</code> <code class="code">meter</code> <code class="code">track</code> or <code class="code">roundedLineCap</code> properties to style the
 				radial.
 			</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="w-full grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 text-center">
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-primary-500" track="stroke-primary-500/30" width="w-full" />
+							<ProgressRadial stroke={strokeProps.value} meter="stroke-primary-500" track="stroke-primary-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
 							<p>Primary</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-secondary-500" track="stroke-secondary-500/30" width="w-full" />
+							<ProgressRadial stroke={strokeProps.value} meter="stroke-secondary-500" track="stroke-secondary-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
 							<p>Secondary</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-tertiary-500" track="stroke-tertiary-500/30" width="w-full" />
+							<ProgressRadial stroke={strokeProps.value} meter="stroke-tertiary-500" track="stroke-tertiary-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
 							<p>Tertiary</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-success-500" track="stroke-success-500/30" width="w-full" />
+							<ProgressRadial stroke={strokeProps.value} meter="stroke-success-500" track="stroke-success-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
 							<p>Success</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-warning-500" track="stroke-warning-500/30" width="w-full" />
+							<ProgressRadial stroke={strokeProps.value} meter="stroke-warning-500" track="stroke-warning-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
 							<p>Warning</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-error-500" track="stroke-error-500/30" width="w-full" />
+							<ProgressRadial stroke={strokeProps.value} meter="stroke-error-500" track="stroke-error-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
 							<p>Error</p>
 						</div>
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<div class="w-48 mx-auto">
+					<div class="w-80 mx-auto flex">
 						<input type="range" min="20" max={strokeProps.max} step={strokeProps.step} bind:value={strokeProps.value} />
+						<SlideToggle class="ml-4" name="rounded" size="sm" bind:checked={strokeProps.roundedLineCap}>Rounded</SlideToggle>
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="html"
-						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" />`}
+						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" roundedLineCap={${strokeProps.roundedLineCap}} />`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -45,34 +45,76 @@
 		<section class="space-y-4">
 			<h2 class="h2">Styling</h2>
 			<p>
-				Use the <code class="code">stroke</code> <code class="code">meter</code> <code class="code">track</code> or <code class="code">roundedLineCap</code> properties to style the
-				radial.
+				Use the <code class="code">stroke</code> <code class="code">meter</code> <code class="code">track</code> or
+				<code class="code">roundedLineCap</code> properties to style the radial.
 			</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="w-full grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 text-center">
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-primary-500" track="stroke-primary-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
+							<ProgressRadial
+								stroke={strokeProps.value}
+								meter="stroke-primary-500"
+								track="stroke-primary-500/30"
+								width="w-full"
+								roundedLineCap={strokeProps.roundedLineCap}
+								value={50}
+							/>
 							<p>Primary</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-secondary-500" track="stroke-secondary-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
+							<ProgressRadial
+								stroke={strokeProps.value}
+								meter="stroke-secondary-500"
+								track="stroke-secondary-500/30"
+								width="w-full"
+								roundedLineCap={strokeProps.roundedLineCap}
+								value={50}
+							/>
 							<p>Secondary</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-tertiary-500" track="stroke-tertiary-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
+							<ProgressRadial
+								stroke={strokeProps.value}
+								meter="stroke-tertiary-500"
+								track="stroke-tertiary-500/30"
+								width="w-full"
+								roundedLineCap={strokeProps.roundedLineCap}
+								value={50}
+							/>
 							<p>Tertiary</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-success-500" track="stroke-success-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
+							<ProgressRadial
+								stroke={strokeProps.value}
+								meter="stroke-success-500"
+								track="stroke-success-500/30"
+								width="w-full"
+								roundedLineCap={strokeProps.roundedLineCap}
+								value={50}
+							/>
 							<p>Success</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-warning-500" track="stroke-warning-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
+							<ProgressRadial
+								stroke={strokeProps.value}
+								meter="stroke-warning-500"
+								track="stroke-warning-500/30"
+								width="w-full"
+								roundedLineCap={strokeProps.roundedLineCap}
+								value={50}
+							/>
 							<p>Warning</p>
 						</div>
 						<div class="p-4 space-y-2">
-							<ProgressRadial stroke={strokeProps.value} meter="stroke-error-500" track="stroke-error-500/30" width="w-full" roundedLineCap={strokeProps.roundedLineCap} value={50} />
+							<ProgressRadial
+								stroke={strokeProps.value}
+								meter="stroke-error-500"
+								track="stroke-error-500/30"
+								width="w-full"
+								roundedLineCap={strokeProps.roundedLineCap}
+								value={50}
+							/>
 							<p>Error</p>
 						</div>
 					</div>

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -20,7 +20,7 @@
 
 	// Reactive
 	$: props = { value: 50, max: 100, step: 10 };
-	$: strokeProps = { value: 100, max: 400, step: 20, strokeLinecap: 'butt' };
+	$: strokeProps = { value: 100, max: 400, step: 20 };
 	let strokeLinecap: 'butt' | 'round' | 'square' = 'butt';
 </script>
 

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -3,7 +3,7 @@
 	import { DocsFeature, type DocsShellSettings } from '$lib/layouts/DocsShell/types';
 	import DocsPreview from '$lib/components/DocsPreview/DocsPreview.svelte';
 	// Components
-	import { ProgressRadial, CodeBlock, SlideToggle } from '@skeletonlabs/skeleton';
+	import { ProgressRadial, CodeBlock } from '@skeletonlabs/skeleton';
 	// Sveld
 	import sveldProgressRadial from '@skeletonlabs/skeleton/components/ProgressRadial/ProgressRadial.svelte?raw&sveld';
 
@@ -20,7 +20,7 @@
 
 	// Reactive
 	$: props = { value: 50, max: 100, step: 10 };
-	$: strokeProps = { value: 100, max: 400, step: 20, roundedLineCap: true };
+	$: strokeProps = { value: 100, max: 400, step: 20, strokeLinecap: 'butt' };
 </script>
 
 <DocsShell {settings}>
@@ -45,8 +45,8 @@
 		<section class="space-y-4">
 			<h2 class="h2">Styling</h2>
 			<p>
-				Use the <code class="code">stroke</code> <code class="code">meter</code> <code class="code">track</code> or
-				<code class="code">roundedLineCap</code> properties to style the radial.
+				Use the <code class="code">meter</code>, or <code class="code">track</code>, <code class="code">stroke</code>,
+				<code class="code">strokeLinecap</code> properties to style the radial.
 			</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
@@ -57,7 +57,7 @@
 								meter="stroke-primary-500"
 								track="stroke-primary-500/30"
 								width="w-full"
-								roundedLineCap={strokeProps.roundedLineCap}
+								strokeLinecap={strokeProps.strokeLinecap}
 								value={50}
 							/>
 							<p>Primary</p>
@@ -68,7 +68,7 @@
 								meter="stroke-secondary-500"
 								track="stroke-secondary-500/30"
 								width="w-full"
-								roundedLineCap={strokeProps.roundedLineCap}
+								strokeLinecap={strokeProps.strokeLinecap}
 								value={50}
 							/>
 							<p>Secondary</p>
@@ -79,7 +79,7 @@
 								meter="stroke-tertiary-500"
 								track="stroke-tertiary-500/30"
 								width="w-full"
-								roundedLineCap={strokeProps.roundedLineCap}
+								strokeLinecap={strokeProps.strokeLinecap}
 								value={50}
 							/>
 							<p>Tertiary</p>
@@ -90,7 +90,7 @@
 								meter="stroke-success-500"
 								track="stroke-success-500/30"
 								width="w-full"
-								roundedLineCap={strokeProps.roundedLineCap}
+								strokeLinecap={strokeProps.strokeLinecap}
 								value={50}
 							/>
 							<p>Success</p>
@@ -101,7 +101,7 @@
 								meter="stroke-warning-500"
 								track="stroke-warning-500/30"
 								width="w-full"
-								roundedLineCap={strokeProps.roundedLineCap}
+								strokeLinecap={strokeProps.strokeLinecap}
 								value={50}
 							/>
 							<p>Warning</p>
@@ -112,7 +112,7 @@
 								meter="stroke-error-500"
 								track="stroke-error-500/30"
 								width="w-full"
-								roundedLineCap={strokeProps.roundedLineCap}
+								strokeLinecap={strokeProps.strokeLinecap}
 								value={50}
 							/>
 							<p>Error</p>
@@ -120,15 +120,21 @@
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="footer">
-					<div class="w-80 mx-auto flex">
-						<input type="range" min="20" max={strokeProps.max} step={strokeProps.step} bind:value={strokeProps.value} />
-						<SlideToggle class="ml-4" name="rounded" size="sm" bind:checked={strokeProps.roundedLineCap}>Rounded</SlideToggle>
+					<div class="flex justify-between items-center gap-4">
+						<div class="w-60">
+							<input type="range" min="20" max={strokeProps.max} step={strokeProps.step} bind:value={strokeProps.value} />
+						</div>
+						<select bind:value={strokeProps.strokeLinecap} class="select w-auto">
+							{#each ['butt', 'round', 'square'] as v}
+								<option value={v}>{v}</option>
+							{/each}
+						</select>
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="html"
-						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" roundedLineCap={${strokeProps.roundedLineCap}} />`}
+						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap={${strokeProps.strokeLinecap}} />`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -21,6 +21,7 @@
 	// Reactive
 	$: props = { value: 50, max: 100, step: 10 };
 	$: strokeProps = { value: 100, max: 400, step: 20, strokeLinecap: 'butt' };
+	let strokeLinecap: 'butt' | 'round' | 'square' = 'butt';
 </script>
 
 <DocsShell {settings}>
@@ -57,7 +58,7 @@
 								meter="stroke-primary-500"
 								track="stroke-primary-500/30"
 								width="w-full"
-								strokeLinecap={strokeProps.strokeLinecap}
+								{strokeLinecap}
 								value={50}
 							/>
 							<p>Primary</p>
@@ -68,7 +69,7 @@
 								meter="stroke-secondary-500"
 								track="stroke-secondary-500/30"
 								width="w-full"
-								strokeLinecap={strokeProps.strokeLinecap}
+								{strokeLinecap}
 								value={50}
 							/>
 							<p>Secondary</p>
@@ -79,7 +80,7 @@
 								meter="stroke-tertiary-500"
 								track="stroke-tertiary-500/30"
 								width="w-full"
-								strokeLinecap={strokeProps.strokeLinecap}
+								{strokeLinecap}
 								value={50}
 							/>
 							<p>Tertiary</p>
@@ -90,7 +91,7 @@
 								meter="stroke-success-500"
 								track="stroke-success-500/30"
 								width="w-full"
-								strokeLinecap={strokeProps.strokeLinecap}
+								{strokeLinecap}
 								value={50}
 							/>
 							<p>Success</p>
@@ -101,7 +102,7 @@
 								meter="stroke-warning-500"
 								track="stroke-warning-500/30"
 								width="w-full"
-								strokeLinecap={strokeProps.strokeLinecap}
+								{strokeLinecap}
 								value={50}
 							/>
 							<p>Warning</p>
@@ -112,7 +113,7 @@
 								meter="stroke-error-500"
 								track="stroke-error-500/30"
 								width="w-full"
-								strokeLinecap={strokeProps.strokeLinecap}
+								{strokeLinecap}
 								value={50}
 							/>
 							<p>Error</p>
@@ -124,7 +125,7 @@
 						<div class="w-60">
 							<input type="range" min="20" max={strokeProps.max} step={strokeProps.step} bind:value={strokeProps.value} />
 						</div>
-						<select bind:value={strokeProps.strokeLinecap} class="select w-auto">
+						<select bind:value={strokeLinecap} class="select w-auto">
 							{#each ['butt', 'round', 'square'] as v}
 								<option value={v}>{v}</option>
 							{/each}
@@ -134,7 +135,7 @@
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="html"
-						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap={${strokeProps.strokeLinecap}} />`}
+						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap={${strokeLinecap}} />`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>


### PR DESCRIPTION
## Linked Issue

Closes https://github.com/skeletonlabs/skeleton/issues/2092

## Description

Introduces a new prop `roundedLineCap` that allows customization of the progress radial. Renaming the prop is welcome.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`. - Done ✅

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
