### PR TITLE
bugfix/drawer-smooth-close-animation

### DIFF
--- a/.changeset/sharp-suns-wash.md
+++ b/.changeset/sharp-suns-wash.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: drawer animates smoothly when closing.

--- a/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
+++ b/packages/skeleton/src/lib/utilities/Drawer/Drawer.svelte
@@ -20,6 +20,7 @@
 	import { getDrawerStore } from './stores.js';
 	import { fade, fly } from 'svelte/transition';
 	import { dynamicTransition } from '../../internal/transitions.js';
+	import { cubicIn } from 'svelte/easing';
 
 	// Props
 	/** Set the anchor position.
@@ -223,7 +224,7 @@
 			}}
 			out:dynamicTransition|local={{
 				transition: fly,
-				params: { x: anim.x, y: anim.y, duration, opacity: opacityTransition ? undefined : 1 },
+				params: { x: anim.x, y: anim.y, duration, opacity: opacityTransition ? undefined : 1, easing: cubicIn },
 				enabled: transitions
 			}}
 		>


### PR DESCRIPTION
## Linked Issue

Closes #2212

## Description

The weird behaviour is because of the easing function, fly uses `cubicOut` as a default value so when the transition enters we get the expected result but when it exits the transition will seem faster. 

see https://svelte.dev/examples/easing for visual reference.

Adding easing -> `cubicIn` when exiting will balance the speed of the transition.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
