### PR TITLE
Update to modern standard for scrollbar styles

### DIFF
--- a/.changeset/thirty-cows-laugh.md
+++ b/.changeset/thirty-cows-laugh.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": minor
+---
+
+Bugfix: Update scrollbar styles to the latest standard.

--- a/packages/plugin/src/styles/base/core.css
+++ b/packages/plugin/src/styles/base/core.css
@@ -26,19 +26,12 @@ html {
 }
 
 /* === Scrollbars === */
+/* https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color */
+/* https://developer.chrome.com/docs/css-ui/scrollbar-styling */
 
-::-webkit-scrollbar {
-	@apply w-2;
-	@apply h-2;
-}
-::-webkit-scrollbar-track {
-	@apply !bg-surface-50-900-token px-[1px];
-}
-::-webkit-scrollbar-thumb {
-	@apply rounded-token bg-surface-400-500-token;
-}
-::-webkit-scrollbar-corner {
-	@apply !bg-surface-50-900-token;
+:root {
+	scrollbar-color: rgba(128, 128, 128, 0.5) rgba(0, 0, 0, 0.1); /* thumb / track */
+	scrollbar-width: thin;
 }
 
 /* Firefox */


### PR DESCRIPTION
## Linked Issue

Closes #2538

## Description

Migrates the Skeleton plugin base styles from the -webkit- vendor prefix to the new modern standards described here:

- https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color
- https://developer.chrome.com/docs/css-ui/scrollbar-styling

This matches the exact implementation in Skeleton v3, which better prepares for the transition going forward.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
