### PR TITLE
Feat/tree-view-minor-features

### DIFF
--- a/.changeset/polite-walls-repair.md
+++ b/.changeset/polite-walls-repair.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Added recursive tree-view enhancements including:
+- Added `click` and `toggle` events.
+- `lead` and `content` props now accepts Svelte components in addition to HTML content.

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
@@ -98,7 +98,16 @@
 
 	function onClick(event: CustomEvent<{ id: string }>) {
 		/** @event {{id:string}} click - Fires on tree item click */
-		dispatch('click', event);
+		dispatch('click', {
+			id: event.detail.id
+		});
+	}
+
+	function onToggle(event: CustomEvent<{ id: string }>) {
+		/** @event {{id:string}} toggle - Fires on tree item toggle */
+		dispatch('toggle', {
+			id: event.detail.id
+		});
 	}
 
 	// Reactive
@@ -114,6 +123,14 @@
 	aria-disabled={disabled}
 >
 	{#if nodes && nodes.length > 0}
-		<RecursiveTreeViewItem {nodes} bind:expandedNodes bind:disabledNodes bind:checkedNodes bind:indeterminateNodes on:click={onClick} />
+		<RecursiveTreeViewItem
+			{nodes}
+			bind:expandedNodes
+			bind:disabledNodes
+			bind:checkedNodes
+			bind:indeterminateNodes
+			on:click={onClick}
+			on:toggle={onToggle}
+		/>
 	{/if}
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setContext } from 'svelte';
+	import { createEventDispatcher, setContext } from 'svelte';
 
 	// Types
 	import type { CssClasses, TreeViewNode } from '../../index.js';
@@ -93,6 +93,14 @@
 	setContext('regionSymbol', regionSymbol);
 	setContext('regionChildren', regionChildren);
 
+	// events
+	const dispatch = createEventDispatcher();
+
+	function onClick(event: CustomEvent<{ id: string }>) {
+		/** @event {{id:string}} click - Fires on tree item click */
+		dispatch('click', event);
+	}
+
 	// Reactive
 	$: classesBase = `${width} ${spacing} ${$$props.class ?? ''}`;
 </script>
@@ -106,6 +114,6 @@
 	aria-disabled={disabled}
 >
 	{#if nodes && nodes.length > 0}
-		<RecursiveTreeViewItem {nodes} bind:expandedNodes bind:disabledNodes bind:checkedNodes bind:indeterminateNodes />
+		<RecursiveTreeViewItem {nodes} bind:expandedNodes bind:disabledNodes bind:checkedNodes bind:indeterminateNodes on:click={onClick} />
 	{/if}
 </div>

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
@@ -2,7 +2,7 @@
 	import TreeViewItem from './TreeViewItem.svelte';
 	import RecursiveTreeViewItem from './RecursiveTreeViewItem.svelte';
 	import type { TreeViewNode } from './types.js';
-	import { getContext, onMount, tick } from 'svelte';
+	import { createEventDispatcher, getContext, onMount, tick } from 'svelte';
 
 	// this can't be passed using context, since we have to pass it to recursive children.
 	/** Provide data-driven nodes. */
@@ -39,6 +39,9 @@
 	// Locals
 	let group: unknown;
 	let name = '';
+
+	// events
+	const dispatch = createEventDispatcher();
 
 	function toggleNode(node: TreeViewNode, open: boolean) {
 		// toggle only nodes with children
@@ -141,6 +144,10 @@
 			indeterminate={indeterminateNodes.includes(node.id)}
 			on:toggle={(e) => toggleNode(node, e.detail.open)}
 			on:groupChange={(e) => checkNode(node, e.detail.checked, e.detail.indeterminate)}
+			on:click={() =>
+				dispatch('click', {
+					id: node.id
+				})}
 		>
 			{@html node.content}
 			<svelte:fragment slot="lead">

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
@@ -148,6 +148,11 @@
 				dispatch('click', {
 					id: node.id
 				})}
+			on:toggle={() => {
+				dispatch('toggle', {
+					id: node.id
+				});
+			}}
 		>
 			{@html node.content}
 			<svelte:fragment slot="lead">
@@ -161,6 +166,14 @@
 					bind:checkedNodes
 					bind:indeterminateNodes
 					bind:treeItems={children[i]}
+					on:click={(e) =>
+						dispatch('click', {
+							id: e.detail.id
+						})}
+					on:toggle={(e) =>
+						dispatch('toggle', {
+							id: e.detail.id
+						})}
 				/>
 			</svelte:fragment>
 		</TreeViewItem>

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeViewItem.svelte
@@ -154,9 +154,17 @@
 				});
 			}}
 		>
