### PR TITLE
bugfix/input-readonly-border

### DIFF
--- a/.changeset/tough-ghosts-lie.md
+++ b/.changeset/tough-ghosts-lie.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": patch
+---
+
+bugfix: fixed Input layout shift when the readonly state changes.

--- a/packages/plugin/src/styles/components/forms.css
+++ b/packages/plugin/src/styles/components/forms.css
@@ -121,7 +121,7 @@
 	.input[readonly],
 	.textarea[readonly],
 	.select[readonly] {
-		@apply !border-0 !cursor-not-allowed hover:!brightness-100;
+		@apply !border-transparent !cursor-not-allowed hover:!brightness-100;
 	}
 
 	/* === Input Groups === */


### PR DESCRIPTION
## Linked Issue

Closes #2244

## Description

readonly sets the border to transparent instead of decreasing its size

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
