### PR TITLE
Feat/add disabled to listbox listboxitem

### DIFF
--- a/.changeset/giant-tomatoes-kick.md
+++ b/.changeset/giant-tomatoes-kick.md
@@ -1,6 +1,5 @@
 ---
-"skeleton.dev": minor
 "@skeletonlabs/skeleton": minor
 ---
 
-feat: Added disabled prop to ListBox and ListBoxItem to prevent selection of inner radio/checkbox inputs
+feat: Added `disabled` prop to ListBox and ListBoxItem components.

--- a/.changeset/giant-tomatoes-kick.md
+++ b/.changeset/giant-tomatoes-kick.md
@@ -1,0 +1,6 @@
+---
+"skeleton.dev": minor
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Added disabled prop to ListBox and ListBoxItem to prevent selection of inner radio/checkbox inputs

--- a/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
@@ -20,9 +20,9 @@
 	/** Provide classes to set the listbox item active background styles. */
 	export let active: CssClasses = 'variant-filled';
 	/** Provide classes to set the listbox item active disabled background styles */
-	export let activeDisabled: CssClasses = 'variant-soft';
+	export let activeDisabled: CssClasses = 'variant-ghost';
 	/** Provide classes to set the listbox item hover background styles. */
-	export let hover: CssClasses = 'hover:variant-ghost';
+	export let hover: CssClasses = 'hover:variant-soft';
 	/** Provide classes to set the listbox item padding styles. */
 	export let padding: CssClasses = 'px-4 py-2';
 

--- a/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
@@ -19,8 +19,6 @@
 	// Props (styles) - Item Only
 	/** Provide classes to set the listbox item active background styles. */
 	export let active: CssClasses = 'variant-filled';
-	/** Provide classes to set the listbox item inactive background styles */
-	export let inactive: CssClasses = 'variant-ghost';
 	/** Provide classes to set the listbox item hover background styles. */
 	export let hover: CssClasses = 'hover:variant-soft';
 	/** Provide classes to set the listbox item padding styles. */
@@ -43,7 +41,6 @@
 	setContext('multiple', multiple);
 	setContext('rounded', rounded);
 	setContext('active', active);
-	setContext('inactive', inactive);
 	setContext('hover', hover);
 	setContext('padding', padding);
 	setContext('regionLead', regionLead);

--- a/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
@@ -7,6 +7,8 @@
 	// Props
 	/** Enable selection of multiple items. */
 	export let multiple = false;
+	/** Disables selection of items. */
+	export let disabled = false;
 
 	// Props (styles)
 	/** Provide class to set the vertical spacing style. */
@@ -17,8 +19,10 @@
 	// Props (styles) - Item Only
 	/** Provide classes to set the listbox item active background styles. */
 	export let active: CssClasses = 'variant-filled';
+	/** Provide classes to set the listbox item active disabled background styles */
+	export let activeDisabled: CssClasses = 'variant-soft';
 	/** Provide classes to set the listbox item hover background styles. */
-	export let hover: CssClasses = 'hover:variant-soft';
+	export let hover: CssClasses = 'hover:variant-ghost';
 	/** Provide classes to set the listbox item padding styles. */
 	export let padding: CssClasses = 'px-4 py-2';
 
@@ -35,9 +39,11 @@
 	export let labelledby = '';
 
 	// Context
+	setContext('disabledItems', disabled);
 	setContext('multiple', multiple);
 	setContext('rounded', rounded);
 	setContext('active', active);
+	setContext('activeDisabled', activeDisabled);
 	setContext('hover', hover);
 	setContext('padding', padding);
 	setContext('regionLead', regionLead);

--- a/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBox.svelte
@@ -19,8 +19,8 @@
 	// Props (styles) - Item Only
 	/** Provide classes to set the listbox item active background styles. */
 	export let active: CssClasses = 'variant-filled';
