### PR TITLE
Update input group doc layout

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/elements/forms/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/forms/+page.svelte
@@ -461,7 +461,7 @@ export default {
 			</ul>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
-					<div class="w-full grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div class="w-full grid grid-cols-1 gap-4">
 						<label class="label">
 							<span>Website</span>
 							<div class="input-group input-group-divider grid-cols-[auto_1fr_auto]">


### PR DESCRIPTION
## Linked Issue

Closes #2230

## Description

Updated the input-group docs to showcase the examples in a vertical column rather than a 2x2 grid.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
