### PR TITLE
feat/autocomplete-custom-filter-function

### DIFF
--- a/.changeset/plenty-drinks-tan.md
+++ b/.changeset/plenty-drinks-tan.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Autocomplete now accepts custom filter function using the prop `filterFunction`.

--- a/.changeset/plenty-drinks-tan.md
+++ b/.changeset/plenty-drinks-tan.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Autocomplete now accepts custom filter function using the prop `filterFunction`.
+feat: Autocomplete now accepts custom filter function using the prop `filter`.

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -70,7 +70,7 @@
 	 * Provide a custom filter function.
 	 * @type {() => AutocompleteOption[]}
 	 */
-	export let filterFunction: () => Option[] = filterOptions;
+	export let filter: () => Option[] = filterOptions;
 
 	// Props (transition)
 	/**
@@ -144,7 +144,7 @@
 
 	// State
 	$: filterByAllowDeny(allowlist, denylist);
-	$: optionsFiltered = input ? filterFunction() : listedOptions;
+	$: optionsFiltered = input ? filter() : listedOptions;
 	$: sliceLimit = limit ?? optionsFiltered.length;
 	// Reactive
 	$: classesBase = `${$$props.class ?? ''}`;

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -66,6 +66,11 @@
 	export let regionButton = 'w-full';
 	/** Provide arbitrary classes to empty message. */
 	export let regionEmpty = 'text-center';
