### PR TITLE
Docs/url tab state

### DIFF
--- a/sites/skeleton.dev/src/lib/layouts/DocsShell/DocsShell.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsShell/DocsShell.svelte
@@ -31,7 +31,8 @@
 	const cPanels = 'space-y-10';
 
 	// Local
-	let tabPanel = $page.url.searchParams.get('tab') || 'usage';
+	const defaultTab = 'usage';
+	let tabPanel = $page.url.searchParams.get('tab') || defaultTab;
 
 	// Page Data
 	const pageData: DocsShellSettings = {
@@ -60,7 +61,11 @@
 	$: classesPanels = `${cPanels}`;
 	$: if (browser) {
 		const url = new URL($page.url);
-		url.searchParams.set('tab', tabPanel);
+		if (tabPanel === defaultTab) {
+			url.searchParams.delete('tab');
+		} else {
+			url.searchParams.set('tab', tabPanel);
+		}
 		goto(url, { replaceState: true });
 	}
 </script>

--- a/sites/skeleton.dev/src/lib/layouts/DocsShell/DocsShell.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsShell/DocsShell.svelte
@@ -17,6 +17,8 @@
 	import PanelSlots from './partials/PanelSlots.svelte';
 	// Utilities
 	import { docShellDefaults } from '$lib/layouts/DocsShell/defaults';
+	import { goto } from '$app/navigation';
+	import { browser } from '$app/environment';
 
 	// Props
 	export let settings: DocsShellSettings;
@@ -28,7 +30,7 @@
 	const cPanels = 'space-y-10';
 
 	// Local
-	let tabPanel = 'usage';
+	let tabPanel = $page.url.searchParams.get('tab') || 'usage';
 
 	// Page Data
 	const pageData: DocsShellSettings = {
@@ -55,6 +57,12 @@
 	$: classesBase = `${cBase}`;
 	$: classesTabs = `${cTabs}`;
 	$: classesPanels = `${cPanels}`;
+
+	$: if (browser) {
+		const url = new URL($page.url);
+		url.searchParams.set('tab', tabPanel);
+		goto(url, { replaceState: true });
+	}
 </script>
 
 <LayoutPage class="doc-shell {classesBase}" tocKey={tabPanel}>

--- a/sites/skeleton.dev/src/lib/layouts/DocsShell/DocsShell.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsShell/DocsShell.svelte
@@ -17,6 +17,7 @@
 	import PanelSlots from './partials/PanelSlots.svelte';
 	// Utilities
 	import { docShellDefaults } from '$lib/layouts/DocsShell/defaults';
+	// SvelteKit
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 
@@ -57,7 +58,6 @@
 	$: classesBase = `${cBase}`;
 	$: classesTabs = `${cTabs}`;
 	$: classesPanels = `${cPanels}`;
-
 	$: if (browser) {
 		const url = new URL($page.url);
 		url.searchParams.set('tab', tabPanel);

--- a/sites/skeleton.dev/src/lib/layouts/DocsShell/DocsShell.svelte
+++ b/sites/skeleton.dev/src/lib/layouts/DocsShell/DocsShell.svelte
@@ -59,13 +59,11 @@
 	$: classesBase = `${cBase}`;
 	$: classesTabs = `${cTabs}`;
 	$: classesPanels = `${cPanels}`;
+	// Handle tab URL param for deep linking
 	$: if (browser) {
 		const url = new URL($page.url);
-		if (tabPanel === defaultTab) {
-			url.searchParams.delete('tab');
-		} else {
-			url.searchParams.set('tab', tabPanel);
-		}
+		url.searchParams.delete('tab');
+		if (tabPanel !== defaultTab) url.searchParams.set('tab', tabPanel);
 		goto(url, { replaceState: true });
 	}
 </script>


### PR DESCRIPTION
## Linked Issue

Closes #2303

## Description

- Added reactive block that syncs the currently selected doc tab in the url using a ``?tab=`` query param.
- Added a default tab constant, whenever the currently selected tab is the default tab instead of updating the ``tab`` query param the ``tab`` query param is removed.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
