### PR TITLE
chore: added logic to enable 0 in table cells

### DIFF
--- a/packages/skeleton/src/lib/components/Table/Table.svelte
+++ b/packages/skeleton/src/lib/components/Table/Table.svelte
@@ -99,7 +99,7 @@
 							aria-colindex={cellIndex + 1}
 							tabindex={cellIndex === 0 ? 0 : -1}
 						>
-							{@html cell === "0" ? cell : (cell ? cell : '-')}
+							{@html Number(cell) === 0 ? cell : (cell ? cell : '-')}
 						</td>
 					{/each}
 				</tr>

--- a/packages/skeleton/src/lib/components/Table/Table.svelte
+++ b/packages/skeleton/src/lib/components/Table/Table.svelte
@@ -99,7 +99,7 @@
 							aria-colindex={cellIndex + 1}
 							tabindex={cellIndex === 0 ? 0 : -1}
 						>
-							{@html cell ? cell : '-'}
+							{@html cell === "0" ? cell : (cell ? cell : '-')}
 						</td>
 					{/each}
 				</tr>


### PR DESCRIPTION
## Linked Issue

Closes #2147

## Description

The integer 0 should not be replaced with '-'. in Table cells This PR aims to fix that. 

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check` 
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test` 
- [x] Includes a changeset (if relevant; see above)