+	/**
+	 * Provide a custom filter function.
+	 * @type {() => AutocompleteOption[]}
+	 */
+	export let filterFunction: () => Option[] = filterOptions;
 
 	// Props (transition)
 	/**
@@ -139,7 +144,7 @@
 
 	// State
 	$: filterByAllowDeny(allowlist, denylist);
-	$: optionsFiltered = input ? filterOptions() : listedOptions;
+	$: optionsFiltered = input ? filterFunction() : listedOptions;
 	$: sliceLimit = limit ?? optionsFiltered.length;
 	// Reactive
 	$: classesBase = `${$$props.class ?? ''}`;

--- a/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
@@ -81,6 +81,19 @@
 	function onPopupDemoSelect(event: CustomEvent<FlavorOption>): void {
 		inputPopupDemo = event.detail.label;
 	}
+
+	function customFilterFunction(): FlavorOption[] {
+		// Create a local copy of options
+		let _options = [...flavorOptions];
+		// Filter options
+		_options = _options.filter((option) => {
+			// Format the input search value
+			const inputFormatted = String(inputDemo).toLowerCase().trim();
+			// Check Match
+			if (option.value.toLowerCase().trim().includes(inputFormatted)) return option;
+		});
+		return _options;
+	}
 </script>
 
 <DocsShell {settings}>
@@ -217,6 +230,51 @@ const flavorOptions: AutocompleteOption<string>[] = [
 				<svelte:fragment slot="source">
 					<CodeBlock language="ts" code={`let flavorDenylist: string[] = ['vanilla', 'chocolate'];`} />
 					<CodeBlock language="html" code={`<Autocomplete ... denylist={flavorDenylist} />`} />
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
+		<!-- Custom Filter -->
+		<section class="space-y-4">
+			<h2 class="h2">Custom filter</h2>
+			<p>Provide a custom filter function using the prop <code class="code">filterFunction</code></p>
+			<DocsPreview background="neutral" regionFooter="text-center">
+				<svelte:fragment slot="preview">
+					<div class="text-token w-full max-w-sm space-y-2">
+						<input class="input" type="search" name="ac-demo" bind:value={inputDemo} placeholder="Search..." />
+						<div class="card w-full max-w-sm max-h-48 p-4 overflow-y-auto" tabindex="-1">
+							<Autocomplete
+								bind:input={inputDemo}
+								options={flavorOptions}
+								filterFunction={customFilterFunction}
+								on:selection={onDemoSelection}
+							/>
+						</div>
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<span class="text-sm">This example uses a custom filter to filter options after value only.</span>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="ts"
+						code={`
+// custom filter function
+function customFilterFunction() : AutocompleteOption<string>[] {
+	// Create a local copy of options
+	let _options = [...flavorOptions];
+	// Filter options
+	_options = _options.filter((option) => {
+		// Format the input search value
+		const inputFormatted = String(inputValue).toLowerCase().trim();
+		// Check Match with value only
+		if (option.value.toLowerCase().trim().includes(inputFormatted)) return option;
+	});
+	// return filtered options
+	return _options;
+}
+					`}
+					/>
+					<CodeBlock language="html" code={`<Autocomplete ... filterFunction={customFilterFunction} />`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
@@ -235,8 +235,8 @@ const flavorOptions: AutocompleteOption<string>[] = [
 		</section>
 		<!-- Custom Filter -->
 		<section class="space-y-4">
-			<h2 class="h2">Custom filter</h2>
-			<p>Provide a custom filter function using the prop <code class="code">filter</code></p>
+			<h2 class="h2">Custom Filter</h2>
+			<p>Provide a custom filter function using the prop <code class="code">filter</code>.</p>
 			<DocsPreview background="neutral" regionFooter="text-center">
 				<svelte:fragment slot="preview">
 					<div class="text-token w-full max-w-sm space-y-2">
@@ -250,23 +250,21 @@ const flavorOptions: AutocompleteOption<string>[] = [
 					<CodeBlock
 						language="ts"
 						code={`
-// custom filter function
-function customFilterFunction() : AutocompleteOption<string>[] {
+function myCustomFilter(): AutocompleteOption<string>[] {
 	// Create a local copy of options
 	let _options = [...flavorOptions];
 	// Filter options
-	_options = _options.filter((option) => {
-		// Format the input search value
+	return _options.filter((option) => {
+		// Format the input and option values
 		const inputFormatted = String(inputValue).toLowerCase().trim();
+		const optionFormatted = option.value.toLowerCase().trim();
 		// Check Match with value only
-		if (option.value.toLowerCase().trim().includes(inputFormatted)) return option;
+		if (optionFormatted.includes(inputFormatted)) return option;
 	});
-	// return filtered options
-	return _options;
 }
 					`}
 					/>
-					<CodeBlock language="html" code={`<Autocomplete ... filter={customFilterFunction} />`} />
+					<CodeBlock language="html" code={`<Autocomplete ... filter={myCustomFilter} />`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
@@ -236,23 +236,15 @@ const flavorOptions: AutocompleteOption<string>[] = [
 		<!-- Custom Filter -->
 		<section class="space-y-4">
 			<h2 class="h2">Custom filter</h2>
-			<p>Provide a custom filter function using the prop <code class="code">filterFunction</code></p>
+			<p>Provide a custom filter function using the prop <code class="code">filter</code></p>
 			<DocsPreview background="neutral" regionFooter="text-center">
 				<svelte:fragment slot="preview">
 					<div class="text-token w-full max-w-sm space-y-2">
 						<input class="input" type="search" name="ac-demo" bind:value={inputDemo} placeholder="Search..." />
 						<div class="card w-full max-w-sm max-h-48 p-4 overflow-y-auto" tabindex="-1">
-							<Autocomplete
-								bind:input={inputDemo}
-								options={flavorOptions}
-								filterFunction={customFilterFunction}
-								on:selection={onDemoSelection}
-							/>
+							<Autocomplete bind:input={inputDemo} options={flavorOptions} filter={customFilterFunction} on:selection={onDemoSelection} />
 						</div>
 					</div>
-				</svelte:fragment>
-				<svelte:fragment slot="footer">
-					<span class="text-sm">This example uses a custom filter to filter options after value only.</span>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
 					<CodeBlock
@@ -274,7 +266,7 @@ function customFilterFunction() : AutocompleteOption<string>[] {
 }
 					`}
 					/>
-					<CodeBlock language="html" code={`<Autocomplete ... filterFunction={customFilterFunction} />`} />
+					<CodeBlock language="html" code={`<Autocomplete ... filter={customFilterFunction} />`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>


### PR DESCRIPTION
## Linked Issue

Closes #1966

## Description

Added prop `filterFunction` with default value of the Skeleton's original filter function.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages/skeleton`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
