### PR TITLE
Remove Divide docs

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/tokens/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/tokens/+page.svelte
@@ -74,18 +74,6 @@
 		head: headings,
 		body: [['<code class="code">.decoration-[color]-[pairings]-token</code>', `${vColorsAll}<br>${vPairings}`, descPairings]]
 	};
-	const tableDivide: TableSource = {
-		head: headings,
-		// body: [['<code class="code">.divide-[color]-[pairings]-token</code>', `${vColorsAll}<br>${vPairings}`, descPairings + `\n` + ` <a class='anchor href='https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line' target="_blank">text-decoration-line</a>`]]
-		body: [
-			[
-				'<code class="code">.divide-[color]-[pairings]-token</code>',
-				`${vColorsAll}<br>${vPairings}`,
-				`\nImplements a <a class='anchor' href='https://tailwindcss.com/docs/text-decoration' target="_blank">text-decoration</a> color. ` +
-					descPairings
-			]
-		]
-	};
 	const tableMisc: TableSource = {
 		head: headings,
 		body: [
@@ -164,12 +152,6 @@
 		<section class="space-y-4">
 			<h2 class="h2">Borders</h2>
 			<Table source={tableBorder} />
-		</section>
-		<!-- Divides -->
-		<section class="space-y-4">
-			<h2 class="h2">Divide</h2>
-			<p>Utility for controlling the border color between elements.</p>
-			<Table source={tableDivide} />
 		</section>
 		<!-- Fills -->
 		<section class="space-y-4">


### PR DESCRIPTION
## Linked Issue

Closes #2412

## Description

Remove the Design Tokens > Divider documentation which incorrectly lists support for color pairings. These are not supported in Skeleton v2, but WILL be supported in v3!

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
