### PR TITLE
NEXT: doc tabs redesigned to match Skeleton

### DIFF
--- a/packages/skeleton-react/src/lib/components/Tabs/Tabs.tsx
+++ b/packages/skeleton-react/src/lib/components/Tabs/Tabs.tsx
@@ -1,245 +1,245 @@
 import React, { useEffect, useRef, useState } from "react";
 import {
-	TabsProps,
-	TabsListProps,
-	TabsControlProps,
-	TabsControlItemProps,
-	TabsPanelItemProps,
+  TabsProps,
+  TabsListProps,
+  TabsControlProps,
+  TabsControlItemProps,
+  TabsPanelItemProps,
 } from "./types.js";
 
 // Components ---
 const TabsRoot: React.FC<TabsProps> = ({
-	id = "",
-	// Root
-	base = "w-full",
-	spaceY = "space-y-4",
-	classes = "",
-	// Children
-	children,
+  id = "",
+  // Root
+  base = "w-full",
+  spaceY = "space-y-4",
+  classes = "",
+  // Children
+  children,
 }) => {
-	return (
-		<div id={id} className={`${base} ${spaceY} ${classes}`} data-testid="tabs">
-			{children}
-		</div>
-	);
+  return (
+    <div id={id} className={`${base} ${spaceY} ${classes}`} data-testid="tabs">
+      {children}
+    </div>
+  );
 };
 
 const TabsList: React.FC<TabsListProps> = ({
-	// Root
-	base = "flex",
-	justify = "justify-start",
-	gap = "gap-2",
-	border = "border-b-[1px] border-surface-200-800",
-	classes = "",
-	// Children
-	children,
+  // Root
+  base = "flex",
+  justify = "justify-start",
+  gap = "gap-2",
+  border = "border-b border-surface-200-800",
+  classes = "",
+  // Children
+  children,
 }) => {
-	return (
-		<div
-			className={`${base} ${gap} ${justify} ${border} ${classes}`}
-			role="tablist"
-		>
-			{children}
-		</div>
-	);
+  return (
+    <div
+      className={`${base} ${gap} ${justify} ${border} ${classes}`}
+      role="tablist"
+    >
+      {children}
+    </div>
+  );
 };
 
 const TabsControl: React.FC<TabsControlProps> = ({
-	id = "",
-	name,
-	group,
-	title = "",
-	// A11y
-	label = "",
-	controls = "",
-	// Root
-	base = "group",
-	width = "",
-	active = "text-surface-950-50 border-surface-950-50",
-	inactive = "text-surface-600-400 border-transparent",
-	flex = "flex justify-center items-center",
-	background = "",
-	border = "border-b-[1px]",
-	text = "type-scale-3",
-	padding = "pb-2",
-	rounded = "",
-	gap = "gap-1",
-	cursor = "cursor-pointer",
-	classes = "",
-	// Events
-	onClick = () => {},
-	onKeydown = () => {},
-	onKeyup = () => {},
-	onChange = () => {},
-	// Children
-	children,
+  id = "",
+  name,
+  group,
+  title = "",
+  // A11y
+  label = "",
+  controls = "",
+  // Root
+  base = "group",
+  width = "",
+  active = "text-surface-950-50 border-surface-950-50",
+  inactive = "text-surface-600-400 border-transparent",
+  flex = "flex justify-center items-center",
+  background = "",
+  border = "border-b",
+  text = "type-scale-3",
+  padding = "pb-2",
+  rounded = "",
+  gap = "gap-1",
+  cursor = "cursor-pointer",
+  classes = "",
+  // Events
+  onClick = () => {},
+  onKeydown = () => {},
+  onKeyup = () => {},
+  onChange = () => {},
+  // Children
+  children,
 }) => {
-	const [selected, setSelected] = useState(group === name);
-	useEffect(() => {
-		setSelected(group === name);
-	}, [group, name]);
+  const [selected, setSelected] = useState(group === name);
+  useEffect(() => {
+    setSelected(group === name);
+  }, [group, name]);
 
-	const [rxActive, setRxActive] = useState(selected ? active : inactive);
-	useEffect(() => {
-		setRxActive(selected ? active : inactive);
-	}, [selected, active, inactive]);
+  const [rxActive, setRxActive] = useState(selected ? active : inactive);
+  useEffect(() => {
+    setRxActive(selected ? active : inactive);
+  }, [selected, active, inactive]);
 
-	function handleOnChange(event: React.ChangeEvent<HTMLInputElement>) {
-		onChange(event.target.value);
-	}
+  function handleOnChange(event: React.ChangeEvent<HTMLInputElement>) {
+    onChange(event.target.value);
+  }
 
-	const elemInputRef = useRef<HTMLInputElement>(null);
-	function onKeyDownHandler(event: React.KeyboardEvent<HTMLDivElement>) {
-		// Fire Event Handler
-		onKeydown(event);
+  const elemInputRef = useRef<HTMLInputElement>(null);
+  function onKeyDownHandler(event: React.KeyboardEvent<HTMLDivElement>) {
+    // Fire Event Handler
+    onKeydown(event);
 
-		// If select key events
-		if (!["ArrowRight", "ArrowLeft", "Home", "End"].includes(event.code))
-			return;
+    // If select key events
+    if (!["ArrowRight", "ArrowLeft", "Home", "End"].includes(event.code))
+      return;
 
-		const elemInput = elemInputRef.current;
-		if (!elemInput) return;
+    const elemInput = elemInputRef.current;
+    if (!elemInput) return;
 
-		// Prevent default behavior
-		event.preventDefault();
+    // Prevent default behavior
+    event.preventDefault();
 
-		// Find the closest tab/tablelist
-		const currTab = elemInput.closest('[role="tab"]');
-		if (!currTab) return;
-		const tabList = elemInput.closest('[role="tablist"]');
-		if (!tabList) return;
+    // Find the closest tab/tablelist
+    const currTab = elemInput.closest('[role="tab"]');
+    if (!currTab) return;
+    const tabList = elemInput.closest('[role="tablist"]');
+    if (!tabList) return;
 
-		// Get RTL mode
-		const isRTL = getComputedStyle(tabList).direction === "rtl";
-		// Get list of tab elements
-		const tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
-		// Get a reference to the current tab
-		const currIndex = tabs.indexOf(currTab);
+    // Get RTL mode
+    const isRTL = getComputedStyle(tabList).direction === "rtl";
+    // Get list of tab elements
+    const tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
+    // Get a reference to the current tab
+    const currIndex = tabs.indexOf(currTab);
 
-		// Determine the index of the next tab
-		let nextIndex = -1;
-		switch (event.code) {
-			case "ArrowRight":
-				if (isRTL) {
-					nextIndex = currIndex - 1 < 0 ? tabs.length - 1 : currIndex - 1;
-					break;
-				}
-				nextIndex = currIndex + 1 >= tabs.length ? 0 : currIndex + 1;
-				break;
-			case "ArrowLeft":
-				if (isRTL) {
-					nextIndex = currIndex + 1 >= tabs.length ? 0 : currIndex + 1;
-					break;
-				}
-				nextIndex = currIndex - 1 < 0 ? tabs.length - 1 : currIndex - 1;
-				break;
-			case "Home":
-				nextIndex = 0;
-				break;
-			case "End":
-				nextIndex = tabs.length - 1;
-				break;
-		}
-		if (nextIndex < 0) return;
+    // Determine the index of the next tab
+    let nextIndex = -1;
+    switch (event.code) {
+      case "ArrowRight":
+        if (isRTL) {
+          nextIndex = currIndex - 1 < 0 ? tabs.length - 1 : currIndex - 1;
+          break;
+        }
+        nextIndex = currIndex + 1 >= tabs.length ? 0 : currIndex + 1;
+        break;
+      case "ArrowLeft":
+        if (isRTL) {
+          nextIndex = currIndex + 1 >= tabs.length ? 0 : currIndex + 1;
+          break;
+        }
+        nextIndex = currIndex - 1 < 0 ? tabs.length - 1 : currIndex - 1;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = tabs.length - 1;
+        break;
+    }
+    if (nextIndex < 0) return;
 
-		// Set Active Tab
-		const nextTab = tabs![nextIndex!];
-		const nextTabInput = nextTab?.querySelector("input");
-		if (nextTabInput) {
-			nextTabInput.click();
-			(nextTab as HTMLDivElement).focus();
-		}
-	}
+    // Set Active Tab
+    const nextTab = tabs![nextIndex!];
+    const nextTabInput = nextTab?.querySelector("input");
+    if (nextTabInput) {
+      nextTabInput.click();
+      (nextTab as HTMLDivElement).focus();
+    }
+  }
 
-	return (
-		<label
-			id={id}
-			className={`${base} ${width} ${rxActive} ${flex} ${background} ${border} ${text} ${padding} ${rounded} ${gap} ${cursor} ${classes}`}
-			aria-label={label}
-			title={title}
-		>
-			{/* NOTE: do not add additional classes to this <div> */}
-			<div
-				className="size-full"
-				role="tab"
-				aria-controls={controls}
-				aria-selected={selected}
-				data-testid="tabs-control"
-				tabIndex={selected ? 0 : -1}
-				onKeyDown={onKeyDownHandler}
-				onKeyUp={onKeyup}
-			>
-				{/* Keep these classes on wrapping element */}
-				<div className="h-0 w-0 flex-none overflow-hidden">
-					<input
-						ref={elemInputRef}
-						type="radio"
-						name={name}
-						value={name}
-						checked={selected}
-						onChange={handleOnChange}
-						onClick={onClick}
-						tabIndex={-1}
-					/>
-				</div>
+  return (
+    <label
+      id={id}
+      className={`${base} ${width} ${rxActive} ${flex} ${background} ${border} ${text} ${padding} ${rounded} ${gap} ${cursor} ${classes}`}
+      aria-label={label}
+      title={title}
+    >
+      {/* NOTE: do not add additional classes to this <div> */}
+      <div
+        className="size-full"
+        role="tab"
+        aria-controls={controls}
+        aria-selected={selected}
+        data-testid="tabs-control"
+        tabIndex={selected ? 0 : -1}
+        onKeyDown={onKeyDownHandler}
+        onKeyUp={onKeyup}
+      >
+        {/* Keep these classes on wrapping element */}
+        <div className="h-0 w-0 flex-none overflow-hidden">
+          <input
+            ref={elemInputRef}
+            type="radio"
+            name={name}
+            value={name}
+            checked={selected}
+            onChange={handleOnChange}
+            onClick={onClick}
+            tabIndex={-1}
+          />
+        </div>
 
-				{children}
-			</div>
-		</label>
-	);
+        {children}
+      </div>
+    </label>
+  );
 };
 
 const TabsControlItem: React.FC<TabsControlItemProps> = ({
-	// Root
-	base = "w-full",
-	flex = "flex justify-center items-center",
-	gap = "gap-2",
-	background = "group-hover:preset-tonal-primary",
-	padding = "p-2 px-4",
-	rounded = "rounded-container",
-	classes = "",
-	// Children
-	children,
+  // Root
+  base = "w-full",
+  flex = "flex justify-center items-center",
+  gap = "gap-2",
+  background = "group-hover:preset-tonal-primary",
+  padding = "p-2 px-4",
+  rounded = "rounded-container",
+  classes = "",
+  // Children
+  children,
 }) => {
-	return (
-		<div
-			className={`${base} ${flex} ${gap} ${background} ${padding} ${rounded} ${classes}`}
-		>
-			{children}
-		</div>
-	);
+  return (
+    <div
+      className={`${base} ${flex} ${gap} ${background} ${padding} ${rounded} ${classes}`}
+    >
+      {children}
+    </div>
+  );
 };
 
 const TabsPanelItem: React.FC<TabsPanelItemProps> = ({
-	id = "",
-	value,
-	group,
-	// A11y
-	labelledBy,
-	// Root
-	classes = "",
-	// Children
-	children,
+  id = "",
+  value,
+  group,
+  // A11y
+  labelledBy,
+  // Root
+  classes = "",
+  // Children
+  children,
 }) => {
-	return (
-		value === group &&
-		children && (
-			<div
-				id={id}
-				role="tabpanel"
-				tabIndex={0}
-				aria-labelledby={labelledBy}
-				className={classes}
-			>
-				{children}
-			</div>
-		)
-	);
+  return (
+    value === group &&
+    children && (
+      <div
+        id={id}
+        role="tabpanel"
+        tabIndex={0}
+        aria-labelledby={labelledBy}
+        className={classes}
+      >
+        {children}
+      </div>
+    )
+  );
 };
 
 export const Tabs = Object.assign(TabsRoot, {
-	List: TabsList,
-	Control: TabsControl,
-	Panel: TabsPanelItem,
-	Item: TabsControlItem,
+  List: TabsList,
+  Control: TabsControl,
+  Panel: TabsPanelItem,
+  Item: TabsControlItem,
 });

