### PR TITLE
bugfix: deleted unused props

### DIFF
--- a/.changeset/famous-pots-trade.md
+++ b/.changeset/famous-pots-trade.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Deleted recursive-tree-view unused props `disabled` and `open`

--- a/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
+++ b/packages/skeleton/src/lib/components/TreeView/RecursiveTreeView.svelte
@@ -43,10 +43,6 @@
 	export let spacing: CssClasses = 'space-y-1';
 
 	// Props (children)
-	/** Set open by default on load. */
-	export let open = false;
-	/** Set the tree disabled state */
-	export let disabled = false;
 	/** Provide classes to set the tree item padding styles. */
 	export let padding: CssClasses = 'py-4 px-4';
 	/** Provide classes to set the tree children indentation */
@@ -77,11 +73,9 @@
 	export let labelledby = '';
 
 	// Context API
-	setContext('open', open);
 	setContext('selection', selection);
 	setContext('multiple', multiple);
 	setContext('relational', relational);
-	setContext('disabled', disabled);
 	setContext('padding', padding);
 	setContext('indent', indent);
 	setContext('hover', hover);
@@ -114,14 +108,7 @@
 	$: classesBase = `${width} ${spacing} ${$$props.class ?? ''}`;
 </script>
 
-<div
-	class="tree {classesBase}"
-	data-testid="tree"
-	role="tree"
-	aria-multiselectable={multiple}
-	aria-label={labelledby}
-	aria-disabled={disabled}
->
+<div class="tree {classesBase}" data-testid="tree" role="tree" aria-multiselectable={multiple} aria-label={labelledby}>
 	{#if nodes && nodes.length > 0}
 		<RecursiveTreeViewItem
 			{nodes}


### PR DESCRIPTION
## Linked Issue

Closes #2426

## Description

Deleted unused props ` disabled`  and ` open` from the recursive-tree-view

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
