### PR TITLE
docs: Added `vite-plugin-tailwind-purgecss` to the docs site

### DIFF
--- a/sites/skeleton.dev/package.json
+++ b/sites/skeleton.dev/package.json
@@ -49,6 +49,7 @@
 		"tslib": "^2.5.3",
 		"typescript": "^5.0.3",
 		"vite": "^4.3.9",
+		"vite-plugin-tailwind-purgecss": "^0.1.3",
 		"vitest": "^0.32.0"
 	},
 	"type": "module"

--- a/sites/skeleton.dev/pnpm-lock.yaml
+++ b/sites/skeleton.dev/pnpm-lock.yaml
@@ -92,6 +92,9 @@ devDependencies:
   vite:
     specifier: ^4.3.9
     version: 4.3.9(@types/node@20.1.4)
+  vite-plugin-tailwind-purgecss:
+    specifier: ^0.1.3
+    version: 0.1.3(vite@4.3.9)
   vitest:
     specifier: ^0.32.0
     version: 0.32.0
@@ -601,6 +604,10 @@ packages:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
 
+  /@types/estree@1.0.2:
+    resolution: {integrity: sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==}
+    dev: true
+
   /@types/json-schema@7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
@@ -1089,6 +1096,11 @@ packages:
     hasBin: true
     dev: true
 
+  /commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+    dev: true
+
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1422,6 +1434,12 @@ packages:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
 
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.2
+    dev: true
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1583,6 +1601,17 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
+
+  /glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
     dev: true
 
   /globals@13.20.0:
@@ -1906,6 +1935,13 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
     dev: true
 
   /minimatch@9.0.3:
@@ -2297,6 +2333,16 @@ packages:
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
+    dev: true
+
+  /purgecss@6.0.0-alpha.0:
+    resolution: {integrity: sha512-UC7d7uIyZsky+srEsSXny9BkbTcVn3ZtBCNX3rW3DsqJKhvUXFRpufA4ktcHzWF0+JLZgmsqjUm/8R82x9bHpw==}
+    hasBin: true
+    dependencies:
+      commander: 10.0.1
+      glob: 8.1.0
+      postcss: 8.4.24
+      postcss-selector-parser: 6.0.12
     dev: true
 
   /query-string@8.1.0:
@@ -3057,6 +3103,16 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vite-plugin-tailwind-purgecss@0.1.3(vite@4.3.9):
+    resolution: {integrity: sha512-VVz9fwKBEEFSbj/rKxtwtczvoSrIqbzbo6S+MT7gH0CsmKNwlx947VMoV8B085ocxGCuFlddOPRDszNXLi2nTQ==}
+    peerDependencies:
+      vite: ^4.1.1
+    dependencies:
+      estree-walker: 3.0.3
+      purgecss: 6.0.0-alpha.0
+      vite: 4.3.9(@types/node@20.1.4)
     dev: true
 
   /vite@4.3.9(@types/node@20.1.4):

--- a/sites/skeleton.dev/vite.config.ts
+++ b/sites/skeleton.dev/vite.config.ts
@@ -1,4 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import { purgeCss } from 'vite-plugin-tailwind-purgecss';
 import type { UserConfig } from 'vite';
 import skeletonPluginWatcher from './vite-plugin-skeleton-plugin-watcher';
 import sveld from './vite-plugin-sveld';
@@ -9,7 +10,17 @@ const json = readFileSync('../../packages/skeleton/package.json', 'utf8');
 const pkg = JSON.parse(json);
 
 const config: UserConfig = {
-	plugins: [sveltekit(), sveld(), skeletonPluginWatcher()],
+	plugins: [
+		sveltekit(),
+		sveld(),
+		skeletonPluginWatcher(),
+		purgeCss({
+			safelist: {
+				// any selectors that begin with "hljs-" will not be purged
+				greedy: [/^hljs-/]
+			}
+		})
+	],
 	define: {
 		__PACKAGE__: pkg
 	}


### PR DESCRIPTION
## Description

#### WITHOUT the plugin:
```
assets/0.3cb19104.css                                           236.36 kB │ gzip:  32.18 kB
```

#### WITH the plugin:
```
assets/0.3cb19104.css                                           197.45 kB │ gzip:  27.86 kB
```

---

The reduction is even more dramatic if we also purge the icon related stylesheets as part of #2114:

#### WITHOUT the plugin:
```
assets/0.99bb4257.css                                           329.71 kB │ gzip:  54.57 kB
```

#### WITH the plugin:
```
assets/0.99bb4257.css                                           202.99 kB │ gzip:  29.57 kB
```

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [X] This PR targets the `dev` branch (NEVER `master`)
- [X] Documentation reflects all relevant changes
- [X] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [X] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [X] Ensure Prettier linting is current - run `pnpm format`
- [X] All test cases are passing - run `pnpm test`
- [X] Includes a changeset (if relevant; see above)
