### PR TITLE
Fix faulty example progress radial documentation

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -135,7 +135,7 @@
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="html"
-						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap={${strokeLinecap}} />`}
+						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap={"${strokeLinecap}"} />`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>

--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-radials/+page.svelte
@@ -135,7 +135,7 @@
 				<svelte:fragment slot="source">
 					<CodeBlock
 						language="html"
-						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap={"${strokeLinecap}"} />`}
+						code={`<ProgressRadial ... stroke={${strokeProps.value}} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap="${strokeLinecap}" />`}
 					/>
 				</svelte:fragment>
 			</DocsPreview>


### PR DESCRIPTION
## Linked Issue

None. 

## Description

The Progress Radials component documentation contains an error in the styling code example, specifically the strokeLinecap should be set to a string 'butt' not a variable called butt. 

Current:
```svelte
<ProgressRadial ... stroke={100} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap={butt} />
```

Corrected:
```svelte
<ProgressRadial ... stroke={100} meter="stroke-primary-500" track="stroke-primary-500/30" strokeLinecap="butt" />
```

## Changsets

chore: Fixed missing quote strings around "butt" in the Progress Radial documentation.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
  - Failing on unmodified file:
 ```bash
│ Error: Module '"$env/static/private"' has no exported member 'VERCEL_ENV'. 
│ import type { LayoutServerLoad } from './$types';
│ import { VERCEL_ENV } from '$env/static/private';
│ ====================================
│ svelte-check found 1 error and 0 warnings in 1 file
└─ Failed in 17.9s at /Users/reinder.vosdewael/repositories/skeleton/sites/skeleton.dev
/Users/reinder.vosdewael/repositories/skeleton/sites/skeleton.dev:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  skeleton.dev@1.0.1 check: `svelte-kit sync && svelte-check --tsconfig ./tsconfig.json
```
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
