### PR TITLE
Bugfix/table cells interactive focusable

### DIFF
--- a/.changeset/rich-squids-decide.md
+++ b/.changeset/rich-squids-decide.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: table cells are not focusable when `interactive` is not set.

--- a/packages/skeleton/src/lib/components/Table/Table.svelte
+++ b/packages/skeleton/src/lib/components/Table/Table.svelte
@@ -68,7 +68,7 @@
 	<table
 		class="{classesTable}"
 		class:table-interactive={interactive}
-		role="grid"
+		role={interactive ? "grid" : "table"}
 		use:tableA11y
 	>
 		<!-- on:keydown={(e) => onTableKeydown(elemTable, e)} -->
@@ -76,7 +76,7 @@
 		<thead class="table-head {regionHead}">
 			<tr>
 				{#each source.head as heading }
-					<th class="{regionHeadCell}">{@html heading}</th>
+					<th class="{regionHeadCell}" role="columnheader">{@html heading}</th>
 				{/each}
 			</tr>
 		</thead>
@@ -95,7 +95,7 @@
 						<!-- prettier-ignore -->
 						<td
 							class="{regionCell}"
-							role="gridcell"
+							role={interactive ? "gridcell" : "cell"}
 							aria-colindex={cellIndex + 1}
 							tabindex={cellIndex === 0 && interactive ? 0 : -1}
 						>

--- a/packages/skeleton/src/lib/components/Table/Table.svelte
+++ b/packages/skeleton/src/lib/components/Table/Table.svelte
@@ -97,7 +97,7 @@
 							class="{regionCell}"
 							role="gridcell"
 							aria-colindex={cellIndex + 1}
-							tabindex={cellIndex === 0 ? 0 : -1}
+							tabindex={cellIndex === 0 && interactive ? 0 : -1}
 						>
 							{@html Number(cell) === 0 ? cell : (cell ? cell : '-')}
 						</td>


### PR DESCRIPTION
## Linked Issue

Closes #2168

## Description

table cells are focusable only in interactive mode.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
