### PR TITLE
docs: strong types for `AppShell` scroll-to-top

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -226,10 +226,11 @@
 			<CodeBlock
 				language="ts"
 				code={`
+import type { AfterNavigate } from '@sveltejs/kit';
 import { afterNavigate } from '$app/navigation';
 
-afterNavigate((params: any) => {
-    const isNewPage: boolean = params.from && params.to && params.from.route.id !== params.to.route.id;
+afterNavigate((params: AfterNavigate) => {
+    const isNewPage: boolean = params.from?.route.id !== params.to?.route.id;
     const elemPage = document.querySelector('#page');
     if (isNewPage && elemPage !== null) {
         elemPage.scrollTop = 0;


### PR DESCRIPTION
## Description

This PR removes an explicit `any` type from the AppShell scroll to top docs, and substitutes the proper type from sveltekit. 

Also use optional chaining to simplify the checks for `isNewPage`

## Changsets

No changeset added since this is a docs only change.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
