### PR TITLE
Documentation v2 deprecations

### DIFF
--- a/sites/skeleton.dev/src/lib/links.ts
+++ b/sites/skeleton.dev/src/lib/links.ts
@@ -36,7 +36,6 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 			list: [
 				{ href: '/docs/generator', label: 'Theme Generator', keywords: 'create, custom, style, css, design' },
 				{ href: '/docs/figma', label: 'Figma', keywords: 'figma, design, mock, wireframe, ui, kit' },
-				{ href: '/docs/purgecss', label: 'PurgeCSS', keywords: 'purgecss, vite, tree, shaking, bundle, optimize' },
 				{ href: '/docs/contributing', label: 'Contributing', keywords: 'branch, pr' },
 				{
 					href: '/docs/sponsorship',
@@ -48,8 +47,9 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 		{
 			title: 'Integrations',
 			list: [
+				{ href: '/docs/purgecss', label: 'PurgeCSS', keywords: 'purgecss, vite, tree, shaking, bundle, optimize' },
 				{ href: '/docs/tauri', label: 'Tauri', keywords: 'Tauri, desktop, setup, install' },
-				{ href: '/docs/ssd', label: 'Datatables', keywords: 'datatables, tables, datagrid, simple', badge: 'New' }
+				{ href: '/docs/ssd', label: 'Datatables', keywords: 'datatables, tables, datagrid, simple' } // badge: 'New'
 			]
 		}
 	],

--- a/sites/skeleton.dev/src/lib/links.ts
+++ b/sites/skeleton.dev/src/lib/links.ts
@@ -23,6 +23,11 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 					href: '/docs/transitions',
 					label: 'Transitions',
 					keywords: 'transition, transitions, blur, fade, fly, slide, scale, draw, crossfade, prefers, reduced, motion'
+				},
+				{
+					href: '/docs/dark-mode',
+					label: 'Dark Mode',
+					keywords: 'light, dark, toggle, prefer, color, scheme, lightswitch'
 				}
 			]
 		},
@@ -30,7 +35,7 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 			title: 'Resources',
 			list: [
 				{ href: '/docs/generator', label: 'Theme Generator', keywords: 'create, custom, style, css, design' },
-				{ href: '/docs/figma', label: 'Figma', keywords: 'figma, design, mock, wireframe, ui, kit' }, // , badge: 'New'
+				{ href: '/docs/figma', label: 'Figma', keywords: 'figma, design, mock, wireframe, ui, kit' },
 				{ href: '/docs/purgecss', label: 'PurgeCSS', keywords: 'purgecss, vite, tree, shaking, bundle, optimize' },
 				{ href: '/docs/contributing', label: 'Contributing', keywords: 'branch, pr' },
 				{
@@ -105,7 +110,6 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 				{ href: '/components/accordions', label: 'Accordions', keywords: 'collapse' },
 				{ href: '/components/app-bar', label: 'App Bar', keywords: 'header, top, bar, title' },
 				{ href: '/components/app-rail', label: 'App Rail', keywords: 'nav, navigation, tile, sidebar' },
-				{ href: '/components/app-shell', label: 'App Shell', keywords: 'layout, header, footer, sidebar, page, content' },
 				{ href: '/components/autocomplete', label: 'Autocomplete', keywords: 'input, filter, fuzzy, auto, complete, suggest' },
 				{ href: '/components/avatars', label: 'Avatars', keywords: 'image, initial, filter' },
 				{ href: '/components/conic-gradients', label: 'Conic Gradients', keywords: 'chart, graph, circle, pie, spinner, legend' },
@@ -120,10 +124,22 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 				{ href: '/components/radio-groups', label: 'Radio Groups', keywords: 'input, form, select, selection' },
 				{ href: '/components/range-sliders', label: 'Range Sliders', keywords: 'value, min, max, step,, tick, input, form' },
 				{ href: '/components/slide-toggles', label: 'Slide Toggles', keywords: 'check, checkbox, toggle, input, form' },
-				{ href: '/components/steppers', label: 'Steppers', keywords: 'intro, onboard, onboarding, form, progress' },
 				{ href: '/components/tabs', label: 'Tabs', keywords: 'select, selection, panel' },
-				{ href: '/components/tables', label: 'Tables', keywords: 'data, entry' },
-				{ href: '/components/tree-views', label: 'Tree Views', keywords: 'tree, view, node', badge: 'Beta' }
+				{ href: '/components/tree-views', label: 'Tree Views', keywords: 'tree, view, node' }
+			]
+		},
+		// Deprecated
+		{
+			title: '',
+			list: [
+				{
+					href: '/components/app-shell',
+					label: 'App Shell',
+					keywords: 'layout, header, footer, sidebar, page, content',
+					badge: 'Deprecated'
+				},
+				{ href: '/components/tables', label: 'Tables', keywords: 'data, entry', badge: 'Deprecated' },
+				{ href: '/components/steppers', label: 'Steppers', keywords: 'intro, onboard, onboarding, form, progress', badge: 'Deprecated' }
 			]
 		}
 	],
