### PR TITLE
Step events now occur in parent Stepper

### DIFF
--- a/.changeset/eight-bugs-report.md
+++ b/.changeset/eight-bugs-report.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+bugfix: Step events now happen in the parent Stepper, matching the documentation spec

--- a/packages/skeleton/src/lib/components/Stepper/Stepper.svelte
+++ b/packages/skeleton/src/lib/components/Stepper/Stepper.svelte
@@ -100,12 +100,39 @@
 	// Stores
 	let state: Writable<StepperState> = writable({ current: start, total: 0 });
 
+	// Event Handlers
+	async function onNext(locked: boolean, stepIndex: number) {
+		// Allows any forms to submit before the Step is removed from the DOM:
+		// https://github.com/skeletonlabs/skeleton/issues/1328
+		await new Promise((resolve) => setTimeout(resolve));
+
+		if (locked) return;
+		$state.current++;
+		/** @event { step: number, $state: StepperState } next - Fires when the NEXT button is pressed per step.  */
+		dispatch('next', { step: stepIndex, state: $state });
+		/** @event { step: number, $state: StepperState } step - Fires when a next/previous step occurs.  */
+		dispatch('step', { step: stepIndex, state: $state });
+	}
+	function onBack(stepIndex: number) {
+		$state.current--;
+		/** @event { step: number, $state: StepperState } back - Fires when the BACK button is pressed per step.  */
+		dispatch('back', { step: stepIndex, state: $state });
+		dispatch('step', { step: stepIndex, state: $state });
+	}
+	function onComplete(stepIndex: number) {
+		/** @event { step: number, $state: StepperState } complete - Fires when the COMPLETE button is pressed.  */
+		dispatch('complete', { step: stepIndex, state: $state });
+	}
+
 	// Context
 	setContext('state', state);
-	setContext('dispatchParent', dispatch);
 	setContext('stepTerm', stepTerm);
 	setContext('gap', gap);
 	setContext('justify', justify);
+	// ---
+	setContext('onNext', onNext);
+	setContext('onBack', onBack);
+	setContext('onComplete', onComplete);
 	// ---
 	setContext('buttonBack', buttonBack);
 	setContext('buttonBackType', buttonBackType);


### PR DESCRIPTION
## Linked Issue

Closes #2323

## Description

Rather than pass the event dispatcher down through the context API, we now instead pass the individual event handler functions. This ensures the events trigger in the parent, which means the documentation matches implementation.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
