### PR TITLE
docs update on pagination  with dynamic size

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/paginators/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/paginators/+page.svelte
@@ -177,6 +177,23 @@ let tableHeaders: string[] = ['Positions', 'Name', 'Weight', 'Symbol'];
 <Table source={{ head: tableHeaders, body: paginatedSource }} />
 				`}
 			/>
+			<p>
+				If the paginated data source is dynamic, you might want to update the size parameter accordingly with the data. To achieve this, you can
+				use a Svelte reactive declaration to update it accordingly.
+			</p>
+			<CodeBlock
+				language="ts"
+				code={`
+let paginationSettings = {
+    page: 0,
+    limit: 5,
+    size: source.length,
+    amounts: [1, 2, 5, 10],
+} satisfies PaginationSettings;
+
+$: paginationSettings.size= source.length;
+				`}
+			/>
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Server-Side Pagination</h2>

--- a/sites/skeleton.dev/src/routes/(inner)/components/paginators/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/paginators/+page.svelte
@@ -194,6 +194,10 @@ let paginationSettings = {
 $: paginationSettings.size= source.length;
 				`}
 			/>
+            <p>
+                With this pagination setup, it's important to update the paginationSettings directly for reactivity. 
+                Simply updating a reference to source will not trigger the reactivity. 
+            </p>
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Server-Side Pagination</h2>

--- a/sites/skeleton.dev/src/routes/(inner)/components/paginators/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/paginators/+page.svelte
@@ -177,27 +177,6 @@ let tableHeaders: string[] = ['Positions', 'Name', 'Weight', 'Symbol'];
 <Table source={{ head: tableHeaders, body: paginatedSource }} />
 				`}
 			/>
-			<p>
-				If the paginated data source is dynamic, you might want to update the size parameter accordingly with the data. To achieve this, you can
-				use a Svelte reactive declaration to update it accordingly.
-			</p>
-			<CodeBlock
-				language="ts"
-				code={`
-let paginationSettings = {
-    page: 0,
-    limit: 5,
-    size: source.length,
-    amounts: [1, 2, 5, 10],
-} satisfies PaginationSettings;
-
-$: paginationSettings.size= source.length;
-				`}
-			/>
-            <p>
-                With this pagination setup, it's important to update the paginationSettings directly for reactivity. 
-                Simply updating a reference to source will not trigger the reactivity. 
-            </p>
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Server-Side Pagination</h2>
@@ -215,6 +194,26 @@ function onAmountChange(e: CustomEvent): void {
 			`}
 			/>
 			<CodeBlock language="html" code={`<Paginator ... on:page={onPageChange} on:amount={onAmountChange}></Paginator>`} />
+		</section>
+		<section class="space-y-4">
+			<h2 class="h2">Handling Reactivity</h2>
+			<!-- prettier-ignore -->
+			<p>
+				Use the following technique if you wish to update pagination data in a reactive manner. Make sure to update <code class="code" >paginationSettings</code> directly, as <a class="anchor" href="https://learn.svelte.dev/tutorial/updating-arrays-and-objects" target="_blank">updating a reference to source will not trigger the reactivity</a>.
+			</p>
+			<CodeBlock
+				language="ts"
+				code={`
+let paginationSettings = {
+    page: 0,
+    limit: 5,
+    size: source.length,
+    amounts: [1, 2, 5, 10],
+} satisfies PaginationSettings;
+
+$: paginationSettings.size = source.length;
+				`}
+			/>
 		</section>
 		<hr />
 		<!-- See Also -->


### PR DESCRIPTION
## Add information on how to have server side pagination with a dynamic size

Closes #2211

## Description
Documentation on updating pagination size accordingly to the dynamic data source

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
