### PR TITLE
Bugfix; Removed manual subscription in Modal component causing memory leak

### DIFF
--- a/.changeset/gentle-melons-decide.md
+++ b/.changeset/gentle-melons-decide.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+Replaced manual subscription with automatic subscriptions handled by svelte

--- a/.changeset/gentle-melons-decide.md
+++ b/.changeset/gentle-melons-decide.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-Replaced manual subscription with automatic subscriptions handled by svelte
+bugfix: Replaced modal manual subscription with an automatic subscription handled by Svelte

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -121,7 +121,6 @@
 	// Modal Store Subscription
 	$: if ($modalStore.length) handleModals($modalStore);
 
-	// Handle Modals
 	function handleModals(modals: ModalSettings[]) {
 		// Set Prompt input value and type
 		if (modals[0].type === 'prompt') promptValue = modals[0].value;

--- a/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
+++ b/packages/skeleton/src/lib/utilities/Modal/Modal.svelte
@@ -119,8 +119,10 @@
 	const modalStore = getModalStore();
 
 	// Modal Store Subscription
-	modalStore.subscribe((modals: ModalSettings[]) => {
-		if (!modals.length) return;
+	$: if ($modalStore.length) handleModals($modalStore);
+
+	// Handle Modals
+	function handleModals(modals: ModalSettings[]) {
 		// Set Prompt input value and type
 		if (modals[0].type === 'prompt') promptValue = modals[0].value;
 		// Override button text per instance, if available
@@ -129,7 +131,7 @@
 		buttonTextSubmit = modals[0].buttonTextSubmit || buttonTextDefaults.buttonTextSubmit;
 		// Set Active Component
 		currentComponent = typeof modals[0].component === 'string' ? components[modals[0].component] : modals[0].component;
-	});
+	}
 
 	// Event Handlers ---
 	function onBackdropInteractionBegin(event: SvelteEvent<MouseEvent, HTMLDivElement>): void {


### PR DESCRIPTION
## Linked Issue

Closes #2335

## Description

Removed manual subscription in favor of svelte's auto subscription syntax ($), this removes the need to manually unsubscribe (which wasn't done in the first place).

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
