### PR TITLE
chore: remove duplicate word

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/contributing/requirements/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/contributing/requirements/+page.svelte
@@ -225,7 +225,7 @@
 	<section class="space-y-4">
 		<h2 class="h2">Dependencies</h2>
 		<p>
-			Introducing new dependencies to projects is strictly prohibited. Please sync with a core core maintainer if this is required. Pull
+			Introducing new dependencies to projects is strictly prohibited. Please sync with a core maintainer if this is required. Pull
 			requests that introduce new dependencies without approval will be rejected.
 		</p>
 	</section>


### PR DESCRIPTION
## Description

Removed duplicate word "core" in the following sentence in the "Dependencies" section in the contribution requirement docs: "Please sync with a core core maintainer if this is required."

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
