### PR TITLE
add popup warning

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/popups/+page.svelte
@@ -177,49 +177,6 @@ const popupFeatured: PopupSettings = {
 
 	<!-- Slot: Usage -->
 	<svelte:fragment slot="usage">
-		<aside class="flex flex-col items-start gap-2 alert alert-message variant-ghost-warning">
-			<p>
-				It is important not to override any of the css selector for the initial popup display. Below is the css. 
-			</p>
-			<CodeBlock
-				language="css"
-				code={`
-[data-popup] {
-	position: absolute;
-	top: 0;
-	left: 0;
-	display: none;
-	transition-property: opacity;
-	transition-timing-function: cubic-bezier(.4,0,.2,1);
-	transition-duration: .15s
-}
-		`}
-			/>
-			<p>
-				If you were to use for
-				example a div with class <code class="code">flex</code> it would override the display property and not hide the popup on first load.
-			</p>
-			<p>Works ✅</p>
-			<CodeBlock
-				language="css"
-				code={`
-<div data-popup="popupClick">
-	<div class="flex">
-		Popup
-	</div>
-</div>
-			`}
-			/>
-			<p>Breaks ❌</p>
-			<CodeBlock
-				language="css"
-				code={`
-<div class="flex" data-popup="popupClick">
-	Popup
-</div>
-			`}
-			/>
-		</aside>
 		<!-- Installation -->
 		<section class="space-y-4">
 			<div class="flex items-center space-x-2">
@@ -679,6 +636,50 @@ const popupCombobox: PopupSettings = {
 		</section>
 
 		<hr />
+
+		<section class="space-y-4">
+			<h2 class="h2">Avoiding Style Conflicts</h2>
+			<p>
+				Please use caution when adjusting the default styling for the <code class="code">[data-popup]</code> element. Specifically in regards
+				to the inherent display, position, and transition properties. These are critical for ensuring the popup loads and displays as expected.
+			</p>
+			<CodeBlock
+				language="css"
+				code={`
+[data-popup] {
+	/* Display */
+	display: none;
+	/* Position */
+	position: absolute;
+	top: 0;
+	left: 0;
+	/* Transitions */
+	transition-property: opacity;
+	transition-timing-function: cubic-bezier(.4,0,.2,1);
+	transition-duration: .15s
+}
+		`}
+			/>
+			<p>Use a child element to introduce new classes and avoid overwriting default values.</p>
+			<CodeBlock
+				language="html"
+				code={`
+<!-- Works ✅ -->
+<div data-popup="popupStyled">
+	<div class="flex">...</div>
+</div>
+			`}
+			/>
+			<CodeBlock
+				language="html"
+				code={`
+<!-- Breaks ❌ -->
+<div class="flex" data-popup="popupStyled">
+	...
+</div>
+			`}
+			/>
+		</section>
 
 		<!-- Z-index -->
 		<section class="space-y-4">

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/popups/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/popups/+page.svelte
@@ -177,6 +177,49 @@ const popupFeatured: PopupSettings = {
 
 	<!-- Slot: Usage -->
 	<svelte:fragment slot="usage">
+		<aside class="flex flex-col items-start gap-2 alert alert-message variant-ghost-warning">
+			<p>
+				It is important not to override any of the css selector for the initial popup display. Below is the css. 
+			</p>
+			<CodeBlock
+				language="css"
+				code={`
+[data-popup] {
+	position: absolute;
+	top: 0;
+	left: 0;
+	display: none;
+	transition-property: opacity;
+	transition-timing-function: cubic-bezier(.4,0,.2,1);
+	transition-duration: .15s
+}
+		`}
+			/>
+			<p>
+				If you were to use for
+				example a div with class <code class="code">flex</code> it would override the display property and not hide the popup on first load.
+			</p>
+			<p>Works ✅</p>
+			<CodeBlock
+				language="css"
+				code={`
+<div data-popup="popupClick">
+	<div class="flex">
+		Popup
+	</div>
+</div>
+			`}
+			/>
+			<p>Breaks ❌</p>
+			<CodeBlock
+				language="css"
+				code={`
+<div class="flex" data-popup="popupClick">
+	Popup
+</div>
+			`}
+			/>
+		</aside>
 		<!-- Installation -->
 		<section class="space-y-4">
 			<div class="flex items-center space-x-2">


### PR DESCRIPTION
## Linked Issue

Closes #2148

## Description

I was stuck for a while on this and finally realized that it was just the display override because of using flex on the `[data-popup]` div.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