--- a/packages/skeleton-svelte/src/lib/components/Tab/Tabs.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tab/Tabs.svelte
@@ -11,7 +11,7 @@
 		listBase = 'flex',
 		listJustify = 'justify-start',
 		listGap = 'gap-2',
-		listBorder = 'border-b-[1px] border-surface-200-800',
+		listBorder = 'border-b border-surface-200-800',
 		listClasses = '',
 		// Snippets
 		list,

--- a/packages/skeleton-svelte/src/lib/components/Tab/TabsControl.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tab/TabsControl.svelte
@@ -16,7 +16,7 @@
 		inactive = 'text-surface-600-400 border-transparent',
 		flex = 'flex justify-center items-center',
 		background = '',
-		border = 'border-b-[1px]',
+		border = 'border-b',
 		text = 'type-scale-3',
 		padding = 'pb-2',
 		rounded = '',

--- a/sites/next.skeleton.dev/src/components/docs/Preview.tsx
+++ b/sites/next.skeleton.dev/src/components/docs/Preview.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 /** Create preview/code tabs for showcasing features. */
 export const Preview: React.FC<any> = (props) => {
 	const [selected, setSelected] = React.useState(props.selected || 'preview');
-	const cTab = 'font-bold py-2 px-4 border-b-[3px] border-transparent capitalize';
+	const cTab = 'border-b border-transparent pb-2 hover:[&>span]:preset-tonal-primary';
+	const cTabControl = 'block p-2 px-4 capitalize rounded-container';
 	const cTabActive = '!border-surface-950-50';
 
 	function selectedClass(tab: string) {
@@ -14,12 +15,12 @@ export const Preview: React.FC<any> = (props) => {
 		// TODO: fix this top margin due to generate script tags
 		<div className="space-y-4 mt-4">
 			{/* Tabs */}
-			<nav className="flex gap-4 border-b-[1px] border-surface-200-800">
+			<nav className="flex gap-4 border-b border-surface-200-800">
 				<button className={`${cTab} ${selectedClass('preview')}`} onClick={() => setSelected('preview')}>
-					Preview
+					<span className={`${cTabControl}`}>Preview</span>
 				</button>
 				<button className={`${cTab} ${selectedClass('code')}`} onClick={() => setSelected('code')}>
-					Code
+					<span className={`${cTabControl}`}>Code</span>
 				</button>
 			</nav>
 			{/* Panel: Preview */}


### PR DESCRIPTION
## Linked Issue

Closes #2591

## Description

- Update docs tabs to match the the Skeleton design aesthetic.
- Minor cosmetic change to the Svelte and React table component (adheres to theme border width)

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