@@ -133,8 +149,6 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 			list: [
 				{ href: '/utilities/codeblocks', label: 'Code Blocks', keywords: 'highlight, syntax, code' },
 				{ href: '/utilities/drawers', label: 'Drawers', keywords: 'overlay, slide, panel, sidebar' },
-				{ href: '/utilities/lightswitches', label: 'Lightswitch', keywords: 'light, dark, toggle, prefer, color, scheme' },
-				{ href: '/utilities/local-storage-stores', label: 'Local Storage Stores', keywords: 'svelte, writable, get, cache, persist' },
 				{
 					href: '/utilities/modals',
 					label: 'Modals',
@@ -143,8 +157,18 @@ export const menuNavLinks: Record<string, Array<{ title: string; list: List }>> 
 				{ href: '/utilities/popups', label: 'Popups', keywords: 'menu, tooltip, overlay, dropdown, combobox, drop, down, select' },
 				{ href: '/utilities/toasts', label: 'Toasts', keywords: 'overlay, snack, snackbar, bar, action, alert, notification' },
 				{ href: '/utilities/table-of-contents', label: 'Table of Contents', keywords: 'page, results, links, navigation' }
-				// DELISTED UNTIL FURTHER NOTICE
-				// { href: '/utilities/data-tables', label: 'Data Tables', keywords: 'search, sort, page, pagination, async', badge: 'Experimental' }
+			]
+		},
+		// Deprecated
+		{
+			title: '',
+			list: [
+				{
+					href: '/utilities/local-storage-stores',
+					label: 'Persisted Store',
+					keywords: 'svelte, writable, get, cache, persist',
+					badge: 'Deprecated'
+				}
 			]
 		}
 	]

--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -36,6 +36,20 @@
 <DocsShell {settings}>
 	<!-- Slot: Sandbox -->
 	<svelte:fragment slot="sandbox">
+		<!-- Alert -->
+		<aside class="alert variant-ghost-error">
+			<i class="fa-solid fa-triangle-exclamation text-4xl" />
+			<div class="alert-message" data-toc-ignore>
+				<h3 class="h3" data-toc-ignore>Deprecated</h3>
+				<!-- prettier-ignore -->
+				<p>
+					This feature is being phased out as we transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This will remain functional for all 2.x releases, but we  recommend you migrate your apps to custom layouts as soon as possible. Expect more guidance around this in the future.
+				</p>
+			</div>
+			<div class="alert-actions">
+				<a class="btn variant-filled" href="https://github.com/skeletonlabs/skeleton/issues/2383" target="_blank"> Learn More </a>
+			</div>
+		</aside>
 		<div class="space-y-2">
 			<DocsPreview regionPreview="h-[280px]">
 				<svelte:fragment slot="lead">

--- a/sites/skeleton.dev/src/routes/(inner)/components/steppers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/steppers/+page.svelte
@@ -58,6 +58,21 @@
 <DocsShell {settings}>
 	<!-- Slot: Sandbox -->
 	<svelte:fragment slot="sandbox">
