### PR TITLE
Docs/modals prerequisite should also import modal

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/drawers/+page.svelte
@@ -100,7 +100,7 @@
 			<p>
 				Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, and Toast stores and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
 			</p>
-			<CodeBlock language="ts" code={`import { initializeStores } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
+			<CodeBlock language="ts" code={`import { initializeStores, Drawer } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
 			<h3 class="h3">Drawer Component</h3>
 			<p>Implement a single instance of the drawer component in your app's root layout, above the App Shell (if present).</p>
 			<CodeBlock language="html" code={`<Drawer />\n\n<!-- <AppShell>...</AppShell> -->`} />

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/modals/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/modals/+page.svelte
@@ -182,7 +182,7 @@
 			<p>
 				Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, and Toast stores and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
 			</p>
-			<CodeBlock language="ts" code={`import { initializeStores } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
+			<CodeBlock language="ts" code={`import { initializeStores, Modal } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
 			<h3 class="h3">Modal Component</h3>
 			<p>Implement a single instance of the modal component in your app's root layout, above the App Shell (if present).</p>
 			<CodeBlock language="html" code={`<Modal />\n\n<!-- <AppShell>...</AppShell> -->`} />

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/toasts/+page.svelte
@@ -162,7 +162,7 @@
 			<p>
 				Implement the following in the root layout of your application. This is required only once when implementing Skeleton's Drawer, Modal, and Toast stores and will prevent known issues with <a class="anchor" href="https://github.com/skeletonlabs/skeleton/wiki/SvelteKit-SSR-Warning" target="_blank">SvelteKit SSR</a>.
 			</p>
-			<CodeBlock language="ts" code={`import { initializeStores } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
+			<CodeBlock language="ts" code={`import { initializeStores, Toast } from '@skeletonlabs/skeleton';\n\ninitializeStores();`} />
 			<h3 class="h3">Toast Component</h3>
 			<p>Implement a single instance of the toast component in your app's root layout, above the App Shell (if present).</p>
 			<CodeBlock language="html" code={`<Toast />\n\n<!-- <AppShell>...</AppShell> -->`} />


### PR DESCRIPTION
## Linked Issue

Closes #2512

## Description

Modals prerequisite should also import modal. I have also added imports for Toast and Drawer utilities