### PR TITLE
fix typo in SectionThemes component

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionThemes.svelte
@@ -49,7 +49,7 @@ plugins: [
 			{/each}
 		</nav>
 		<p>
-			First, register you preferred theme(s) in <code class="code">tailwind.config.[ts|js|cjs]</code>. This will ensure each theme is
+			First, register your preferred theme(s) in <code class="code">tailwind.config.[ts|js|cjs]</code>. This will ensure each theme is
 			available to use.
 		</p>
 		<CodeBlock language="ts" code={activeThemeStylesheet} />


### PR DESCRIPTION
## Linked Issue

Closes #{issueNumber}

## Description

Fixes a small typo in the SectionThemes portion of the getting started section.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
