### PR TITLE
docs/remove label prop in progress bar docs

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/progress-bars/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/progress-bars/+page.svelte
@@ -41,13 +41,13 @@
 	<svelte:fragment slot="sandbox">
 		<DocsPreview>
 			<svelte:fragment slot="preview">
-				<ProgressBar label="Progress Bar" bind:value={props.value} max={props.max} />
+				<ProgressBar bind:value={props.value} max={props.max} />
 			</svelte:fragment>
 			<svelte:fragment slot="footer">
 				<div class="w-48 mx-auto"><input type="range" min="0" bind:value={props.value} max={props.max} step={props.step} /></div>
 			</svelte:fragment>
 			<svelte:fragment slot="source">
-				<CodeBlock language="html" code={`<ProgressBar label="Progress Bar" value={${props.value}} max={${props.max}} />`} />
+				<CodeBlock language="html" code={`<ProgressBar value={${props.value}} max={${props.max}} />`} />
 			</svelte:fragment>
 		</DocsPreview>
 	</svelte:fragment>


### PR DESCRIPTION
## Linked Issue

Closes #[2516](https://github.com/skeletonlabs/skeleton/issues/2516)

## Description

This PR removes the `label` prop from the example code within the documentation for the ProgressBar component. There is no `label` prop in the ProgressBar component. 

link to ProgressBar and its props: https://github.com/skeletonlabs/skeleton/blob/dev/packages/skeleton/src/lib/components/ProgressBar/ProgressBar.svelte

link to documentation: https://www.skeleton.dev/components/progress-bars


Note: the linting problems are in files I did not touch. Let me know if it's helpful for me to include lint fixes for those files in this PR.


## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [X] This PR targets the `dev` branch (NEVER `master`)
- [X] Documentation reflects all relevant changes
- [X] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [X] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [X] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