-	/** Provide classes to set the listbox item active disabled background styles */
-	export let activeDisabled: CssClasses = 'variant-ghost';
+	/** Provide classes to set the listbox item inactive background styles */
+	export let inactive: CssClasses = 'variant-ghost';
 	/** Provide classes to set the listbox item hover background styles. */
 	export let hover: CssClasses = 'hover:variant-soft';
 	/** Provide classes to set the listbox item padding styles. */
@@ -39,11 +39,11 @@
 	export let labelledby = '';
 
 	// Context
-	setContext('disabledItems', disabled);
+	setContext('disabled', disabled);
 	setContext('multiple', multiple);
 	setContext('rounded', rounded);
 	setContext('active', active);
-	setContext('activeDisabled', activeDisabled);
+	setContext('inactive', inactive);
 	setContext('hover', hover);
 	setContext('padding', padding);
 	setContext('regionLead', regionLead);

--- a/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
@@ -17,11 +17,15 @@
 	export let name: string;
 	/** Set the input's value. */
 	export let value: any;
+	/** Disables selection of the item. */
+	export let disabled: boolean = false;
 
 	// Context
+	export let disabledItems: boolean = getContext('disabledItems');
 	export let multiple: string = getContext('multiple');
 	export let rounded: CssClasses = getContext('rounded');
 	export let active: CssClasses = getContext('active');
+	export let activeDisabled: CssClasses = getContext('activeDisabled');
 	export let hover: CssClasses = getContext('hover');
 	export let padding: CssClasses = getContext('padding');
 	export let regionLead: CssClasses = getContext('regionLead');
@@ -29,7 +33,7 @@
 	export let regionTrail: CssClasses = getContext('regionTrail');
 
 	// Classes
-	const cBase = 'cursor-pointer -outline-offset-[3px]';
+	const cBase = '-outline-offset-[3px]';
 	const cLabel = 'flex items-center space-x-4';
 
 	// Local
@@ -95,8 +99,9 @@
 
 	// Reactive
 	$: selected = multiple ? group.some((groupVal: unknown) => areDeeplyEqual(value, groupVal)) : areDeeplyEqual(group, value);
-	$: classesActive = selected ? active : hover;
-	$: classesBase = `${cBase} ${rounded} ${padding} ${classesActive} ${$$props.class ?? ''}`;
+	$: enabled = (!disabledItems && !disabled) ? 'cursor-pointer' : 'cursor-default';
+	$: classesActive = !disabledItems && !disabled ? (selected ? active : hover) : (selected ? activeDisabled : '');
+	$: classesBase = `${cBase} ${enabled} ${rounded} ${padding} ${classesActive} ${$$props.class ?? ''}`;
 	$: classesLabel = `${cLabel}`;
 	$: classesRegionLead = `${cRegionLead} ${regionLead}`;
 	$: classesRegionDefault = `${cRegionDefault} ${regionDefault}`;
