### PR TITLE
Bugfix/popup empty close query

### DIFF
--- a/.changeset/eight-toes-itch.md
+++ b/.changeset/eight-toes-itch.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+Adjust popup 'onWindowClick' to respect an empty 'queryString'

--- a/packages/skeleton/src/lib/utilities/Popup/popup.ts
+++ b/packages/skeleton/src/lib/utilities/Popup/popup.ts
@@ -148,6 +148,8 @@ export function popup(triggerNode: HTMLElement, args: PopupSettings) {
 		}
 		// Handle Close Query State
 		const closeQueryString: string = args.closeQuery === undefined ? 'a[href], button' : args.closeQuery;
+		// Return if no closeQuery is provided
+		if (closeQueryString === '') return;
 		const closableMenuElements = elemPopup?.querySelectorAll(closeQueryString);
 		closableMenuElements?.forEach((elem) => {
 			if (elem.contains(event.target)) close();


### PR DESCRIPTION
## Linked Issue

Closes #2218 

## Description

Adjusted the `onWindowClick` method in `popup` so that it matches the functionality outlined in the documentation regarding the `queryString` option.

Went for a guard statement since the rest of the method doesn't need to run if it's an empty string.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
