### PR TITLE
Made table source example dynamic

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
@@ -80,11 +80,11 @@
 					language="ts"
 					code={`
 const sourceData = [
-	{ position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H' },
-	{ position: 2, name: 'Helium', weight: 4.0026, symbol: 'He' },
-	{ position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li' },
-	{ position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be' },
-	{ position: 5, name: 'Boron', weight: 10.811, symbol: 'B' },
+	{ position: 1, name: '${sourceData[0].name}', number: ${sourceData[0].atomicNumber}, symbol: '${sourceData[0].symbol}' },
+	{ position: 2, name: '${sourceData[1].name}', number: ${sourceData[1].atomicNumber}, symbol: '${sourceData[1].symbol}' },
+	{ position: 3, name: '${sourceData[2].name}', number: ${sourceData[2].atomicNumber}, symbol: '${sourceData[2].symbol}' },
+	{ position: 4, name: '${sourceData[3].name}', number: ${sourceData[3].atomicNumber}, symbol: '${sourceData[3].symbol}' },
+	{ position: 5, name: '${sourceData[4].name}', number: ${sourceData[4].atomicNumber}, symbol: '${sourceData[4].symbol}' },
 ];
 				`}
 				/>
@@ -97,11 +97,11 @@ const sourceData = [
 					code={`
 const tableSimple: TableSource = {
 	// A list of heading labels.
-	head: ['Name', 'Symbol', 'Weight'],
+	head: ['Name', 'Symbol', 'Number'],
 	// The data visibly shown in your table body UI.
-	body: tableMapperValues(sourceData, ['name', 'symbol', 'weight']),
+	body: tableMapperValues(sourceData, ['name', 'symbol', 'atomicNumber']),
 	// Optional: The data returned when interactive is enabled and a row is clicked.
-	meta: tableMapperValues(sourceData, ['position', 'name', 'symbol', 'weight']),
+	meta: tableMapperValues(sourceData, ['position', 'name', 'symbol', 'atomicNumber']),
 	// Optional: A list of footer labels.
 	foot: ['Total', '', '<code class="code">${sourceData.length}</code>']
 };
@@ -144,10 +144,10 @@ const tableSimple: TableSource = {
 				<CodeBlock
 					language="ts"
 					code={`
-tableMapperValues(sourceData, ['name', 'symbol', 'weight'])\n
+tableMapperValues(sourceData, ['name', 'symbol', 'atomicNumber'])\n
 //	[
-//		['Hydrogen', 'H', '1.0079'],
-//		['Helium', 'He', '4.0026'],
+//		['${sourceData[0].name}', '${sourceData[0].symbol}', '${sourceData[0].atomicNumber}'],
+//		['${sourceData[1].name}', '${sourceData[1].symbol}', '${sourceData[1].atomicNumber}'],
 //		...
 //	]
 				`}
@@ -160,8 +160,8 @@ tableMapperValues(sourceData, ['name', 'symbol', 'weight'])\n
 					code={`
 tableSourceMapper(sourceData, ['name', 'symbol', 'weight']);\n
 //[
-//		{ name: 'Hydrogen', symbol: 'H', weight: '1.0079' },
-//		{ name: 'Helium', symbol: 'He', weight: '4.0026' },
+//		{ name: '${sourceData[0].name}', symbol: '${sourceData[0].symbol}', weight: '${sourceData[0].atomicNumber}' },
+//		{ name: '${sourceData[1].name}', symbol: '${sourceData[1].symbol}', weight: '${sourceData[1].atomicNumber}' }
 //		...
 //]
 					`}
@@ -178,8 +178,8 @@ tableSourceMapper(sourceData, ['name', 'symbol', 'weight']);\n
 					code={`
 tableSourceValues(sourceData);\n
 //[
-//		[ 1, 'Hydrogen', '1.0079', 'H' ],
-//		[ 2, 'Helium', '4.0026', 'He' ],
+//		[ 1, '${sourceData[0].name}', '${sourceData[0].atomicNumber}', '${sourceData[0].symbol}' ],
+//		[ 2, '${sourceData[1].name}', '${sourceData[1].atomicNumber}', '${sourceData[1].symbol}' ],
 //		...
 //]
 `}

--- a/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { faker } from '@faker-js/faker';
 	import { writable, type Writable } from 'svelte/store';
 	// Docs
 	import DocsShell from '$lib/layouts/DocsShell/DocsShell.svelte';
@@ -46,15 +45,19 @@
 	};
 
 	// Local
-	const sourceData = Array(5)
-		.fill(undefined)
-		.map(() => faker.science.chemicalElement());
+	const sourceData = [
+		{ position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H' },
+		{ position: 2, name: 'Helium', weight: 4.0026, symbol: 'He' },
+		{ position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li' },
+		{ position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be' },
+		{ position: 5, name: 'Boron', weight: 10.811, symbol: 'B' }
+	];
 
 	// Table Simple
 	const tableSimple: TableSource = {
-		head: ['Symbol', 'Name', 'Number'],
-		body: tableMapperValues(sourceData, ['symbol', 'name', 'atomicNumber']),
-		meta: tableMapperValues(sourceData, ['name', 'symbol', 'atomicNumber']),
+		head: ['Symbol', 'Name', 'weight'],
+		body: tableMapperValues(sourceData, ['symbol', 'name', 'weight']),
+		meta: tableMapperValues(sourceData, ['name', 'symbol', 'weight']),
 		foot: ['Total Elements', '', `<span class="badge variant-soft-primary">${sourceData.length} Elements</span>`]
 	};
 
@@ -80,11 +83,11 @@
 					language="ts"
 					code={`
 const sourceData = [
-	{ position: 1, name: '${sourceData[0].name}', number: ${sourceData[0].atomicNumber}, symbol: '${sourceData[0].symbol}' },
-	{ position: 2, name: '${sourceData[1].name}', number: ${sourceData[1].atomicNumber}, symbol: '${sourceData[1].symbol}' },
-	{ position: 3, name: '${sourceData[2].name}', number: ${sourceData[2].atomicNumber}, symbol: '${sourceData[2].symbol}' },
-	{ position: 4, name: '${sourceData[3].name}', number: ${sourceData[3].atomicNumber}, symbol: '${sourceData[3].symbol}' },
-	{ position: 5, name: '${sourceData[4].name}', number: ${sourceData[4].atomicNumber}, symbol: '${sourceData[4].symbol}' },
+	{ position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H' },
+	{ position: 2, name: 'Helium', weight: 4.0026, symbol: 'He' },
+	{ position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li' },
+	{ position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be' },
+	{ position: 5, name: 'Boron', weight: 10.811, symbol: 'B' },
 ];
 				`}
 				/>
@@ -97,11 +100,11 @@ const sourceData = [
 					code={`
 const tableSimple: TableSource = {
 	// A list of heading labels.
-	head: ['Name', 'Symbol', 'Number'],
+	head: ['Name', 'Symbol', 'Weight'],
 	// The data visibly shown in your table body UI.
-	body: tableMapperValues(sourceData, ['name', 'symbol', 'atomicNumber']),
+	body: tableMapperValues(sourceData, ['name', 'symbol', 'weight']),
 	// Optional: The data returned when interactive is enabled and a row is clicked.
-	meta: tableMapperValues(sourceData, ['position', 'name', 'symbol', 'atomicNumber']),
+	meta: tableMapperValues(sourceData, ['position', 'name', 'symbol', 'weight']),
 	// Optional: A list of footer labels.
 	foot: ['Total', '', '<code class="code">${sourceData.length}</code>']
 };
@@ -144,10 +147,10 @@ const tableSimple: TableSource = {
 				<CodeBlock
 					language="ts"
 					code={`
-tableMapperValues(sourceData, ['name', 'symbol', 'atomicNumber'])\n
+tableMapperValues(sourceData, ['name', 'symbol', 'weight'])\n
 //	[
-//		['${sourceData[0].name}', '${sourceData[0].symbol}', '${sourceData[0].atomicNumber}'],
-//		['${sourceData[1].name}', '${sourceData[1].symbol}', '${sourceData[1].atomicNumber}'],
+//		['Hydrogen', 'H', '1.0079'],
+//		['Helium', 'He', '4.0026'],
 //		...
 //	]
 				`}
@@ -160,8 +163,8 @@ tableMapperValues(sourceData, ['name', 'symbol', 'atomicNumber'])\n
 					code={`
 tableSourceMapper(sourceData, ['name', 'symbol', 'weight']);\n
 //[
-//		{ name: '${sourceData[0].name}', symbol: '${sourceData[0].symbol}', weight: '${sourceData[0].atomicNumber}' },
-//		{ name: '${sourceData[1].name}', symbol: '${sourceData[1].symbol}', weight: '${sourceData[1].atomicNumber}' }
+//		{ name: 'Hydrogen', symbol: 'H', weight: '1.0079' },
+//		{ name: 'Helium', symbol: 'He', weight: '4.0026' },
 //		...
 //]
 					`}
@@ -178,8 +181,8 @@ tableSourceMapper(sourceData, ['name', 'symbol', 'weight']);\n
 					code={`
 tableSourceValues(sourceData);\n
 //[
-//		[ 1, '${sourceData[0].name}', '${sourceData[0].atomicNumber}', '${sourceData[0].symbol}' ],
-//		[ 2, '${sourceData[1].name}', '${sourceData[1].atomicNumber}', '${sourceData[1].symbol}' ],
+//		[ 1, 'Hydrogen', '1.0079', 'H' ],
+//		[ 2, 'Helium', '4.0026', 'He' ],
 //		...
 //]
 `}


### PR DESCRIPTION
## Linked Issue

Closes #2234

## Description

Table example output was created dynamically while the code example was static. Both are now dynamics and will display data that faker generated

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
