### PR TITLE
feat/progressbar-animation-prop

### DIFF
--- a/.changeset/mighty-cycles-drive.md
+++ b/.changeset/mighty-cycles-drive.md
@@ -1,5 +1,5 @@
 ---
-"@skeletonlabs/skeleton": major
+"@skeletonlabs/skeleton": minor
 ---
 
 feat: Added the prop `indeterminateAnimation` to customize the ProgressBar indeterminate animation.

--- a/.changeset/mighty-cycles-drive.md
+++ b/.changeset/mighty-cycles-drive.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": major
+---
+
+feat: Added the prop `indeterminateAnimation` to customize the ProgressBar indeterminate animation.

--- a/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte
+++ b/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte
@@ -18,6 +18,8 @@
 	export let rounded: CssClasses = 'rounded-token';
 	/** Provide classes to set the meter transition styles. */
 	export let transition: CssClasses = 'transition-[width]';
+	/** Provide classes to a custom indeterminate animation. */
+	export let indeterminateAnimation: CssClasses = 'animIndeterminate';
 
 	// Props (elements)
 	/** Sets the base classes of the meter element. */
@@ -38,7 +40,7 @@
 
 	// Indeterminate State
 	$: indeterminate = value === undefined || value < 0;
-	$: classesIndeterminate = indeterminate ? 'animIndeterminate' : '';
+	$: classesIndeterminate = indeterminate ? indeterminateAnimation : '';
 	// Reactive Classes
 	$: classesTrack = `${cTrack} ${track} ${height} ${rounded} ${$$props.class ?? ''}`;
 	$: classesMeter = `${cMeter} ${meter} ${rounded} ${classesIndeterminate} ${transition}`;

--- a/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte
+++ b/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte
@@ -18,8 +18,8 @@
 	export let rounded: CssClasses = 'rounded-token';
 	/** Provide classes to set the meter transition styles. */
 	export let transition: CssClasses = 'transition-[width]';
-	/** Provide classes to a custom indeterminate animation. */
-	export let indeterminateAnimation: CssClasses = 'animIndeterminate';
+	/** Provide classes to replace the default animation styles. */
+	export let animIndeterminate: CssClasses = 'anim-indeterminate';
 
 	// Props (elements)
 	/** Sets the base classes of the meter element. */
@@ -40,7 +40,7 @@
 
 	// Indeterminate State
 	$: indeterminate = value === undefined || value < 0;
-	$: classesIndeterminate = indeterminate ? indeterminateAnimation : '';
+	$: classesIndeterminate = indeterminate ? animIndeterminate : '';
 	// Reactive Classes
 	$: classesTrack = `${cTrack} ${track} ${height} ${rounded} ${$$props.class ?? ''}`;
 	$: classesMeter = `${cMeter} ${meter} ${rounded} ${classesIndeterminate} ${transition}`;
@@ -61,12 +61,12 @@
 </div>
 
 <style lang="postcss">
