### PR TITLE
Updated table style and add reactive data example

### DIFF
--- a/.changeset/spotty-ads-care.md
+++ b/.changeset/spotty-ads-care.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": patch
+---
+
+chore: Table element styles now use a `md:` breakpoint for adjusting whitespace settings for cells

--- a/packages/plugin/src/styles/components/tables.css
+++ b/packages/plugin/src/styles/components/tables.css
@@ -54,8 +54,9 @@
 	}
 
 	.table tbody td {
-		/* NOTE: removed this to allow wrapping */
-		@apply text-sm px-3 py-4 align-top whitespace-nowrap lg:whitespace-normal;
+		/* FIXME: let's abstract the whitespace setting to a standalone utility class in v3 */
+		/* https://github.com/skeletonlabs/skeleton/issues/2302#issuecomment-1865051861 */
+		@apply text-sm px-3 py-4 align-top whitespace-nowrap md:whitespace-normal;
 	}
 
 	.table-compact tbody td {

--- a/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
@@ -45,12 +45,20 @@
 	};
 
 	// Local
-	const sourceData = [
+	let sourceData = [
 		{ position: 1, name: 'Hydrogen', weight: 1.0079, symbol: 'H' },
 		{ position: 2, name: 'Helium', weight: 4.0026, symbol: 'He' },
 		{ position: 3, name: 'Lithium', weight: 6.941, symbol: 'Li' },
 		{ position: 4, name: 'Beryllium', weight: 9.0122, symbol: 'Be' },
 		{ position: 5, name: 'Boron', weight: 10.811, symbol: 'B' }
+	];
+
+	let sourceDataUpdated = [
+		{ position: 1, name: 'Hydrogen XXX', weight: 1.0079, symbol: 'H' },
+		{ position: 2, name: 'Helium XXX', weight: 4.0026, symbol: 'He' },
+		{ position: 3, name: 'Lithium XXX', weight: 6.941, symbol: 'Li' },
+		{ position: 4, name: 'Beryllium XXX', weight: 9.0122, symbol: 'Be' },
+		{ position: 5, name: 'Boron XXX', weight: 10.811, symbol: 'B' }
 	];
 
 	// Table Simple
@@ -118,6 +126,7 @@ const tableSimple: TableSource = {
 
 	<!-- Slot: Usage -->
 	<svelte:fragment slot="usage">
+		<!-- Interactive Mode -->
 		<section class="space-y-4">
 			<h2 class="h2">Interactive Mode</h2>
 			<p>
@@ -127,6 +136,29 @@ const tableSimple: TableSource = {
 				<code class="code">meta</code> value.
 			</p>
 			<CodeBlock language="html" code={`<Table ... interactive={true} on:selected={mySelectionHandler} />`} />
+		</section>
+		<!-- Handling Reactive Data -->
+		<section class="space-y-4">
+			<h2 class="h2">Handling Reactive Data</h2>
+			<!-- prettier-ignore -->
+			<p>
+				In some scenarios you may need need to rreactive manner. Since <code class="code">TableSource</code> is a Javascript object, it will need to follow Svelte's rules for <a class="anchor" href="https://learn.svelte.dev/tutorial/updating-arrays-and-objects" target="_blank" rel="noreferrer">reactive object updates</a>.
+			</p>
+			<CodeBlock
+				language="ts"
+				code={`
+function setTableSource(): TableSource {
+	return {
+		head: ['Symbol', 'Name', 'weight'],
+		body: tableMapperValues(sourceData, ['symbol', 'name', 'weight']),
+		meta: tableMapperValues(sourceData, ['name', 'symbol', 'weight']),
+		foot: ['Total Elements', '', \`<span class="badge variant-soft-primary">${sourceData.length} Elements</span>\`]
+	};
+}\n
+// If sourceData updates, set the new TableSource values
+$: tableSimple = sourceData ? setTableSource() : undefined;
+		`}
+			/>
 		</section>
 		<!-- Table Utilities -->
 		<section class="space-y-4">

--- a/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
@@ -142,7 +142,7 @@ const tableSimple: TableSource = {
 			<h2 class="h2">Handling Reactive Data</h2>
 			<!-- prettier-ignore -->
 			<p>
-				In some scenarios you may need need to rreactive manner. Since <code class="code">TableSource</code> is a Javascript object, it will need to follow Svelte's rules for <a class="anchor" href="https://learn.svelte.dev/tutorial/updating-arrays-and-objects" target="_blank" rel="noreferrer">reactive object updates</a>.
+				In some scenarios you may need need to reactive manner. Since <code class="code">TableSource</code> is a Javascript object, it will need to follow Svelte's rules for <a class="anchor" href="https://learn.svelte.dev/tutorial/updating-arrays-and-objects" target="_blank" rel="noreferrer">reactive object updates</a>.
 			</p>
 			<CodeBlock
 				language="ts"

--- a/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
@@ -53,14 +53,6 @@
 		{ position: 5, name: 'Boron', weight: 10.811, symbol: 'B' }
 	];
 
-	let sourceDataUpdated = [
-		{ position: 1, name: 'Hydrogen XXX', weight: 1.0079, symbol: 'H' },
-		{ position: 2, name: 'Helium XXX', weight: 4.0026, symbol: 'He' },
-		{ position: 3, name: 'Lithium XXX', weight: 6.941, symbol: 'Li' },
-		{ position: 4, name: 'Beryllium XXX', weight: 9.0122, symbol: 'Be' },
-		{ position: 5, name: 'Boron XXX', weight: 10.811, symbol: 'B' }
-	];
-
 	// Table Simple
 	const tableSimple: TableSource = {
 		head: ['Symbol', 'Name', 'weight'],

--- a/sites/skeleton.dev/src/routes/(inner)/elements/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/tables/+page.svelte
@@ -7,6 +7,9 @@
 	// Components
 	import { CodeBlock, TabGroup, Tab } from '@skeletonlabs/skeleton';
 
+	const lorem =
+		'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Perspiciatis animi, ullam excepturi at necessitatibus magni, voluptatem unde tenetur aliquam maxime quibusdam beatae non atque enim, fugit officiis temporibus aperiam cumque.';
+
 	// Docs Shell
 	const settings: DocsShellSettings = {
 		feature: DocsFeature.Element,
@@ -57,7 +60,7 @@
 						<tbody>
 							{#each tableArr as row}
 								<tr>
-									<td>{row.name}</td>
+									<td>{row.name} - {lorem}</td>
 									<td>{row.symbol}</td>
 									<td><span class="badge variant-soft-primary">{row.atomicNumber}</span></td>
 								</tr>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/tables/+page.svelte
@@ -7,9 +7,6 @@
 	// Components
 	import { CodeBlock, TabGroup, Tab } from '@skeletonlabs/skeleton';
 
-	const lorem =
-		'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Perspiciatis animi, ullam excepturi at necessitatibus magni, voluptatem unde tenetur aliquam maxime quibusdam beatae non atque enim, fugit officiis temporibus aperiam cumque.';
-
 	// Docs Shell
 	const settings: DocsShellSettings = {
 		feature: DocsFeature.Element,
@@ -60,7 +57,7 @@
 						<tbody>
 							{#each tableArr as row}
 								<tr>
-									<td>{row.name} - {lorem}</td>
+									<td>{row.name}</td>
 									<td>{row.symbol}</td>
 									<td><span class="badge variant-soft-primary">{row.atomicNumber}</span></td>
 								</tr>


### PR DESCRIPTION
## Linked Issue

Closes #2302
Closes #2318

## Description

> NOTE: I grouped these since they are both related to tables

1. Element: Adjusts the whitespace breakpoint from `lg` -> `md`
2. Component: Adds a reactive table data example to the docs

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
