### PR TITLE
Progress bar component - Removed classMeter applied twice in the temp…

### DIFF
--- a/.changeset/red-drinks-obey.md
+++ b/.changeset/red-drinks-obey.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+bugfix: ProgressBar component classesMeter applied twice in the template #2280

--- a/.changeset/red-drinks-obey.md
+++ b/.changeset/red-drinks-obey.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": minor
 ---
 
-bugfix: ProgressBar component classesMeter applied twice in the template #2280
+bugfix: ProgressBar component classesMeter applied twice in the template

--- a/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte
+++ b/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte
@@ -55,7 +55,7 @@
 	aria-valuemax={max - min}
 >
 	<!-- Meter -->
-	<div class="progress-bar-meter {classesMeter} {classesMeter}" style:width="{indeterminate ? 100 : fillPercent}%" />
+	<div class="progress-bar-meter {classesMeter}" style:width="{indeterminate ? 100 : fillPercent}%" />
 </div>
 
 <style lang="postcss">


### PR DESCRIPTION
…late

## Linked Issue

Closes #2280

## Description

Removed ProgressBar component classesMeter applied twice in the template 

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
