### PR TITLE
Support nested keys with `tableSourceMapper`

### DIFF
--- a/packages/skeleton/src/lib/components/Table/utils.ts
+++ b/packages/skeleton/src/lib/components/Table/utils.ts
@@ -23,7 +23,18 @@
 export function tableSourceMapper(source: any[], keys: string[]): any[] {
 	return source.map((row) => {
 		const mappedRow: any = {};
-		keys.forEach((key) => (mappedRow[key] = row[key]));
+		keys.forEach((key) => {
+			const nestedKeys = key.split('.');
+			let value = row;
+			nestedKeys.forEach(nestedKey => {
+				if (value && (nestedKey in value)) {
+					value = value[nestedKey];
+				} else {
+					value = undefined;
+				}
+			});
+			mappedRow[key] = value;
+		});
 		return mappedRow;
 	});
 }

--- a/packages/skeleton/src/lib/components/Table/utils.ts
+++ b/packages/skeleton/src/lib/components/Table/utils.ts
@@ -26,8 +26,8 @@ export function tableSourceMapper(source: any[], keys: string[]): any[] {
 		keys.forEach((key) => {
 			const nestedKeys = key.split('.');
 			let value = row;
-			nestedKeys.forEach(nestedKey => {
-				if (value && (nestedKey in value)) {
+			nestedKeys.forEach((nestedKey) => {
+				if (value && nestedKey in value) {
 					value = value[nestedKey];
 				} else {
 					value = undefined;


### PR DESCRIPTION
## Linked Issue

Closes #2459

## Description

Adds the ability to use nested keys in `tableSourceMapper`

## Changsets


## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