+		<!-- Alert -->
+		<aside class="alert variant-ghost-error">
+			<i class="fa-solid fa-triangle-exclamation text-4xl" />
+			<div class="alert-message" data-toc-ignore>
+				<h3 class="h3" data-toc-ignore>Deprecated</h3>
+				<!-- prettier-ignore -->
+				<p>
+					This feature is being phased out as we transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This will remain functional for all 2.x releases. Expect a dedicated v3 alternative as soon as possible.
+				</p>
+			</div>
+			<div class="alert-actions">
+				<a class="btn variant-filled" href="https://github.com/skeletonlabs/skeleton/issues/1780" target="_blank"> Learn More </a>
+			</div>
+		</aside>
+		<!-- Preview -->
 		<DocsPreview>
 			<svelte:fragment slot="preview">
 				<div class="w-full card p-4 text-token">

--- a/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
@@ -70,6 +70,20 @@
 <DocsShell {settings}>
 	<!-- Slot: Sandbox -->
 	<svelte:fragment slot="sandbox">
+		<!-- Alert -->
+		<aside class="alert variant-ghost-error">
+			<i class="fa-solid fa-triangle-exclamation text-4xl" />
+			<div class="alert-message" data-toc-ignore>
+				<h3 class="h3" data-toc-ignore>Deprecated</h3>
+				<!-- prettier-ignore -->
+				<p>
+					This feature is being phased out as transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This will remain functional for all 2.x releases, but recommend you migrate to <a class="underline" href="/elements/tables" target="_blank">table elements</a> as soon as possible.
+				</p>
+			</div>
+			<div class="alert-actions">
+				<a class="btn variant-filled" href="https://github.com/skeletonlabs/skeleton/issues/2388" target="_blank"> Learn More </a>
+			</div>
+		</aside>
 		<DocsPreview>
 			<svelte:fragment slot="preview">
 				<Table source={tableSimple} interactive={true} on:selected={onSelected} text="text-token" />

--- a/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/tables/+page.svelte
@@ -77,7 +77,7 @@
 				<h3 class="h3" data-toc-ignore>Deprecated</h3>
 				<!-- prettier-ignore -->
 				<p>
-					This feature is being phased out as transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This will remain functional for all 2.x releases, but recommend you migrate to <a class="underline" href="/elements/tables" target="_blank">table elements</a> as soon as possible.
+					This feature is being phased out as transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This will remain functional for all 2.x releases, but recommend you migrate to <a class="underline" href="/elements/tables">table elements</a> as soon as possible.
 				</p>
 			</div>
 			<div class="alert-actions">

--- a/sites/skeleton.dev/src/routes/(inner)/docs/dark-mode/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/dark-mode/+page.svelte
@@ -10,12 +10,12 @@
 	// Docs Shell
 	const settings: DocsShellSettings = {
 		feature: DocsFeature.Utility,
-		name: 'Lightswitch',
-		description: `Components and utilities for toggling <a class="anchor" href="https://tailwindcss.com/docs/dark-mode" target="_blank" rel="noreferrer">Tailwind's dark mode</a>.`,
-		imports: ['LightSwitch'],
-		source: 'packages/skeleton/src/lib/utilities/LightSwitch',
-		aria: 'https://www.w3.org/WAI/ARIA/apg/patterns/switch/',
-		components: [{ sveld: sveldLightSwitch }],
+		name: 'Dark Mode',
+		description: `Learn how to use <a class="anchor" href="https://tailwindcss.com/docs/dark-mode" target="_blank" rel="noreferrer">Tailwind's dark mode</a> within your Skeleton application. Skeleton provides two methods for handling dark mode. Choose a method that meets your application's requirements.`,
+		// imports: ['LightSwitch'],
+		// source: 'packages/skeleton/src/lib/utilities/LightSwitch',
+		// aria: 'https://www.w3.org/WAI/ARIA/apg/patterns/switch/',
+		components: [{ label: 'Lightswitch', sveld: sveldLightSwitch }],
 		keyboard: [['<kbd class="kbd">Space</kbd> or <kbd class="kbd">Enter</kbd>', 'Toggle the switch state.']]
 	};
 
