### PR TITLE
NEXT - remove docs common mdx body content

### DIFF
--- a/sites/next.skeleton.dev/src/content/components/common/accordions.mdx
+++ b/sites/next.skeleton.dev/src/content/components/common/accordions.mdx
@@ -6,15 +6,3 @@ srcReact: '/src/components/Accordion'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/accordion/'
 showDocsUrl: true
 ---
-
-export const components = componentSet;
-
-{/* --- */}
-
-## Multiple Items
-
-Apply the `multiple` prop to to enable opening more than one panel at a time.
-
-```html
-<Accordion multiple>...</Accordion>
-```

--- a/sites/next.skeleton.dev/src/content/components/common/app-bars.mdx
+++ b/sites/next.skeleton.dev/src/content/components/common/app-bars.mdx
@@ -5,5 +5,3 @@ srcReact: '/src/components/AppBar'
 srcSvelte: '/src/lib/components/AppBar'
 showDocsUrl: true
 ---
-
-export const components = componentSet;

--- a/sites/next.skeleton.dev/src/content/components/common/avatars.mdx
+++ b/sites/next.skeleton.dev/src/content/components/common/avatars.mdx
@@ -5,14 +5,3 @@ srcSvelte: '/src/lib/components/Avatar'
 srcReact: '/src/components/Avatar'
 showDocsUrl: true
 ---
-
-export const components = componentSet;
-
-## Fallback
-
-When the `src` prop is _undefined_, default children will show. This can be used for initials, icons, or fallback images.
-
-```tsx
-<Avatar>SK</Avatar>
-<Avatar>💀</Avatar>
-```

--- a/sites/next.skeleton.dev/src/content/components/react/accordions.mdx
+++ b/sites/next.skeleton.dev/src/content/components/react/accordions.mdx
@@ -7,8 +7,6 @@ export const components = componentSet;
 import { Page as Example } from '@examples/components/accordions/Example.tsx';
 import ExampleRaw from '@examples/components/accordions/Example.tsx?raw';
 
-import * as Common from '@content/components/common/accordions.mdx';
-
 {/* --- */}
 
 <Preview client:load>
@@ -20,7 +18,13 @@ import * as Common from '@content/components/common/accordions.mdx';
 	</Fragment>
 </Preview>
 
-<Common.Content />
+## Multiple Items
+
+Apply the `multiple` prop to to enable opening more than one panel at a time.
+
+```html
+<Accordion multiple>...</Accordion>
+```
 
 ## Open State
 

--- a/sites/next.skeleton.dev/src/content/components/react/app-bars.mdx
+++ b/sites/next.skeleton.dev/src/content/components/react/app-bars.mdx
@@ -10,7 +10,6 @@ import { Page as ExampleToolbar } from '@examples/components/app-bars/ExampleToo
 import ExampleToolbarRaw from '@examples/components/app-bars/ExampleToolbar.tsx?raw';
 import { Page as ExampleResponsive } from '@examples/components/app-bars/ExampleResponsive';
 import ExampleResponsiveRaw from '@examples/components/app-bars/ExampleResponsive.tsx?raw';
-import * as Common from '@content/components/common/app-bars.mdx';
 
 <Preview client:load>
 	<Fragment slot="preview">
@@ -44,5 +43,3 @@ Use Tailwind's [responsive design](https://tailwindcss.com/docs/responsive-desig
 		<Code code={ExampleResponsiveRaw} lang="tsx" />
 	</Fragment>
 </Preview>
-
-<Common.Content />

--- a/sites/next.skeleton.dev/src/content/components/react/avatars.mdx
+++ b/sites/next.skeleton.dev/src/content/components/react/avatars.mdx
@@ -6,7 +6,6 @@ export const components = componentSet;
 
 import { Page as Example } from '@examples/components/avatars/Example.tsx';
 import ExampleRaw from '@examples/components/avatars/Example.tsx?raw';
-import * as Common from '@content/components/common/avatars.mdx';
 
 <Preview client:load>
 	<Fragment slot="preview">

--- a/sites/next.skeleton.dev/src/content/components/react/avatars.mdx
+++ b/sites/next.skeleton.dev/src/content/components/react/avatars.mdx
@@ -17,4 +17,12 @@ import * as Common from '@content/components/common/avatars.mdx';
 	</Fragment>
 </Preview>
 
