### PR TITLE
use variant-filled-primary class for active nav item to also use corr…

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/lists/+page.svelte
@@ -195,7 +195,7 @@
 				</svelte:fragment>
 			</DocsPreview>
 			<p>To highlight active state, we recommend conditionally applying a background color to the anchor tag.</p>
-			<CodeBlock language="ts" code={`$: classesActive = (href: string) => (href === $page.url.pathname ? '!bg-primary-500' : '');`} />
+			<CodeBlock language="ts" code={`$: classesActive = (href: string) => (href === $page.url.pathname ? '!variant-filled-primary' : '');`} />
 			<CodeBlock language="html" code={`<a href={href} class="{classesActive(href)}">Page</a>`} />
 		</section>
 	</svelte:fragment>


### PR DESCRIPTION
currently example to highlight active nav item is using a bg background color class, however, that might lead to "incompatible" textcolor usage.

Therefore I would suggest to use a variant-filled-primary class instead, which will automatically select correct textcolor as well.

This is my first PR, so not sure what I have to comply to, but since it is an quite easy simple change.. 

## Linked Issue
None

## Description
currently example to highlight active nav item is using a bg background color class, however, that might lead to "incompatible" textcolor usage.

Therefore I would suggest to use a variant-filled-primary class instead, which will automatically select correct textcolor as well.

## Changsets


## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