@@ -34,47 +34,47 @@
 
 	<!-- Slot: Usage -->
 	<svelte:fragment slot="usage">
-		<p class="!text-xl">Skeleton provides two strategies for toggling light and dark mode. Choose your preference.</p>
 		<section class="space-y-4">
-			<h2 class="h2">Strategy: Class</h2>
-			<p>
-				We recommend this approach for most users. Please note the Lightswitch component must be present on page load in order to operate.
-				For best results, insert this in a fixed element that appears on every page.
-			</p>
+			<h2 class="h2">Via Selector</h2>
+			<p>Allows users to toggle between light and dark mode with an interactive Lightswitch component.</p>
 			<CodeBlock
 				language="ts"
 				code={`
 // tailwind.config.[ts|js|cjs]\n
 module.exports = {
-  darkMode: 'class', // <-- ADD THIS
+  darkMode: 'selector', // <--
   // ...
 }
 			`}
 			/>
+			<p>Then implement the Skeleton Lightswitch component.</p>
 			<DocsPreview background="neutral">
 				<svelte:fragment slot="preview">
 					<LightSwitch />
 				</svelte:fragment>
 				<svelte:fragment slot="source">
-					<CodeBlock language="ts" code={`<LightSwitch />`} />
+					<blockquote class="blockquote">
+						TIP: Note this must be present in the DOM on page load in order to operate. For best results insert this in a fixed element that
+						appears on every page, such as your header.
+					</blockquote>
+					<CodeBlock
+						language="ts"
+						code={`import { LightSwitch } from '@skeletonlabs/skeleton';
+						`}
+					/>
+					<CodeBlock language="html" code={`<LightSwitch />`} />
 				</svelte:fragment>
 			</DocsPreview>
 		</section>
 		<section class="space-y-4">
-			<h2 class="h2">Strategy: OS Preference</h2>
-			<p>
-				Skeleton provides a utility method to adjust the mode based on operating system preference. This replaces both the class strategy
-				and Lightswitch component.
-			</p>
-			<div class="alert variant-ghost-surface">
-				<p>When adjusting your operating system setting, macOS is the only OS that does not require a browser refresh.</p>
-			</div>
+			<h2 class="h2">Via Media</h2>
+			<p>Skeleton provides a utility method to adjust the mode based on the user's operating system preference.</p>
 			<CodeBlock
 				language="ts"
 				code={`
 // tailwind.config.[ts|js|cjs]\n
 module.exports = {
-	// darkMode // <-- REMOVE THIS
+	darkMode: 'media', // <--
 	// ...
 }
 		`}
