### PR TITLE
Bugfix/center

### DIFF
--- a/.changeset/rotten-stingrays-deny.md
+++ b/.changeset/rotten-stingrays-deny.md
@@ -1,0 +1,5 @@
+---
+"create-skeleton-app": patch
+---
+
+Vertically center content for barebones template.

--- a/.changeset/rotten-stingrays-deny.md
+++ b/.changeset/rotten-stingrays-deny.md
@@ -2,4 +2,4 @@
 "create-skeleton-app": patch
 ---
 
-Vertically center content for barebones template.
+bugfix:Vertically center content for barebones template.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Closes #{issueNumber}
 
 ## Changsets
 
-Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.
+Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm cs` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.
 
 ## Checklist
 

--- a/packages/create-skeleton-app/templates/skeleton-template-bare/src/app.postcss
+++ b/packages/create-skeleton-app/templates/skeleton-template-bare/src/app.postcss
@@ -2,3 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 @tailwind variants;
+
+html,
+body {
+	@apply h-full;
+}


### PR DESCRIPTION
## Linked Issue
https://github.com/skeletonlabs/create-skeleton-app/issues/41


## Description

Applies the tailwind class h-full to html and body elements in the barebones template so that the content is centered.


## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x ] This PR targets the `dev` branch (NEVER `master`)
- [x ] Documentation reflects all relevant changes
- [x ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x ] Ensure Prettier linting is current - run `pnpm format`
- [x ] All test cases are passing - run `pnpm test`
- [x ] Includes a changeset (if relevant; see above)
