### PR TITLE
Chore/modal transition padding prop

### DIFF
--- a/.changeset/smooth-sloths-work.md
+++ b/.changeset/smooth-sloths-work.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: Modal backdrop padding can now be overwritten via `regionProp` and `backdropClasses`

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -25,13 +25,13 @@
 	import { getModalStore } from './stores.js';
 	import type { ModalComponent, ModalSettings } from './types.js';
 
-	// Props
-	/** Set the modal position within the backdrop container */
-	export let position: CssClasses = 'items-center';
-
 	// Props (components)
 	/** Register a list of reusable component modals. */
 	export let components: Record<string, ModalComponent> = {};
+
+	// Props (backdrop)
+	/** Set the modal position within the backdrop container */
+	export let position: CssClasses = 'items-center';
 
 	// Props (modal)
 	/** Provide classes to style the modal background. */
@@ -64,8 +64,8 @@
 	export let buttonTextSubmit: CssClasses = 'Submit';
 
 	// Props (regions)
-	/** Provide classes to style the backdrop. */
-	export let regionBackdrop: CssClasses = 'bg-surface-backdrop-token';
+	/** Provide arbitrary classes to the backdrop region. */
+	export let regionBackdrop: CssClasses = '';
 	/** Provide arbitrary classes to modal header region. */
 	export let regionHeader: CssClasses = 'text-2xl font-bold';
 	/** Provide arbitrary classes to modal body region. */
@@ -101,8 +101,8 @@
 	export let transitionOutParams: TransitionParams<TransitionOut> = { duration: 150, opacity: 0, x: 0, y: 100 };
 
 	// Base Styles
-	const cBackdrop = 'fixed top-0 left-0 right-0 bottom-0';
-	const cTransitionLayer = 'w-full h-fit min-h-full p-4 overflow-y-auto flex justify-center';
+	const cBackdrop = 'fixed top-0 left-0 right-0 bottom-0 bg-surface-backdrop-token p-4';
+	const cTransitionLayer = 'w-full h-fit min-h-full overflow-y-auto flex justify-center';
 	const cModal = 'block overflow-y-auto'; // max-h-full overflow-y-auto overflow-x-hidden
 	const cModalImage = 'w-full h-auto';
 

--- a/sites/skeleton.dev/src/lib/modals/examples/ModalExampleFullscreen.svelte
+++ b/sites/skeleton.dev/src/lib/modals/examples/ModalExampleFullscreen.svelte
@@ -10,12 +10,8 @@
 
 	const modalStore = getModalStore();
 
-	/*
-		Notes:
-		- Use `w-screen h-screen` to fit the visible canvas size.
-		- Use `-m-4` to counter the backdrop padding (FIXME: incoming in Skeleton v3+)
-	*/
-	const cBase = 'bg-surface-100-800-token w-screen h-screen -m-4 p-4 flex justify-center items-center';
+	// Notes: Use `w-screen h-screen` to fit the visible canvas size.
+	const cBase = 'bg-surface-100-800-token w-screen h-screen p-4 flex justify-center items-center';
 </script>
 
 {#if $modalStore[0]}


### PR DESCRIPTION
## Linked Issue

Closes #2050

## Description

Adjusts a few styles to ensure the backdrop padding can be overwritten. Which is now possible via both the `regionBackdrop` prop AND the ModalSettings `backdropClasses` parameter. This is beneficial for full screen modals, since we no longer have to set a negative margin to counter-act this.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
