### PR TITLE
Bugfix/accordion svg duped class attribute

### DIFF
--- a/.changeset/cuddly-bats-return.md
+++ b/.changeset/cuddly-bats-return.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+Bugfix: Removed duplicate `class` attribute on AccordionItem SVG caret icon

--- a/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
+++ b/packages/skeleton/src/lib/components/Accordion/AccordionItem.svelte
@@ -96,7 +96,7 @@
 	export let transitionOutParams: TransitionParams<TransitionOut> = getContext('transitionOutParams');
 
 	const svgCaretIcon = `
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class={classesControlCaret}>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
 			<path d="M201.4 374.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 306.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z" />
 		</svg>`;
 


### PR DESCRIPTION
## Linked Issue

Closes #2586

## Description

Fixes AccordionItem caret `classesControlCaret` class duplicated on the SVG element

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
