### PR TITLE
Bug fix: Issue #2188 - Faux Italic and Faux Bold

### DIFF
--- a/sites/skeleton.dev/src/app.postcss
+++ b/sites/skeleton.dev/src/app.postcss
@@ -10,16 +10,19 @@
 	font-family: 'Quicksand';
 	src: url('/fonts/Quicksand.ttf');
 	font-display: swap;
+	font-style: italic;
 }
 @font-face {
 	font-family: 'Space Grotesk';
 	src: url('/fonts/SpaceGrotesk.ttf');
 	font-display: swap;
+	font-weight: 700;
 }
 @font-face {
 	font-family: 'Playfair Display';
 	src: url('/fonts/PlayfairDisplay-Italic.ttf');
 	font-display: swap;
+	font-weight: 700;
 }
 @font-face {
 	font-family: 'Abril Fatface';


### PR DESCRIPTION
Description:

Fixes: https://github.com/skeletonlabs/skeleton/issues/2188

**Summary of Changes:**

This pull request addresses the issue related to the inappropriate rendering of faux italic and faux bold styles (#2188). The necessary adjustments have been made to ensure that the typography is displayed as intended without any unintended stylings.

**Details:**

- Corrected the font styling issues preventing the proper display of italic and bold text.
- Adjusted the relevant CSS rules and typography components to ensure accuracy in text representation.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
