### PR TITLE
Bugfix/tree view flow bugs

### DIFF
--- a/.changeset/gold-ads-flash.md
+++ b/.changeset/gold-ads-flash.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: fixed tree-view bug preventing clicking tree elements.

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-
 	import { createEventDispatcher, setContext } from 'svelte';
 
 	// Types

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
@@ -106,6 +106,6 @@
 	aria-disabled={disabled}
 >
 	{#if nodes && nodes.length > 0}
-		<RecursiveTreeViewItem {nodes} bind:expandedNodes bind:disabledNodes bind:checkedNodes bind:indeterminateNodes/>
+		<RecursiveTreeViewItem {nodes} bind:expandedNodes bind:disabledNodes bind:checkedNodes bind:indeterminateNodes />
 	{/if}
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
+	import { setContext, tick } from 'svelte';
 
 	// Types
 	import type { CssClasses, TreeViewNode } from '../../index.js';
@@ -106,6 +106,6 @@
 	aria-disabled={disabled}
 >
 	{#if nodes && nodes.length > 0}
-		<RecursiveTreeViewItem {nodes} bind:expandedNodes bind:disabledNodes bind:checkedNodes bind:indeterminateNodes />
+		<RecursiveTreeViewItem {nodes} bind:expandedNodes bind:disabledNodes bind:checkedNodes bind:indeterminateNodes/>
 	{/if}
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
@@ -2,7 +2,7 @@
 	import TreeViewItem from './TreeViewItem.svelte';
 	import RecursiveTreeViewItem from './RecursiveTreeViewItem.svelte';
 	import type { TreeViewNode } from './types.js';
-	import { getContext, onMount, tick } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 
 	// this can't be passed using context, since we have to pass it to recursive children.
 	/** Provide data-driven nodes. */
@@ -34,12 +34,10 @@
 	let multiple: boolean = getContext('multiple');
 	let relational: boolean = getContext('relational');
 
-	let tempCheckedNodes: string[] = [];
-
 	// Locals
-	let group: unknown;
+	let group: unknown = multiple ? [] : '';
 	let name = '';
-
+	
 	function toggleNode(node: TreeViewNode, open: boolean) {
 		// toggle only nodes with children
 		if (!node.children?.length) return;
@@ -90,33 +88,23 @@
 		}
 	}
 
-	// init check flow will messup the checked nodes, so we save it to reassign it onMount.
-	tempCheckedNodes = [...checkedNodes];
+	if(selection && multiple) {
+		nodes.forEach(node => {
+			if(!Array.isArray(group)) return;
+			if(checkedNodes.includes(node.id) && !group.includes(node.id)) {
+				group.push(node.id);
+			}
+		});
+		group = group;
+	}
+
 	onMount(async () => {
 		if (selection) {
 			// random number as name
 			name = String(Math.random());
 
-			// init groups if not initialized yet
-			if (group === undefined) {
-				if (multiple) {
-					group = [];
-					nodes.forEach((node) => {
-						if (checkedNodes.includes(node.id) && Array.isArray(group)) group.push(node.id);
-					});
-					group = group;
-				} else if (!nodes.some((node) => checkedNodes.includes(node.id))) {
-					group = '';
-				}
-			}
-
 			// remove relational links
 			if (!relational) treeItems = [];
-
-			// reassign checkNodes to ensure component starting with the correct check values.
-			checkedNodes = [];
-			await tick();
-			checkedNodes = [...tempCheckedNodes];
 		}
 	});
 

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
@@ -37,7 +37,7 @@
 	// Locals
 	let group: unknown = multiple ? [] : '';
 	let name = '';
-	
+
 	function toggleNode(node: TreeViewNode, open: boolean) {
 		// toggle only nodes with children
 		if (!node.children?.length) return;
@@ -88,10 +88,10 @@
 		}
 	}
 
