### PR TITLE
Added fallback for media query event listener

### DIFF
--- a/.changeset/metal-ligers-drum.md
+++ b/.changeset/metal-ligers-drum.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Added fallback for `mediaQueryList.addEventListener`

--- a/packages/skeleton/src/lib/utilities/PrefersReducedMotion/PrefersReducedMotion.ts
+++ b/packages/skeleton/src/lib/utilities/PrefersReducedMotion/PrefersReducedMotion.ts
@@ -15,15 +15,28 @@ function prefersReducedMotion() {
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
  */
 export const prefersReducedMotionStore = readable(prefersReducedMotion(), (set) => {
-	if (BROWSER) {
-		const setReducedMotion = (event: MediaQueryListEvent) => {
-			set(event.matches);
-		};
-		const mediaQueryList = window.matchMedia(reducedMotionQuery);
-		mediaQueryList.addEventListener('change', setReducedMotion);
-
-		return () => {
-			mediaQueryList.removeEventListener('change', setReducedMotion);
-		};
+	if (!BROWSER) {
+		return;
 	}
+
+	const setReducedMotion = (event: MediaQueryListEvent) => {
+		set(event.matches);
+	};
+	const mediaQueryList = window.matchMedia(reducedMotionQuery);
+
+	if (mediaQueryList?.addEventListener) {
+		mediaQueryList.addEventListener('change', setReducedMotion);
+	} else if (mediaQueryList?.addListener) {
+		// https://github.com/skeletonlabs/skeleton/issues/2656
+		mediaQueryList.addListener(setReducedMotion);
+	}
+
+	return () => {
+		if (mediaQueryList?.removeEventListener) {
+			mediaQueryList.removeEventListener('change', setReducedMotion);
+		} else if (mediaQueryList?.removeListener) {
+			// https://github.com/skeletonlabs/skeleton/issues/2656
+			mediaQueryList.removeListener(setReducedMotion);
+		}
+	};
 });


### PR DESCRIPTION
## Linked Issue

Closes #2656

## Description

Adds a fallback to `addListener` when `addEventListener` isn't available to the mediaQueryList

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