-<Common.Content />
+## Fallback
+
+When the `src` prop is _undefined_, default children will show. This can be used for initials, icons, or fallback images.
+
+```tsx
+<Avatar>SK</Avatar>
+<Avatar>💀</Avatar>
+```
+

--- a/sites/next.skeleton.dev/src/content/components/svelte/accordions.mdx
+++ b/sites/next.skeleton.dev/src/content/components/svelte/accordions.mdx
@@ -7,8 +7,6 @@ export const components = componentSet;
 import Example from '@examples/components/accordions/Example.svelte';
 import ExampleRaw from '@examples/components/accordions/Example.svelte?raw';
 
-import * as Common from '@content/components/common/accordions.mdx';
-
 {/* --- */}
 
 <Preview client:load>
@@ -20,7 +18,13 @@ import * as Common from '@content/components/common/accordions.mdx';
 	</Fragment>
 </Preview>
 
-<Common.Content />
+## Multiple Items
+
+Apply the `multiple` prop to to enable opening more than one panel at a time.
+
+```html
+<Accordion multiple>...</Accordion>
+```
 
 ## Open State
 

--- a/sites/next.skeleton.dev/src/content/components/svelte/app-bars.mdx
+++ b/sites/next.skeleton.dev/src/content/components/svelte/app-bars.mdx
@@ -10,7 +10,6 @@ import ExampleToolbar from '@examples/components/app-bars/ExampleToolbar.svelte'
 import ExampleToolbarRaw from '@examples/components/app-bars/ExampleToolbar.svelte?raw';
 import ExampleResponsive from '@examples/components/app-bars/ExampleResponsive.svelte';
 import ExampleResponsiveRaw from '@examples/components/app-bars/ExampleResponsive.svelte?raw';
-import * as Common from '@content/components/common/app-bars.mdx';
 
 <Preview client:load>
 	<Fragment slot="preview">
@@ -45,4 +44,3 @@ Use Tailwind's [responsive design](https://tailwindcss.com/docs/responsive-desig
 	</Fragment>
 </Preview>
 
-<Common.Content />

--- a/sites/next.skeleton.dev/src/content/components/svelte/avatars.mdx
+++ b/sites/next.skeleton.dev/src/content/components/svelte/avatars.mdx
@@ -7,8 +7,6 @@ export const components = componentSet;
 import Example from '@examples/components/avatars/Example.svelte';
 import ExampleRaw from '@examples/components/avatars/Example.svelte?raw';
 
-import * as Common from '@content/components/common/avatars.mdx';
-
 <Preview client:load>
 	<Fragment slot="preview">
 		<Example client:load />

--- a/sites/next.skeleton.dev/src/content/components/svelte/avatars.mdx
+++ b/sites/next.skeleton.dev/src/content/components/svelte/avatars.mdx
@@ -18,4 +18,11 @@ import * as Common from '@content/components/common/avatars.mdx';
 	</Fragment>
 </Preview>
 
-<Common.Content />
+## Fallback
+
+When the `src` prop is _undefined_, default children will show. This can be used for initials, icons, or fallback images.
+
+```tsx
+<Avatar>SK</Avatar>
+<Avatar>💀</Avatar>
+```

--- a/sites/next.skeleton.dev/src/content/resources/contribute/documentation.mdx
+++ b/sites/next.skeleton.dev/src/content/resources/contribute/documentation.mdx
@@ -50,6 +50,19 @@ export const components = componentSet {/* <-- ADD THIS! */}
 {/* (content) */}
 ```
 
+### Common MDX Content
+
+> NOTE: This technique is NOT recommended.
+
+Please be aware it is technically possible to pull shared MDX content from `/content/component/*.mdx` files and display these within each framework-specific tab page. However, Astro does not currently support generating Table of Content headings for imported MDX content. We highly recommend against using this technique, and instead recommend copy/pasting common instructions.
+
+```ts
+import * as Common from '@content/components/common/avatars.mdx';
+```
+```html
+<Common.Content />
+```
+
 ## Global Components
 
 A selection of globally accessible uitlity components provided to MDX contents via `astro-auto-importer`.


### PR DESCRIPTION
## Linked Issue

#2353

## Description

Remove docs common mdx body content, redistribute to each framework-specific mdx page.
