### PR TITLE
Disable pointer events in hidden popups to avoid interactions

### DIFF
--- a/packages/skeleton/src/lib/utilities/Popup/popup.ts
+++ b/packages/skeleton/src/lib/utilities/Popup/popup.ts
@@ -124,6 +124,7 @@ export function popup(triggerNode: HTMLElement, args: PopupSettings) {
 			// Update the DOM
 			elemPopup.style.opacity = '0';
 			// disable popup interactions
+        		elemPopup.style.pointerEvents = 'none';
 			elemPopup.setAttribute('inert', '');
 			// Cleanup Floating UI autoUpdate (close only)
 			if (popupState.autoUpdateCleanup) popupState.autoUpdateCleanup();


### PR DESCRIPTION
## Linked Issue

Closes #2214 

## Description

Sets pointer-events to none for all popups that are hidden. This prevents the user from accidentally clicking on random popups.

## Changesets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