-	.animIndeterminate {
+	.anim-indeterminate {
 		transform-origin: 0% 50%;
-		animation: animIndeterminate 2s infinite linear;
+		animation: anim-indeterminate 2s infinite linear;
 	}
 	/* prettier-ignore */
-	@keyframes animIndeterminate {
+	@keyframes anim-indeterminate {
 		0% { transform: translateX(0) scaleX(0); }
 		40% { transform: translateX(0) scaleX(0.4); }
 		100% { transform: translateX(100%) scaleX(0.5); }

--- a/sites/skeleton.dev/src/app.postcss
+++ b/sites/skeleton.dev/src/app.postcss
@@ -50,13 +50,19 @@ body {
 	@apply space-y-4;
 }
 
-.progressbar-anim-indeterminate-example {
+/* Progress Bar - Custom Animation Example */
+.anim-progress-bar-example {
 	transform-origin: 0% 50%;
-	animation: progressbar-anim-indeterminate-example 2s infinite linear;
+	animation: anim-progress-bar-example 2s infinite linear;
 }
-/* prettier-ignore */
-@keyframes progressbar-anim-indeterminate-example {
-	0% { transform: translateX(50%) scaleX(0.5); }
-	50% { transform: translateX(0) scaleX(0.5); }
-	100% { transform: translateX(50%) scaleX(0.5); }
+@keyframes anim-progress-bar-example {
+	0% {
+		transform: translateX(50%) scaleX(0.5);
+	}
+	50% {
+		transform: translateX(0) scaleX(0.5);
+	}
+	100% {
+		transform: translateX(50%) scaleX(0.5);
+	}
 }

--- a/sites/skeleton.dev/src/app.postcss
+++ b/sites/skeleton.dev/src/app.postcss
@@ -49,3 +49,14 @@ body {
 .page-section {
 	@apply space-y-4;
 }
+
+.progressbar-anim-indeterminate-example {
+	transform-origin: 0% 50%;
+	animation: progressbar-anim-indeterminate-example 2s infinite linear;
+}
+/* prettier-ignore */
+@keyframes progressbar-anim-indeterminate-example {
+	0% { transform: translateX(50%) scaleX(0.5); }
+	50% { transform: translateX(0) scaleX(0.5); }
+	100% { transform: translateX(50%) scaleX(0.5); }
+}

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-bars/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-bars/+page.svelte
@@ -80,38 +80,32 @@
 					<CodeBlock language="html" code={`<ProgressBar value={undefined} />`} />
 				</svelte:fragment>
 			</DocsPreview>
-			<h3 class="h3">Custom animation</h3>
-			<p>
-				To use a custom indeterminate animation, provide the animation class with the <code class="code">indeterminateAnimation</code> property.
-			</p>
-			<p>
-				Define or import your animation in the global stylesheet because Svelte uses component-based styles and those defined in the
-				component won't apply to the ProgressBar.
-			</p>
+			<h3 class="h3">Custom Animation</h3>
+			<p>Use the <code class="code">animIndeterminate</code> prop to pass a custom CSS animation for the progress bar meter.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<div class="w-full space-y-10">
-						<ProgressBar indeterminateAnimation="progressbar-anim-indeterminate-example" />
+						<ProgressBar animIndeterminate="anim-progress-bar-example" />
 					</div>
 				</svelte:fragment>
 				<svelte:fragment slot="source">
+					<p>Define your new animation class in your global stylesheet <code class="code">app.postcss</code>.</p>
 					<CodeBlock
 						language="css"
 						code={`
-/* Global Stylesheet */
-
-.anim-indeterminate {
+.anim-progress-bar {
 	transform-origin: 0% 50%;
-	animation: anim-indeterminate  2s infinite linear;
+	animation: anim-progress-bar 2s infinite linear;
 }
-@keyframes anim-indeterminate {
+@keyframes anim-progress-bar {
 	0% { transform: translateX(50%) scaleX(0.5); }
 	50% { transform: translateX(0) scaleX(0.5); }
 	100% { transform: translateX(50%) scaleX(0.5); }
 }
 `}
 					/>
-					<CodeBlock language="html" code={`<ProgressBar indeterminateAnimation="anim-indeterminate"/>`} />
+					<p>Append the animation class to via the <code class="code">animIndeterminate</code> prop.</p>
+					<CodeBlock language="html" code={`<ProgressBar animIndeterminate="anim-progress-bar"/>`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-bars/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-bars/+page.svelte
@@ -80,6 +80,40 @@
 					<CodeBlock language="html" code={`<ProgressBar value={undefined} />`} />
 				</svelte:fragment>
 			</DocsPreview>
+			<h3 class="h3">Custom animation</h3>
+			<p>
+				To use a custom indeterminate animation, provide the animation class with the <code class="code">indeterminateAnimation</code> property.
+			</p>
+			<p>
+				Define or import your animation in the global stylesheet because Svelte uses component-based styles and those defined in the
+				component won't apply to the ProgressBar.
+			</p>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<div class="w-full space-y-10">
+						<ProgressBar indeterminateAnimation="progressbar-anim-indeterminate-example" />
+					</div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock
+						language="css"
+						code={`
+/* Global Stylesheet */
+
+.anim-indeterminate {
+	transform-origin: 0% 50%;
+	animation: anim-indeterminate  2s infinite linear;
+}
+@keyframes anim-indeterminate {
+	0% { transform: translateX(50%) scaleX(0.5); }
+	50% { transform: translateX(0) scaleX(0.5); }
+	100% { transform: translateX(50%) scaleX(0.5); }
+}
+`}
+					/>
+					<CodeBlock language="html" code={`<ProgressBar indeterminateAnimation="anim-indeterminate"/>`} />
+				</svelte:fragment>
+			</DocsPreview>
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Native Alternative</h2>


### PR DESCRIPTION
## Linked Issue

Closes #2281

## Description

Added Prop `indeterminateAnimation` which can be used to supply a custom indeterminate animation.

## Note
@endigo9740 
per your comment:
> @Mahmoud-zino I see what you mean, if there's not equivalent ways to handle these animation properties in a piecemeal fashion, then allowing folks to replace the entire animation may be the best route here. I'd suggest researching the former, and if not possible we go with the latter.

- the first option is not possible (see last option for something similar ^^).
- the second option is possible but requires users to define their animations in the global style-sheet, not great but sadly I can't think of anything else that could be easy to implement without introducing another dependency, so I implemented it but feel free to close the PR if this is something we don't want to do.
- A third option would be to define custom utilities for tailwind to target the animations. It would be nice but it feels like creating (again the next option :smile: ) from scratch...
- The last option I found was to use plugins, I didn't use any until now but at a quick glance [tailwindcss-animated](https://github.com/new-data-services/tailwindcss-animated) seems like a good addition.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
