### PR TITLE
chore: Use the `ActionReturn` type for the `clipboard` action

### DIFF
--- a/.changeset/nervous-roses-arrive.md
+++ b/.changeset/nervous-roses-arrive.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: Use the `ActionReturn` type for the `clipboard` action

--- a/packages/skeleton/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
+++ b/packages/skeleton/src/lib/actions/Clipboard/additional-svelte-typings.d.ts
@@ -1,5 +1,0 @@
-declare namespace svelteHTML {
-	interface HTMLAttributes {
-		'on:copyComplete'?: () => void;
-	}
-}

--- a/packages/skeleton/src/lib/actions/Clipboard/clipboard.ts
+++ b/packages/skeleton/src/lib/actions/Clipboard/clipboard.ts
@@ -5,9 +5,10 @@ type ClipboardArgs = string | { element: string } | { input: string };
 type ClipboardAttributes = { 'on:copyComplete'?: () => void };
 export function clipboard(node: HTMLElement, args: ClipboardArgs): ActionReturn<ClipboardArgs, ClipboardAttributes> {
 	if (!window.isSecureContext) {
-		throw new Error(
+		console.error(
 			'Clipboard action failed: app not running in secure context, see: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard'
 		);
+		return {};
 	}
 	const fireCopyCompleteEvent = () => {
 		node.dispatchEvent(new CustomEvent('copyComplete'));

--- a/packages/skeleton/src/lib/actions/Clipboard/clipboard.ts
+++ b/packages/skeleton/src/lib/actions/Clipboard/clipboard.ts
@@ -1,11 +1,13 @@
+import type { ActionReturn } from 'svelte/action';
+
 // Action: Clipboard
 type ClipboardArgs = string | { element: string } | { input: string };
-export function clipboard(node: HTMLElement, args: ClipboardArgs) {
+type ClipboardAttributes = { 'on:copyComplete'?: () => void };
+export function clipboard(node: HTMLElement, args: ClipboardArgs): ActionReturn<ClipboardArgs, ClipboardAttributes> {
 	if (!window.isSecureContext) {
-		console.error(
+		throw new Error(
 			'Clipboard action failed: app not running in secure context, see: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard'
 		);
-		return;
 	}
 	const fireCopyCompleteEvent = () => {
 		node.dispatchEvent(new CustomEvent('copyComplete'));


### PR DESCRIPTION
## Description

Noticed that we were using an `additional-svelte-typings.d.ts` type declaration file to type the `copyComplete` event for the clipboard action. This PR replaces that with the more idiomatic approach of using the `ActionReturn` type instead.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
