### PR TITLE
delete Docs link trailing slash if included

### DIFF
--- a/sites/next.skeleton.dev/src/components/docs/ChipsBar.astro
+++ b/sites/next.skeleton.dev/src/components/docs/ChipsBar.astro
@@ -46,7 +46,7 @@ const { frontmatter, urls } = Astro.props;
 		frontmatter.showDocsUrl && (
 			<a
 				class="chip preset-filled-surface-200-800"
-				href={urls.githubDocsUrl + Astro.url.pathname + '.mdx'}
+				href={urls.githubDocsUrl + Astro.url.pathname.replace(/\/$/, '') + '.mdx'}
 				target="_blank"
 			>
 				<BookOpen size={16} />


### PR DESCRIPTION
fixes docs links that ends with a slash by deleting the slash.