### PR TITLE
Feat: Avatar fontSize prop

### DIFF
--- a/.changeset/smart-ligers-rest.md
+++ b/.changeset/smart-ligers-rest.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+Added a new `fontSize` prop to the Avatar component to control the size of the initials

--- a/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
+++ b/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
@@ -8,7 +8,7 @@
 	export let initials = 'AB';
 	/** Initials only - Provide classes to set the SVG text fill color. */
 	export let fill: CssClasses = 'fill-token';
-	/** Initials only - Provide a font size for the initials */
+	/** Initials only - Set the base font size for the scalable SVG text. */
 	export let fontSize = 150;
 
 	// Props (actions)

--- a/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
+++ b/packages/skeleton/src/lib/components/Avatar/Avatar.svelte
@@ -8,6 +8,8 @@
 	export let initials = 'AB';
 	/** Initials only - Provide classes to set the SVG text fill color. */
 	export let fill: CssClasses = 'fill-token';
+	/** Initials only - Provide a font size for the initials */
+	export let fontSize = 150;
 
 	// Props (actions)
 	/** Provide the avatar image element source. */
@@ -64,7 +66,15 @@
 		/>
 	{:else}
 		<svg class="avatar-initials w-full h-full" viewBox="0 0 512 512">
-			<text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-weight="bold" font-size={150} class="avatar-text {fill}">
+			<text
+				x="50%"
+				y="50%"
+				dominant-baseline="central"
+				text-anchor="middle"
+				font-weight="bold"
+				font-size={fontSize}
+				class="avatar-text {fill}"
+			>
 				{String(initials).substring(0, 2).toUpperCase()}
 			</text>
 		</svg>

--- a/packages/skeleton/src/lib/components/Avatar/Avatar.test.ts
+++ b/packages/skeleton/src/lib/components/Avatar/Avatar.test.ts
@@ -22,6 +22,7 @@ describe('Avatar.svelte', () => {
 				// Props (initials)
 				initials: 'AB',
 				text: 'text-xl',
+				fontSize: 100,
 				color: 'text-white'
 			}
 		});


### PR DESCRIPTION
## Linked Issue

Closes #2321

## Description

Added a ``fontSize`` prop that targets the font size for the initials, this allows for more fine grained control over the initials when having bigger or smaller avatars

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
