### PR TITLE
docs/fix typo in file path for Datatable.svelte within SSD docs

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/ssd/ClientSSD.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/ssd/ClientSSD.svelte
@@ -29,7 +29,7 @@ export default [
 	<section class="space-y-4">
 		<h3 class="h3" data-toc-ignore>2. The Datatable Component</h3>
 		<p>
-			Create the new Datatable component in <code class="code">/src/lib/comonents/Datatable.svelte</code>, import your custom dataset, as
+			Create the new Datatable component in <code class="code">/src/lib/components/Datatable.svelte</code>, import your custom dataset, as
 			well as the
 			<code class="code">DataHandler</code> from Svelte Simple Datatables. Then, intialize the <code class="code">handler</code> and
 			<code class="code">rows</code>.

--- a/sites/skeleton.dev/src/routes/(inner)/docs/ssd/ServerSSD.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/ssd/ServerSSD.svelte
@@ -100,7 +100,7 @@ const getParams = (state: State) => {
 		<h3 class="h3" data-toc-ignore>2. The Datatable Component</h3>
 
 		<p>
-			Create the new Datatable component in <code class="code">/src/lib/comonents/Datatable.svelte</code>. Import
+			Create the new Datatable component in <code class="code">/src/lib/components/Datatable.svelte</code>. Import
 			<code class="code">reload</code>
 			from <code class="code">api.ts</code>. Then import <code class="code">DataHandler</code> and the
 			<code class="code">State</code>


### PR DESCRIPTION
## Linked Issue

Closes https://github.com/skeletonlabs/skeleton/issues/2513

## Description

This PR fixes a small typo in the documentation or Svelte Simple Datatables. Currently, in step 2 of [Creating the Components](https://www.skeleton.dev/docs/ssd#creating-the-components), both the Client-Based and Server-Based instructions misspell the path to the Datatable.svelte file. 

Before the fix, the path is `/src/lib/comonents/Datatable.svelte`.
After the fix, the path is `/src/lib/components/Datatable.svelte`

link to documentation: https://www.skeleton.dev/docs/ssd

Note: this is my first contribution to any open source project :0  small change but exciting! 

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [X] This PR targets the `dev` branch (NEVER `master`)
- [X] Documentation reflects all relevant changes
- [X] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [X] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [X] Ensure Prettier linting is current - run `pnpm format`
- [X] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
