### PR TITLE
Blog style PurgeCSS fix

### DIFF
--- a/sites/skeleton.dev/vite.config.ts
+++ b/sites/skeleton.dev/vite.config.ts
@@ -20,6 +20,8 @@ const config: UserConfig = {
 				greedy: [
 					// Used for Highlight.js (code blocks)
 					/^hljs-/,
+					// Used for Highlight.js (code blocks)
+					/^kg-/,
 					// Used for Carbon ad styles
 					/carbonads/
 				]


### PR DESCRIPTION
## Linked Issue

Closes #2268

## Description

Resolve an issue that allows PurgeCSS to remove required blog styles.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