-	if(selection && multiple) {
-		nodes.forEach(node => {
-			if(!Array.isArray(group)) return;
-			if(checkedNodes.includes(node.id) && !group.includes(node.id)) {
+	if (selection && multiple) {
+		nodes.forEach((node) => {
+			if (!Array.isArray(group)) return;
+			if (checkedNodes.includes(node.id) && !group.includes(node.id)) {
 				group.push(node.id);
 			}
 		});

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
@@ -88,14 +88,22 @@
 		}
 	}
 
-	if (selection && multiple) {
-		nodes.forEach((node) => {
-			if (!Array.isArray(group)) return;
-			if (checkedNodes.includes(node.id) && !group.includes(node.id)) {
-				group.push(node.id);
-			}
-		});
-		group = group;
+	if (selection) {
+		if (multiple) {
+			nodes.forEach((node) => {
+				if (!Array.isArray(group)) return;
+				if (checkedNodes.includes(node.id) && !group.includes(node.id)) {
+					group.push(node.id);
+				}
+			});
+			group = group;
+		} else {
+			nodes.forEach((node) => {
+				if (checkedNodes.includes(node.id) && group !== node.id) {
+					group = node.id;
+				}
+			});
+		}
 	}
 
 	onMount(async () => {

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -114,11 +114,10 @@
 				group = group;
 			}
 		}
-		if(!indeterminate) {
+		if (!indeterminate) {
 			onParentChange();
 		}
 	}
-
 
 	$: if (!multiple) updateRadio(group);
 	$: if (!multiple) updateRadioGroup(checked);
@@ -223,7 +222,7 @@
 			child.onParentChange();
 		});
 	}
-	
+
 	// used to update children of item when checked / unchecked in single mode
 	$: if (!multiple && group !== undefined) {
 		if (group !== value) {

--- a/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/TreeViewItem.svelte
@@ -93,20 +93,12 @@
 	// REPL: https://svelte.dev/repl/de117399559f4e7e9e14e2fc9ab243cc?version=3.12.1
 	$: if (multiple) updateCheckbox(group, indeterminate);
 	$: if (multiple) updateGroup(checked, indeterminate);
-	$: if (!multiple) updateRadio(group);
-	$: if (!multiple) updateRadioGroup(checked);
-	let initUpdate = true;
 	function updateCheckbox(group: unknown, indeterminate: boolean) {
 		if (!Array.isArray(group)) return;
 		checked = group.indexOf(value) >= 0;
 		/** @event {{checked: boolean, indeterminate: boolean}} groupChange - Fires when the group changes */
 		dispatch('groupChange', { checked: checked, indeterminate: indeterminate });
 		dispatch('childChange');
-		// called only once when initializing to apply default checks
-		if (initUpdate) {
-			onParentChange();
-			initUpdate = false;
-		}
 	}
 	function updateGroup(checked: boolean, indeterminate: boolean) {
 		if (!Array.isArray(group)) return;
@@ -115,19 +107,21 @@
 			if (index < 0) {
 				group.push(value);
 				group = group;
-				// called only when the group changes
-				onParentChange();
 			}
 		} else {
 			if (index >= 0) {
 				group.splice(index, 1);
 				group = group;
-				// called only when the group changes
-				onParentChange();
 			}
+		}
+		if(!indeterminate) {
+			onParentChange();
 		}
 	}
 
+
+	$: if (!multiple) updateRadio(group);
+	$: if (!multiple) updateRadioGroup(checked);
 	function updateRadio(group: unknown) {
 		checked = group === value;
 		/** @event {{checked: boolean, indeterminate: boolean}} groupChange - Fires when the group changes */
@@ -229,7 +223,7 @@
 			child.onParentChange();
 		});
 	}
-
+	
 	// used to update children of item when checked / unchecked in single mode
 	$: if (!multiple && group !== undefined) {
 		if (group !== value) {

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -72,9 +72,9 @@
 
 	let expandedNodes: string[] = [];
 	let disabledNodes: string[] = ['programming'];
-	let singleCheckedNodes: string[] = [];
+	let singleCheckedNodes: string[] = ['programming'];
 	let multiCheckedNodes: string[] = ['javascript'];
-	let indeterminateNodes: string[] = [];
+	let indeterminateNodes: string[] = ['programming', 'language'];
 </script>
 
 <DocsShell {settings}>
@@ -761,7 +761,7 @@ let disabledNodes : string[] = [];
 						language="ts"
 						code={`
 let myTreeViewNodes: TreeViewNode[] = //...
-let checkedNodes : string[] = [];
+let checkedNodes : string[] = ['programming'];
 						`}
 					/>
 					<CodeBlock
@@ -796,8 +796,8 @@ let checkedNodes : string[] = [];
 						language="ts"
 						code={`
 let myTreeViewNodes: TreeViewNode[] = //...
-let checkedNodes : string[] = [];
-let indeterminateNodes : string[] = [];
+let checkedNodes : string[] = ['javascript'];
+let indeterminateNodes : string[] = ['programming', 'language'];
 						`}
 					/>
 					<CodeBlock


### PR DESCRIPTION
## Linked Issue

Closes #2145
Closes #2144

## Description

@endigo9740 

FYI, I didn't go with the readonly-way (it is too complicated and I will have to invent svelte5 inside a component which is not realistic), instead of that the component now just expects a correct array in relational mode when changing the checkedNodes programmatically,
this means when the user wants to check a child programmatically, the user must also include its parent in the checkedNodes array etc..., this makes managing the relations a lot easier (no more magic needed) but it let's the user shoot their foots if they wanted to 😄.

@Sarenor If this PR get's accepted, I expect you to answer a ton of questions on the behaviour above so I wanted to mention you as well 😅 


## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
