### PR TITLE
PurgeCSS config updated to allow Carbon ads

### DIFF
--- a/sites/skeleton.dev/vite.config.ts
+++ b/sites/skeleton.dev/vite.config.ts
@@ -16,7 +16,7 @@ const config: UserConfig = {
 		skeletonPluginWatcher(),
 		purgeCss({
 			safelist: {
-				// Allow any selectors that match the following conditions:
+				// Allow selectors with a regex match:
 				greedy: [
 					// Used for Highlight.js (code blocks)
 					/^hljs-/,

--- a/sites/skeleton.dev/vite.config.ts
+++ b/sites/skeleton.dev/vite.config.ts
@@ -16,8 +16,13 @@ const config: UserConfig = {
 		skeletonPluginWatcher(),
 		purgeCss({
 			safelist: {
-				// any selectors that begin with "hljs-" will not be purged
-				greedy: [/^hljs-/]
+				// Allow any selectors that match the following conditions:
+				greedy: [
+					// Used for Highlight.js (code blocks)
+					/^hljs-/,
+					// Used for Carbon ad styles
+					/carbonads/
+				]
 			}
 		})
 	],


### PR DESCRIPTION
## Linked Issue

Closes #2156

## Description

PurgeCSS config updated to allow Carbon ads

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
