### PR TITLE
Docs/ Nav List example for highlighting to match main Nav List example

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
@@ -183,7 +183,7 @@
 	<ul>
 		<li>
 			<a href="/elements/lists">
-				<span class="badge bg-primary-500">💀</span>
+				<span class="badge bg-primary-500">📋</span>
 				<span class="flex-auto">Skeleton</span>
 			</a>
 		</li>
@@ -200,14 +200,14 @@
 				language="html"
 				code={`
 <nav class="list-nav">
-	<ul>
-		<li>
-			<a href="/elements/lists" class={classesActive(href="/elements/lists")}>
-				<span class="badge bg-primary-500">💀</span>
-				<span class="flex-auto">Skeleton</span>
-			</a>
-		</li>
-	</ul>
+    <ul>
+        <li>
+            <a href="/elements/lists" class={classesActive("/elements/lists")}>
+                <span class="badge bg-primary-500">📋</span>
+                <span class="flex-auto">Lists</span>
+            </a>
+        </li>
+    </ul>
 </nav>
 `}
 			/>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
@@ -196,7 +196,18 @@
 			</DocsPreview>
 			<p>To highlight active state, we recommend conditionally applying a background color to the anchor tag.</p>
 			<CodeBlock language="ts" code={`$: classesActive = (href: string) => (href === $page.url.pathname ? '!bg-primary-500' : '');`} />
-			<CodeBlock language="html" code={`<a {href} class="{classesActive(href)}">Page</a>`} />
+			<CodeBlock language="html" code={`
+<nav class="list-nav">
+	<ul>
+		<li>
+			<a href="/elements/lists" class={classesActive(href="/elements/lists")}>
+				<span class="badge bg-primary-500">💀</span>
+				<span class="flex-auto">Skeleton</span>
+			</a>
+		</li>
+	</ul>
+</nav>
+`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
@@ -196,7 +196,9 @@
 			</DocsPreview>
 			<p>To highlight active state, we recommend conditionally applying a background color to the anchor tag.</p>
 			<CodeBlock language="ts" code={`$: classesActive = (href: string) => (href === $page.url.pathname ? '!bg-primary-500' : '');`} />
-			<CodeBlock language="html" code={`
+			<CodeBlock
+				language="html"
+				code={`
 <nav class="list-nav">
 	<ul>
 		<li>
@@ -207,7 +209,8 @@
 		</li>
 	</ul>
 </nav>
-`} />
+`}
+			/>
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
@@ -183,7 +183,7 @@
 	<ul>
 		<li>
 			<a href="/elements/lists">
-				<span class="badge bg-primary-500">📋</span>
+				<span class="badge bg-primary-500">(icon)</span>
 				<span class="flex-auto">Skeleton</span>
 			</a>
 		</li>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
@@ -196,21 +196,7 @@
 			</DocsPreview>
 			<p>To highlight active state, we recommend conditionally applying a background color to the anchor tag.</p>
 			<CodeBlock language="ts" code={`$: classesActive = (href: string) => (href === $page.url.pathname ? '!bg-primary-500' : '');`} />
-			<CodeBlock
-				language="html"
-				code={`
-<nav class="list-nav">
-    <ul>
-        <li>
-            <a href="/elements/lists" class={classesActive("/elements/lists")}>
-                <span class="badge bg-primary-500">📋</span>
-                <span class="flex-auto">Lists</span>
-            </a>
-        </li>
-    </ul>
-</nav>
-`}
-			/>
+			<CodeBlock language="html" code={`<a href={href} class="{classesActive(href)}">Page</a>`} />
 		</section>
 	</svelte:fragment>
 </DocsShell>


### PR DESCRIPTION
## Description
I struggled a bit understanding the Skeleton.dev > Explore > Tailwind > Lists > Nav List for highlighting. As a newbie I was unfamiliar with the shorthand format it was written in, and after searching Discord for that the `{href}` was shorthand for how it would be written inside a loop. This makes sense, but was a bit unclear as someone newer.

So I suggest changing the highlighting example to match the main Nav List example just above the highlighting example. 

Dominik and Niktek helped with some pointers in the Discord channel, as well as suggesting changing the icons.

{description}

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