@@ -118,10 +118,10 @@ onMount(() => {
 			</TabGroup>
 		</section>
 		<hr />
+		<!-- Custom Component -->
 		<section class="space-y-4">
-			<h2 class="h2">Build Your Own Component</h2>
-			<!-- Build Your Own -->
-			<p>Skeleton exposes all utility methods used within the Lightswitch component. Use these to construct your own!</p>
+			<h2 class="h2">Custom Component</h2>
+			<p>If you wish to build a custom Lightswitch component, Skeleton exposes all required utility methods.</p>
 			<aside class="alert alert-message variant-ghost">
 				<p>
 					Please consult the Skeleton <a
@@ -133,15 +133,15 @@ onMount(() => {
 				</p>
 				<!-- prettier-ignore -->
 			</aside>
-			<h3 class="h3">Set Initial Classes</h3>
+			<h3 class="h3">Initilize</h3>
 			<p>
-				Import and add the following to your component. This will set the <code class="code">.dark</code> class on the root HTML element in
-				a highly performant manner. Please note that the CLI installer inserts <code class="code">class="dark"</code>
+				Import and add the following within your component. This will set the <code class="code">.dark</code> class on the root HTML element
+				in a highly performant manner. Please note that the CLI installer inserts <code class="code">class="dark"</code>
 				statically in the <code class="code">html</code> element of app.html and you should remove it when going this route.
 			</p>
 			<CodeBlock language="ts" code={`import { setInitialClassState } from '@skeletonlabs/skeleton';`} />
 			<CodeBlock language="html" code={snippetSetInitClass} />
-			<h3 class="h3">Interface Methods</h3>
+			<h3 class="h3">Utilities</h3>
 			<p>
 				Light mode is represented by <code class="code">true</code>, while dark mode is represented by
 				<code class="code">false</code>.
@@ -243,13 +243,6 @@ onMount(() => {
 					{/if}
 				</svelte:fragment>
 			</TabGroup>
-		</section>
-		<section>
-			<h2 class="h2">Reference</h2>
-			<aside class="alert alert-message variant-ghost">
-				<!-- prettier-ignore -->
-				<p>View the Skeleton <a class="anchor" href="https://github.com/skeletonlabs/skeleton/tree/master/packages/skeleton/src/lib/utilities/LightSwitch" target="_blank" rel="noreferrer">Lightswitch component source code</a> for a detailed reference. </p>
-			</aside>
 		</section>
 	</svelte:fragment>
 </DocsShell>

--- a/sites/skeleton.dev/src/routes/(inner)/elements/tables/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/tables/+page.svelte
@@ -169,13 +169,13 @@
 				</svelte:fragment>
 			</TabGroup>
 		</section>
-		<!-- See Also -->
+		<!-- Datatables -->
 		<section class="space-y-4">
-			<h2 class="h2">See Also</h2>
+			<h2 class="h2">Datatables</h2>
 			<div class="card p-4 space-y-4">
 				<div class="!flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0 md:space-x-4">
-					<p>A simple data-driven table component.</p>
-					<a class="btn variant-ghost-surface" href="/components/tables">Tables Component &rarr;</a>
+					<p>View our guide for integrating datatable features into your tables.</p>
+					<a class="btn variant-ghost-surface" href="/docs/ssd">Datatable Integration &rarr;</a>
 				</div>
 			</div>
 		</section>

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/local-storage-stores/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/local-storage-stores/+page.svelte
@@ -7,9 +7,8 @@
 	// Docs Shell
 	const settings: DocsShellSettings = {
 		feature: DocsFeature.Utility,
-		name: 'Local Storage Store',
-		description:
-			'An extended version of the <a class="anchor" href="https://svelte.dev/tutorial/writable-stores" target="_blank" rel="noreferrer">Svelte writable store</a> that includes pub/sub to local storage.',
+		name: 'Persisted Store',
+		description: 'An extended version of the Svelte writable store that automatically persists to local storage',
 		imports: ['localStorageStore'],
 		source: 'packages/skeleton/src/lib/utilities/LocalStorageStore'
 	};
@@ -18,6 +17,20 @@
 <DocsShell {settings}>
 	<!-- Slot: Usage -->
 	<svelte:fragment slot="usage">
+		<!-- Alert -->
+		<aside class="alert variant-ghost-error">
+			<i class="fa-solid fa-triangle-exclamation text-4xl" />
+			<div class="alert-message" data-toc-ignore>
+				<h3 class="h3" data-toc-ignore>Deprecated</h3>
+				<!-- prettier-ignore -->
+				<p>
+					This feature is being phased out as we transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This will remain functional for all 2.x releases, but recommend migrating to <a class="underline" href="https://github.com/joshnuss/svelte-persisted-store" target="_blank">svelte-persisted-store</a> as soon as possible.
+				</p>
+			</div>
+			<div class="alert-actions">
+				<a class="btn variant-filled" href="https://github.com/skeletonlabs/skeleton/issues/2383" target="_blank"> Learn More </a>
+			</div>
+		</aside>
 		<section class="space-y-4">
 			<p>
 				The first parameter <code class="code">storeExample</code> is the local storage key name. The second parameter is the initial value of


### PR DESCRIPTION
## Linked Issue

Closes #2607

## Description

Notable changes:
- I've moved `Utilities > Lightswitch` to `Docs > Essentials > Dark Mode` to better align with the v3 approach
- Depreciated components: App Shell, Tables, Steppers
- Depreciated utilities: Persisted Store (aka localstorage stores)

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
