### PR TITLE
Fix RadioGroup spacing

### DIFF
--- a/.changeset/thick-trains-chew.md
+++ b/.changeset/thick-trains-chew.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+bugfix: RadioGroup now supports a `flexDirection` and `gap` props for handling vertical layouts and item spacing respectively.

--- a/packages/skeleton/src/lib/components/Radio/RadioGroup.svelte
+++ b/packages/skeleton/src/lib/components/Radio/RadioGroup.svelte
@@ -12,7 +12,7 @@
 	/** Provide classes to set the border styles. */
 	export let border: CssClasses = 'border-token border-surface-400-500-token';
 	/** Provide classes horizontal spacing between items. */
-	export let spacing: CssClasses = '';
+	export let spacing: CssClasses = 'space-x-1';
 	/** Provide classes to set the border radius. */
 	export let rounded: CssClasses = 'rounded-token';
 
@@ -47,8 +47,6 @@
 	const cBase = 'p-1';
 
 	// Reactive
-	// display space-x only on row flex as it is not needed on column flex.
-	$: spacing = `${display.includes('flex-col') ? '' : 'space-x-1'}`;
 	$: classesBase = `${cBase} ${display} ${background} ${border} ${spacing} ${rounded} ${$$props.class ?? ''}`;
 </script>
 

--- a/packages/skeleton/src/lib/components/Radio/RadioGroup.svelte
+++ b/packages/skeleton/src/lib/components/Radio/RadioGroup.svelte
@@ -5,14 +5,16 @@
 	import type { CssClasses } from '../../index.js';
 
 	// Props (Group)
-	/** Provide display classes. Set `flex` to stretch full width. */
+	/** Provide display classes. Use `flex` to stretch full width. */
 	export let display: CssClasses = 'inline-flex';
+	/** Provide classes to set flex-direction. Use `flex-col` for vertical layout. */
+	export let flexDirection: CssClasses = 'inline-flex';
+	/** Provide classes to set gap spacing between items. */
+	export let gap: CssClasses = 'gap-1';
 	/** Provide classes to set the base background color. */
 	export let background: CssClasses = 'bg-surface-200-700-token';
 	/** Provide classes to set the border styles. */
 	export let border: CssClasses = 'border-token border-surface-400-500-token';
-	/** Provide classes horizontal spacing between items. */
-	export let spacing: CssClasses = 'space-x-1';
 	/** Provide classes to set the border radius. */
 	export let rounded: CssClasses = 'rounded-token';
 
@@ -47,7 +49,7 @@
 	const cBase = 'p-1';
 
 	// Reactive
-	$: classesBase = `${cBase} ${display} ${background} ${border} ${spacing} ${rounded} ${$$props.class ?? ''}`;
+	$: classesBase = `${cBase} ${display} ${flexDirection} ${gap} ${background} ${border} ${rounded} ${$$props.class ?? ''}`;
 </script>
 
 <div class="radio-group {classesBase}" data-testid="radio-group" role="radiogroup" aria-labelledby={labelledby}>

--- a/packages/skeleton/src/lib/components/Radio/RadioGroup.test.ts
+++ b/packages/skeleton/src/lib/components/Radio/RadioGroup.test.ts
@@ -15,7 +15,7 @@ describe('RadioGroup.svelte', () => {
 		const { getByTestId } = render(RadioGroup, {
 			props: {
 				display: 'inline-flex',
-				spacing: 'space-x-2',
+				gap: 'gap-1',
 				background: 'bg-surface-300 dark:bg-surface-700',
 				hover: 'hover:bg-primary-500/10',
 				accent: 'bg-primary-500 !text-white',

--- a/packages/skeleton/src/lib/components/Radio/RadioGroup.test.ts
+++ b/packages/skeleton/src/lib/components/Radio/RadioGroup.test.ts
@@ -15,6 +15,7 @@ describe('RadioGroup.svelte', () => {
 		const { getByTestId } = render(RadioGroup, {
 			props: {
 				display: 'inline-flex',
+				spacing: 'space-x-2',
 				background: 'bg-surface-300 dark:bg-surface-700',
 				hover: 'hover:bg-primary-500/10',
 				accent: 'bg-primary-500 !text-white',

--- a/sites/skeleton.dev/src/routes/(inner)/components/radio-groups/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/radio-groups/+page.svelte
@@ -105,10 +105,10 @@
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Vertical</h2>
-			<p>Set <em>display</em> to <code class="code">flex-col</code> for a vertical layout.</p>
+			<p>Set <code class="code">flexDirection="flex-col"</code> to utilize a vertical layout.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<RadioGroup rounded="rounded-container-token" display="flex-col">
+					<RadioGroup rounded="rounded-container-token" flexDirection="flex-col">
 						{#each timeNames as name}
 							<RadioItem bind:group={timeVertical} label={name} {name} value={name}>{name}</RadioItem>
 						{/each}
@@ -118,7 +118,7 @@
 					<CodeBlock
 						language="html"
 						code={`
-<RadioGroup rounded="rounded-container-token" display="flex-col">...</RadioGroup>
+<RadioGroup rounded="rounded-container-token" flexDirection="flex-col">...</RadioGroup>
 `}
 					/>
 				</svelte:fragment>


### PR DESCRIPTION
## Linked Issue

Closes #2295

## Description

Made spacing props to adopt value passed in and set *space-x-1* as default value for it

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