@@ -119,9 +124,9 @@
 		<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
 		<div class="h-0 w-0 overflow-hidden">
 			{#if multiple}
-				<input bind:this={elemInput} type="checkbox" {name} {value} bind:checked tabindex="-1" on:click on:change />
+				<input disabled={disabledItems || disabled} bind:this={elemInput} type="checkbox" {name} {value} bind:checked tabindex="-1" on:click on:change />
 			{:else}
-				<input bind:this={elemInput} type="radio" bind:group {name} {value} tabindex="-1" on:click on:change />
+				<input disabled={disabledItems || disabled} bind:this={elemInput} type="radio" bind:group {name} {value} tabindex="-1" on:click on:change />
 			{/if}
 		</div>
 		<!-- <slot /> -->

--- a/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
@@ -99,7 +99,7 @@
 
 	// Reactive
 	$: selected = multiple ? group.some((groupVal: unknown) => areDeeplyEqual(value, groupVal)) : areDeeplyEqual(group, value);
-	$: enabled = (!disabledItems && !disabled) ? 'cursor-pointer' : 'cursor-default';
+	$: enabled = !disabledItems && !disabled ? 'cursor-pointer' : 'cursor-default';
 	$: classesActive = !disabledItems && !disabled ? (selected ? active : hover) : (selected ? activeDisabled : '');
 	$: classesBase = `${cBase} ${enabled} ${rounded} ${padding} ${classesActive} ${$$props.class ?? ''}`;
 	$: classesLabel = `${cLabel}`;

--- a/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
@@ -23,7 +23,6 @@
 	export let multiple: string = getContext('multiple');
 	export let rounded: CssClasses = getContext('rounded');
 	export let active: CssClasses = getContext('active');
-	export let inactive: CssClasses = getContext('inactive');
 	export let hover: CssClasses = getContext('hover');
 	export let padding: CssClasses = getContext('padding');
 	export let regionLead: CssClasses = getContext('regionLead');
@@ -32,6 +31,7 @@
 
 	// Classes
 	const cBase = 'cursor-pointer -outline-offset-[3px]';
+	const cDisabled = 'opacity-50 !cursor-default';
 	const cLabel = 'flex items-center space-x-4';
 
 	// Local
@@ -97,8 +97,9 @@
 
 	// Reactive
 	$: selected = multiple ? group.some((groupVal: unknown) => areDeeplyEqual(value, groupVal)) : areDeeplyEqual(group, value);
-	$: classesActive = !disabled ? (selected ? active : hover) : (selected ? inactive : '');
-	$: classesBase = `${cBase} ${rounded} ${padding} ${classesActive} ${$$props.class ?? ''}`;
+	$: classesActive = selected ? active : !disabled ? hover : '';
+	$: classesDisabled = disabled ? cDisabled : '';
+	$: classesBase = `${cBase} ${classesDisabled} ${rounded} ${padding} ${classesActive} ${$$props.class ?? ''}`;
 	$: classesLabel = `${cLabel}`;
 	$: classesRegionLead = `${cRegionLead} ${regionLead}`;
 	$: classesRegionDefault = `${cRegionDefault} ${regionDefault}`;

--- a/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
+++ b/packages/skeleton/src/lib/components/ListBox/ListBoxItem.svelte
@@ -17,15 +17,13 @@
 	export let name: string;
 	/** Set the input's value. */
 	export let value: any;
-	/** Disables selection of the item. */
-	export let disabled: boolean = false;
 
 	// Context
-	export let disabledItems: boolean = getContext('disabledItems');
+	export let disabled: boolean = getContext('disabled');
 	export let multiple: string = getContext('multiple');
 	export let rounded: CssClasses = getContext('rounded');
 	export let active: CssClasses = getContext('active');
-	export let activeDisabled: CssClasses = getContext('activeDisabled');
+	export let inactive: CssClasses = getContext('inactive');
 	export let hover: CssClasses = getContext('hover');
 	export let padding: CssClasses = getContext('padding');
 	export let regionLead: CssClasses = getContext('regionLead');
@@ -33,7 +31,7 @@
 	export let regionTrail: CssClasses = getContext('regionTrail');
 
 	// Classes
-	const cBase = '-outline-offset-[3px]';
+	const cBase = 'cursor-pointer -outline-offset-[3px]';
 	const cLabel = 'flex items-center space-x-4';
 
 	// Local
@@ -99,9 +97,8 @@
 
 	// Reactive
 	$: selected = multiple ? group.some((groupVal: unknown) => areDeeplyEqual(value, groupVal)) : areDeeplyEqual(group, value);
-	$: enabled = !disabledItems && !disabled ? 'cursor-pointer' : 'cursor-default';
-	$: classesActive = !disabledItems && !disabled ? (selected ? active : hover) : (selected ? activeDisabled : '');
-	$: classesBase = `${cBase} ${enabled} ${rounded} ${padding} ${classesActive} ${$$props.class ?? ''}`;
+	$: classesActive = !disabled ? (selected ? active : hover) : (selected ? inactive : '');
+	$: classesBase = `${cBase} ${rounded} ${padding} ${classesActive} ${$$props.class ?? ''}`;
 	$: classesLabel = `${cLabel}`;
 	$: classesRegionLead = `${cRegionLead} ${regionLead}`;
 	$: classesRegionDefault = `${cRegionDefault} ${regionDefault}`;
@@ -124,9 +121,9 @@
 		<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
 		<div class="h-0 w-0 overflow-hidden">
 			{#if multiple}
-				<input disabled={disabledItems || disabled} bind:this={elemInput} type="checkbox" {name} {value} bind:checked tabindex="-1" on:click on:change />
+				<input {disabled} bind:this={elemInput} type="checkbox" {name} {value} bind:checked tabindex="-1" on:click on:change />
 			{:else}
-				<input disabled={disabledItems || disabled} bind:this={elemInput} type="radio" bind:group {name} {value} tabindex="-1" on:click on:change />
+				<input {disabled} bind:this={elemInput} type="radio" bind:group {name} {value} tabindex="-1" on:click on:change />
 			{/if}
 		</div>
 		<!-- <slot /> -->

--- a/sites/skeleton.dev/src/routes/(inner)/components/listboxes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/listboxes/+page.svelte
@@ -122,9 +122,7 @@
 		</section>
 		<section class="space-y-4">
 			<h3 class="h3">Disabled</h3>
-			<p>
-				By adding the <code class="code">disabled</code> property, 
-				it disables selection of child listboxitems. To disable each one individually, <code class="code">disabled</code> also can be set in a listboxitem component.</p>
+			<p>To disable all items or singular items, use the <code class="code">disabled</code> prop.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<ListBox disabled active="variant-filled-primary" activeDisabled="variant-ghost-primary" hover="hover:variant-soft-primary" multiple class="w-full max-w-[480px]">

--- a/sites/skeleton.dev/src/routes/(inner)/components/listboxes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/listboxes/+page.svelte
@@ -121,42 +121,10 @@
 			</DocsPreview>
 		</section>
 		<section class="space-y-4">
-			<h3 class="h3">Disabled</h3>
-			<p>To disable all items or singular items, use the <code class="code">disabled</code> prop.</p>
-			<DocsPreview background="neutral">
-				<svelte:fragment slot="preview">
-					<ListBox disabled active="variant-filled-primary" activeDisabled="variant-ghost-primary" hover="hover:variant-soft-primary" multiple class="w-full max-w-[480px]">
-						<ListBoxItem bind:group={valueDisabled} name="medium" value="books">
-							<svelte:fragment slot="lead"><i class="fa-solid fa-book w-6 text-center" /></svelte:fragment>
-							Books
-						</ListBoxItem>
-						<ListBoxItem bind:group={valueDisabled} name="medium" value="movies">
-							<svelte:fragment slot="lead"><i class="fa-solid fa-film w-6 text-center" /></svelte:fragment>
-							Movies
-						</ListBoxItem>
-						<ListBoxItem bind:group={valueDisabled} name="medium" value="television">
-							<svelte:fragment slot="lead"><i class="fa-solid fa-tv w-6 text-center" /></svelte:fragment>
-							Television
-						</ListBoxItem>
-					</ListBox>
-				</svelte:fragment>
-				<svelte:fragment slot="footer">
-					<div class="text-center"><code class="code">Selected: {valueDisabled.length ? valueDisabled : 'None'}</code></div>
-				</svelte:fragment>
-				<svelte:fragment slot="source">
-					<CodeBlock language="ts" code={`let valueMultiple: string[] = ['books', 'movies'];`} />
-					<CodeBlock
-						language="html"
-						code={`
-<ListBox disabled activeDisabled="variant-ghost-primary">
-	<ListBoxItem bind:group={valueDisabled} name="medium" value="books">Books</ListBoxItem>
-	<ListBoxItem bind:group={valueDisabled} name="medium" value="movies">Movies</ListBoxItem>
-	<ListBoxItem bind:group={valueDisabled} name="medium" value="tv">TV</ListBoxItem>
-</ListBox>
-			`}
-					/>
-				</svelte:fragment>
-			</DocsPreview>
+			<h2 class="h2">Disabled</h2>
+			<p>Use the <code class="code">disabled</code> property to disable the entire listbox or each item.</p>
+			<CodeBlock language="html" code={`<ListBox ... disabled>...</ListBox>`} />
+			<CodeBlock language="html" code={`<ListBoxItem ... disabled>...</ListBoxItem>`} />
 		</section>
 		<section class="space-y-4">
 			<h2 class="h2">Lead and Trail Slots</h2>

--- a/sites/skeleton.dev/src/routes/(inner)/components/listboxes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/listboxes/+page.svelte
@@ -30,6 +30,7 @@
 	// Local
 	let valueSingle = 'books';
 	let valueMultiple = ['books', 'movies'];
+	let valueDisabled = ['books', 'movies'];
 </script>
 
 <DocsShell {settings}>
@@ -113,6 +114,46 @@
 	<ListBoxItem bind:group={valueMultiple} name="medium" value="books">Books</ListBoxItem>
 	<ListBoxItem bind:group={valueMultiple} name="medium" value="movies">Movies</ListBoxItem>
 	<ListBoxItem bind:group={valueMultiple} name="medium" value="tv">TV</ListBoxItem>
+</ListBox>
+			`}
+					/>
+				</svelte:fragment>
+			</DocsPreview>
+		</section>
+		<section class="space-y-4">
+			<h3 class="h3">Disabled</h3>
+			<p>
+				By adding the <code class="code">disabled</code> property, 
+				it disables selection of child listboxitems. To disable each one individually, <code class="code">disabled</code> also can be set in a listboxitem component.</p>
+			<DocsPreview background="neutral">
+				<svelte:fragment slot="preview">
+					<ListBox disabled active="variant-filled-primary" activeDisabled="variant-ghost-primary" hover="hover:variant-soft-primary" multiple class="w-full max-w-[480px]">
+						<ListBoxItem bind:group={valueDisabled} name="medium" value="books">
+							<svelte:fragment slot="lead"><i class="fa-solid fa-book w-6 text-center" /></svelte:fragment>
+							Books
+						</ListBoxItem>
+						<ListBoxItem bind:group={valueDisabled} name="medium" value="movies">
+							<svelte:fragment slot="lead"><i class="fa-solid fa-film w-6 text-center" /></svelte:fragment>
+							Movies
+						</ListBoxItem>
+						<ListBoxItem bind:group={valueDisabled} name="medium" value="television">
+							<svelte:fragment slot="lead"><i class="fa-solid fa-tv w-6 text-center" /></svelte:fragment>
+							Television
+						</ListBoxItem>
+					</ListBox>
+				</svelte:fragment>
+				<svelte:fragment slot="footer">
+					<div class="text-center"><code class="code">Selected: {valueDisabled.length ? valueDisabled : 'None'}</code></div>
+				</svelte:fragment>
+				<svelte:fragment slot="source">
+					<CodeBlock language="ts" code={`let valueMultiple: string[] = ['books', 'movies'];`} />
+					<CodeBlock
+						language="html"
+						code={`
+<ListBox disabled activeDisabled="variant-ghost-primary">
+	<ListBoxItem bind:group={valueDisabled} name="medium" value="books">Books</ListBoxItem>
+	<ListBoxItem bind:group={valueDisabled} name="medium" value="movies">Movies</ListBoxItem>
+	<ListBoxItem bind:group={valueDisabled} name="medium" value="tv">TV</ListBoxItem>
 </ListBox>
 			`}
 					/>


### PR DESCRIPTION
## Linked Issue

Closes #2484

## Description

Added disabled prop to ListBox and ListBoxItem to prevent selection of inner radio/checkbox inputs.
A ListBoxItem disabled will:
- restrict selection
- lose hover style
- cursor defaults to cursor-default
- default style of `variant-ghost´

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
