### PR TITLE
Supporting RTL layout in Accordion component

### DIFF
--- a/.changeset/modern-bags-join.md
+++ b/.changeset/modern-bags-join.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore:RTL compatibility in Accordion component

--- a/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
+++ b/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
@@ -37,7 +37,7 @@
 
 	// Classes
 	const cBase = '';
-	const cControl = 'text-left w-full flex items-center space-x-4';
+	const cControl = 'text-start w-full flex items-center space-x-4';
 	const cControlCaret = 'fill-current w-3 transition-transform duration-[200ms]';
 	const cPanel = '';
 


### PR DESCRIPTION
## Description

Using `text-start` instead of `text-left`

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
