### PR TITLE
docs/fix autocomplete component documentation

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/autocomplete/+page.svelte
@@ -141,8 +141,8 @@ function onFlavorSelection(event: CustomEvent<AutocompleteOption<string>>): void
 				/>
 				<p>Implement the autocomplete component.</p>
 				<p>
-					To style the autocomplete component you can either apply a <code class="code">class</code> tag directly the component and set your
-					styles, or you can wrap the component in a <code class="code">div</code> and apply your styles to the
+					To style the autocomplete component you can either apply a <code class="code">class</code> tag directly to the component and set
+					your styles, or you can wrap the component in a <code class="code">div</code> and apply your styles to the
 					<code class="code">div</code>
 				</p>
 				<CodeBlock
@@ -161,7 +161,7 @@ function onFlavorSelection(event: CustomEvent<AutocompleteOption<string>>): void
 	<svelte:fragment slot="usage">
 		<!-- prettier-ignore -->
 		<p>
-			The Autocomplete component does not contain it's own input by default. Instead, by using input binding paired with an <code class="code">on:selection</code> event, you may utilize this component alongside any type of input that takes in suggested values.
+			The Autocomplete component does not contain its own input by default. Instead, by using input binding paired with an <code class="code">on:selection</code> event, you may utilize this component alongside any type of input that takes in suggested values.
 		</p>
 		<section class="space-y-4">
 			<h2 class="h2">Data Structure</h2>
@@ -363,7 +363,7 @@ let popupSettings: PopupSettings = {
 		<section class="space-y-4">
 			<h2 class="h2">Browser Support</h2>
 			<p>
-				For Firefox, when wrapping the Autocomplete component in an parent element that uses <code class="code">overflow</code>
+				For Firefox, when wrapping the Autocomplete component in a parent element that uses <code class="code">overflow</code>
 				styling, make sure you add <code class="code">tabindex="-1"</code>. By doing this, it will ensure that tab navigation selects the
 				children within, instead of the wrapping element itself.
 			</p>


### PR DESCRIPTION
## Linked Issue

Closes #2608 

## Description

This PR fixes multiple typos in the autocomplete component documentation.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
