### PR TITLE
bugfix: codeblock copy btn type

### DIFF
--- a/.changeset/nasty-terms-allow.md
+++ b/.changeset/nasty-terms-allow.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: set CodeBlock copy button type to `button` instead of `submit`

--- a/packages/skeleton/src/lib/utilities/CodeBlock/CodeBlock.svelte
+++ b/packages/skeleton/src/lib/utilities/CodeBlock/CodeBlock.svelte
@@ -94,7 +94,7 @@
 		<!-- Language -->
 		<span class="codeblock-language">{languageFormatter(language)}</span>
 		<!-- Copy Button -->
-		<button class="codeblock-btn {button}" on:click={onCopyClick} use:clipboard={code}>
+		<button type="button" class="codeblock-btn {button}" on:click={onCopyClick} use:clipboard={code}>
 			{!copyState ? buttonLabel : buttonCopied}
 		</button>
 	</header>


### PR DESCRIPTION
## Linked Issue

Closes #2416

## Description

changed the type to ` button` so the copy button doesn't submit forms.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
