### PR TITLE
Bugfix/modal prompt inconsistent type

### DIFF
--- a/.changeset/stupid-maps-peel.md
+++ b/.changeset/stupid-maps-peel.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: Modal Prompt always returns string as result.
+bugfix: Modal Prompt of type number returns number as result.

--- a/.changeset/stupid-maps-peel.md
+++ b/.changeset/stupid-maps-peel.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Modal Prompt always returns string as result.

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -125,7 +125,7 @@
 	modalStore.subscribe((modals: ModalSettings[]) => {
 		if (!modals.length) return;
 		// Set Prompt input value and type
-		if (modals[0].type === 'prompt') promptValue = modals[0].value?.toString();
+		if (modals[0].type === 'prompt') promptValue = modals[0].value;
 		// Override button text per instance, if available
 		buttonTextCancel = modals[0].buttonTextCancel || buttonTextDefaults.buttonTextCancel;
 		buttonTextConfirm = modals[0].buttonTextConfirm || buttonTextDefaults.buttonTextConfirm;
@@ -183,7 +183,11 @@
 
 	function onPromptSubmit(event: SvelteEvent<SubmitEvent, HTMLFormElement>): void {
 		event.preventDefault();
-		if ($modalStore[0].response) $modalStore[0].response(promptValue);
+		if ($modalStore[0].response) {
+			if ($modalStore[0].valueAttr !== undefined && 'type' in $modalStore[0].valueAttr && $modalStore[0].valueAttr.type === 'number')
+				$modalStore[0].response(parseInt(promptValue));
+			else $modalStore[0].response(promptValue);
+		}
 		modalStore.close();
 	}
 

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -125,7 +125,7 @@
 	modalStore.subscribe((modals: ModalSettings[]) => {
 		if (!modals.length) return;
 		// Set Prompt input value and type
-		if (modals[0].type === 'prompt') promptValue = modals[0].value;
+		if (modals[0].type === 'prompt') promptValue = modals[0].value?.toString();
 		// Override button text per instance, if available
 		buttonTextCancel = modals[0].buttonTextCancel || buttonTextDefaults.buttonTextCancel;
 		buttonTextConfirm = modals[0].buttonTextConfirm || buttonTextDefaults.buttonTextConfirm;


### PR DESCRIPTION
## Linked Issue

Closes #2283

## Description

when using "any" as the type of the variable we return number if the default value is not changed, but when it is changed the variable will have the type string (changed by the input) which is causing the inconsistency.
to solve this I converted any input to string (with accounting for null an undefined).

----

After further discussion, we decided to cast only numbers when the prompt modal of type number.
Discussion: https://discord.com/channels/1003691521280856084/1003699523522142399/1187099645684498512

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
