### PR TITLE
Bugfix/modal slide right on open

### DIFF
--- a/.changeset/hot-houses-joke.md
+++ b/.changeset/hot-houses-joke.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Fixes Issue #2239, added overflow-hidden to the base backdrop class list, and max-h-screen to the base transition class list.

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -101,8 +101,8 @@
 	export let transitionOutParams: TransitionParams<TransitionOut> = { duration: 150, opacity: 0, x: 0, y: 100 };
 
 	// Base Styles
-	const cBackdrop = 'fixed top-0 left-0 right-0 bottom-0 overflow-y-auto';
-	const cTransitionLayer = 'w-full h-fit min-h-full p-4 overflow-y-auto flex justify-center';
+	const cBackdrop = 'fixed top-0 left-0 right-0 bottom-0 overflow-hidden';
+	const cTransitionLayer = 'w-full h-fit min-h-full max-h-screen p-4 overflow-y-auto flex justify-center';
 	const cModal = 'block overflow-y-auto'; // max-h-full overflow-y-auto overflow-x-hidden
 	const cModalImage = 'w-full h-auto';
 


### PR DESCRIPTION
## Linked Issue

Closes #2239

## Description

Add base classes to modal to prevent scrollbar on open

The scrollbar appearing quickly on modal open is causing the modal slide. A proposed solution here, https://github.com/skeletonlabs/skeleton/issues/1870#issuecomment-1691777511, fixes this issue. 
- Added `overflow-hidden` to `cBackdrop`
- Added `max-h-screen` to `cTransitionLayer`

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