-			{@html node.content}
+			{#if typeof node.content === 'string'}
+				{@html node.content}
+			{:else}
+				<svelte:component this={node.content} {...node.contentProps} />
+			{/if}
 			<svelte:fragment slot="lead">
-				{@html node.lead}
+				{#if typeof node.lead === 'string'}
+					{@html node.lead}
+				{:else}
+					<svelte:component this={node.lead} {...node.leadProps} />
+				{/if}
 			</svelte:fragment>
 			<svelte:fragment slot="children">
 				<RecursiveTreeViewItem

--- a/packages/skeleton/src/lib/components/TreeView/types.ts
+++ b/packages/skeleton/src/lib/components/TreeView/types.ts
@@ -1,10 +1,16 @@
+import type { ComponentType } from 'svelte';
+
 export interface TreeViewNode {
 	/** Nodes Unique ID */
 	id: string;
-	/** Main content. accepts HTML. */
-	content: string;
-	/** Lead content. accepts HTML. */
-	lead?: string;
+	/** Main content. accepts HTML or svelte component. */
+	content: string | ComponentType;
+	/** Main content props. only used when the Content is a svelte component. */
+	contentProps?: object;
+	/** Lead content. accepts HTML or svelte component. */
+	lead?: string | ComponentType;
+	/** lead props. only used when the Lead is a svelte component. */
+	leadProps?: object;
 	/** children nodes. */
 	children?: TreeViewNode[];
 	/** Set the input's value. */

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/+page.svelte
@@ -10,7 +10,7 @@
 	import sveldTreeView from '@skeletonlabs/skeleton/components/TreeView/TreeView.svelte?raw&sveld';
 	import sveldTreeViewItem from '@skeletonlabs/skeleton/components/TreeView/TreeViewItem.svelte?raw&sveld';
 	import sveldRecursiveTreeView from '@skeletonlabs/skeleton/components/TreeView/RecursiveTreeView.svelte?raw&sveld';
-	import { nodes } from './exampleData';
+	import { nodes, leadExampleNodes } from './exampleData';
 
 	// Docs Shell
 	const settings: DocsShellSettings = {
@@ -682,7 +682,44 @@ let myTreeViewNodes: TreeViewNode[] = [
 					<CodeBlock
 						language="html"
 						code={`
-<RecursiveTreeView nodes={nodes} />
+<RecursiveTreeView nodes={myTreeViewNodes} />
+						`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+			<!--Svelte Component-->
+			<h3 class="h3">Svelte Components</h3>
+			<p>
+				The props <code class="code">lead</code> and <code class="code">content</code> supports Svelte Components in addition to HTML content.
+			</p>
+			<DocsPreview background="neutral" regionFooter="flex justify-center gap-4">
+				<svelte:fragment slot="preview">
+					<RecursiveTreeView nodes={leadExampleNodes} />
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<p>To get expected results make sure to include a <em>unique Id</em> for each node.</p>
+					<CodeBlock
+						language="ts"
+						code={`
+import ExampleComponent from './exampleComponent.svelte';
+
+let myTreeViewNodes: TreeViewNode[] = [
+	{
+		id: 'unique-id'
+		content: 'content',
+		lead: ExampleComponent,
+		leadProps: {
+			myProp: 'myValue',
+		}
+	},
+	// ...
+]
+						`}
+					/>
+					<CodeBlock
+						language="html"
+						code={`
+<RecursiveTreeView nodes={myTreeViewNodes} />
 						`}
 					/>
 				</svelte:fragment>
@@ -737,7 +774,7 @@ let disabledNodes : string[] = [];
 					<CodeBlock
 						language="html"
 						code={`
-<RecursiveTreeView nodes={nodes} bind:disabledNodes={disabledNodes} />
+<RecursiveTreeView nodes={myTreeViewNodes} bind:disabledNodes={disabledNodes} />
 						`}
 					/>
 				</svelte:fragment>
@@ -767,7 +804,7 @@ let checkedNodes : string[] = [];
 					<CodeBlock
 						language="html"
 						code={`
-<RecursiveTreeView selection nodes={nodes} bind:checkedNodes={checkedNodes} />
+<RecursiveTreeView selection nodes={myTreeViewNodes} bind:checkedNodes={checkedNodes} />
 						`}
 					/>
 				</svelte:fragment>
@@ -807,7 +844,7 @@ let indeterminateNodes : string[] = [];
 	selection 
 	multiple 
 	relational 
-	nodes={nodes} 
+	nodes={myTreeViewNodes} 
 	bind:checkedNodes={checkedNodes} 
 	bind:indeterminateNodes={indeterminateNodes}/>
 						`}

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/exampleComponent.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/exampleComponent.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Avatar } from '@skeletonlabs/skeleton';
+
+	export let avatarId: number;
+</script>
+
+<Avatar src="https://i.pravatar.cc/?img={avatarId}" width="w-8" />

--- a/sites/skeleton.dev/src/routes/(inner)/components/tree-views/exampleData.ts
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tree-views/exampleData.ts
@@ -1,4 +1,5 @@
 import type { TreeViewNode } from '@skeletonlabs/skeleton';
+import ExampleComponent from './exampleComponent.svelte';
 
 export const nodes: TreeViewNode[] = [
 	{
@@ -219,5 +220,32 @@ export const nodes: TreeViewNode[] = [
 				]
 			}
 		]
+	}
+];
+
+export const leadExampleNodes: TreeViewNode[] = [
+	{
+		id: 'person1',
+		content: 'Susan',
+		lead: ExampleComponent,
+		leadProps: {
+			avatarId: 31
+		}
+	},
+	{
+		id: 'person2',
+		content: 'Michael',
+		lead: ExampleComponent,
+		leadProps: {
+			avatarId: 14
+		}
+	},
+	{
+		id: 'person3',
+		content: 'Melissa',
+		lead: ExampleComponent,
+		leadProps: {
+			avatarId: 9
+		}
 	}
 ];


### PR DESCRIPTION
## Linked Issue

Closes #2170
Closes #2141

## Description

Recursive Tree-view enhancements including:
- `toggle` and `click` events
- `lead` and `content` accepts svelte components with the ability to pass them props using the new `leadProps` and `contentProps` props.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
