### PR TITLE
chore: Fix watcher plugin for Windows users

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"preinstall": "npx only-allow pnpm",
 		"getall": "node scripts/checkout.cjs && pnpm i",
 		"postinstall": "pnpm -r sync",
-		"dev": "pnpm --no-sort --filter=skeleton.dev --filter=@skeletonlabs/tw-plugin dev",
+		"dev": "pnpm --no-sort --filter=skeleton.dev dev",
 		"csa": "node ./packages/create-skeleton-app/src/index.js --types=typescript --prettier --eslint --playwright=false --vitest=false --codeblocks --popups --typography --forms -t=skeleton --skeletontemplate=welcome -p=sites --monorepo --inspector",
 		"csl": "node ./packages/create-skeleton-app/src/index.js --types=typescript --library --prettier --eslint --playwright --vitest --codeblocks --popups --typography --forms -t=skeleton --skeletontemplate=bare -p=packages --monorepo --inspector",
 		"templategen": "node ./scripts/template-gen.js",

--- a/sites/skeleton.dev/vite-plugin-skeleton-plugin-watcher/index.ts
+++ b/sites/skeleton.dev/vite-plugin-skeleton-plugin-watcher/index.ts
@@ -5,7 +5,7 @@ import { join, resolve, basename } from 'path';
 
 export default function skeletonPluginWatcher(): Plugin {
 	const pluginSrcPath = resolve('.', join('..', '..', 'packages', 'plugin', 'src'));
-	const mm = new Minimatch(join(pluginSrcPath, '**/*'));
+	const mm = new Minimatch('**/packages/plugin/src/**/*');
 	let locked = false;
 
 	return {
@@ -13,7 +13,7 @@ export default function skeletonPluginWatcher(): Plugin {
 		configureServer(vite) {
 			vite.watcher.add(pluginSrcPath);
 			vite.watcher.on('all', async (event, path) => {
-				if (mm.match(path) && !path.includes('/generated/')) {
+				if (mm.match(path) && !path.includes('generated')) {
 					console.log(`[TW Plugin]: File Updated: ${basename(path)}`);
 					if (!locked) {
 						locked = true;


### PR DESCRIPTION
## Description

This PR addresses an issue where our watcher plugin that rebuilds the TW plugin previously didn't work for contributors that were using Windows.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
