### PR TITLE
feat: optionally prioritize new toasts

### DIFF
--- a/.changeset/eleven-poets-rest.md
+++ b/.changeset/eleven-poets-rest.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+feat: Added prioritizeNew boolean prop to Toast.svelte that allows enabling/disabling newer toasts being prioritized when the total number of toasts is greater than the maximum defined by the max prop. Prop is false by default so default behavior is unchanged.

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -23,8 +23,8 @@
 	export let position: 't' | 'b' | 'l' | 'r' | 'tl' | 'tr' | 'bl' | 'br' = 'b';
 	/** Maximum toasts that can show at once. */
 	export let max = 3;
-	/** Enable/Disable closing oldest toasts when new toasts exceed maximum. */
-	export let replace = false;
+	/** Enable/Disable prioritizing newest toasts when total number exceeds maximum. */
+	export let prioritizeNew = false;
 
 	// Props (styles)
 	/** Provide classes to set the background color. */
@@ -131,7 +131,7 @@
 	$: classesSnackbar = `${cSnackbar} ${cAlign} ${padding}`;
 	$: classesToast = `${cToast} ${width} ${color} ${padding} ${spacing} ${rounded} ${shadow}`;
 	// Filtered Toast Store
-	$: filteredToasts = replace ? Array.from($toastStore).slice(-max) : Array.from($toastStore).slice(0, max);
+	$: filteredToasts = prioritizeNew ? Array.from($toastStore).slice(-max) : Array.from($toastStore).slice(0, max);
 
 	$: if (filteredToasts.length) {
 		wrapperVisible = true;

--- a/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
+++ b/packages/skeleton/src/lib/utilities/Toast/Toast.svelte
@@ -23,6 +23,8 @@
 	export let position: 't' | 'b' | 'l' | 'r' | 'tl' | 'tr' | 'bl' | 'br' = 'b';
 	/** Maximum toasts that can show at once. */
 	export let max = 3;
+	/** Enable/Disable closing oldest toasts when new toasts exceed maximum. */
+	export let replace = false;
 
 	// Props (styles)
 	/** Provide classes to set the background color. */
@@ -129,7 +131,7 @@
 	$: classesSnackbar = `${cSnackbar} ${cAlign} ${padding}`;
 	$: classesToast = `${cToast} ${width} ${color} ${padding} ${spacing} ${rounded} ${shadow}`;
 	// Filtered Toast Store
-	$: filteredToasts = Array.from($toastStore).slice(0, max);
+	$: filteredToasts = replace ? Array.from($toastStore).slice(-max) : Array.from($toastStore).slice(0, max);
 
 	$: if (filteredToasts.length) {
 		wrapperVisible = true;


### PR DESCRIPTION
## Description

Added prioritizeNew prop to Toast.svelte to allow enabling/disabling prioritizing newer toasts when the total number of toasts exceed the maximum. Currently older toasts are prioritized, and this is still the stock behavior as the prop defaults to false. 

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
