### PR TITLE
chore/remove superflous styles from chips and cards docs

### DIFF
--- a/.changeset/fuzzy-apricots-hope.md
+++ b/.changeset/fuzzy-apricots-hope.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+chore:Removed styles from Chips and Cards documentation pages that do not exist.

--- a/sites/skeleton.dev/src/routes/(inner)/elements/cards/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/cards/+page.svelte
@@ -19,12 +19,7 @@
 			['<code class="code">.card</code>', '-', 'Adds basic card styling to any block element.'],
 			['<code class="code">.card-header</code>', '-', 'The header region of the card.'],
 			['<code class="code">.card-footer</code>', '-', 'The footer region of the card.'],
-			['<code class="code">.card-hover</code>', '-', 'Provides an animated hover effect.'],
-			[
-				'<code class="code">.variant-glass-[color]</code>',
-				'primary | secondary | tertiary | success | warning | error | surface',
-				'A semi-transparent glass variation.'
-			]
+			['<code class="code">.card-hover</code>', '-', 'Provides an animated hover effect.']
 		]
 	};
 

--- a/sites/skeleton.dev/src/routes/(inner)/elements/chips/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/chips/+page.svelte
@@ -16,13 +16,6 @@
 		source: 'packages/plugin/src/styles/components/chips.css',
 		classes: [
 			['<code class="code">chip</code>', '', 'Provides the standard chip style.'],
-			['<code class="code">chip-[color]</code>', '<a class="anchor" href="/docs/colors">Any theme color.</a>', 'Applies a variant style.'],
-			['<code class="code">chip-active</code>', '', 'Sets the default active state.'],
-			[
-				'<code class="code">chip-[color]-active</code>',
-				'<a class="anchor" href="/docs/colors">Any theme color.</a>',
-				'Set a colored active state.'
-			],
 			['<code class="code">chip-disabled</code>', '', 'Applies disabled styling.']
 		]
 	};


### PR DESCRIPTION
## Linked Issue

Closes #2463

## Description

Removes superfluous styles from Chips and Cards documentation pages that could potentially confuse users

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
