### PR TITLE
chore/autocomplete empty html markup rendering

### DIFF
--- a/.changeset/swift-insects-rush.md
+++ b/.changeset/swift-insects-rush.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore:Applied HTML-markup interpretation to Autocomplete-empty-state

--- a/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
+++ b/packages/skeleton/src/lib/components/Autocomplete/Autocomplete.svelte
@@ -174,6 +174,6 @@
 			</ul>
 		</nav>
 	{:else}
-		<div class="autocomplete-empty {classesEmpty}">{emptyState}</div>
+		<div class="autocomplete-empty {classesEmpty}">{@html emptyState}</div>
 	{/if}
 </div>


### PR DESCRIPTION
## Linked Issue

Closes #2447 

## Description

This pull requests adds the already documented feature of rendering HTML-markup for the Autocomplete-components `emptyState`-prop. 

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
