### PR TITLE
Bugfix: Bump `vite-plugin-pagefind`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,8 +413,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0
       vite-plugin-pagefind:
-        specifier: ^0.2.7
-        version: 0.2.7
+        specifier: ^0.2.8
+        version: 0.2.8
       vite-plugin-tw-plugin-watcher:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-tw-plugin-watcher
@@ -6225,8 +6225,8 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-plugin-pagefind@0.2.7:
-    resolution: {integrity: sha512-4jHhdcoHWvfBLUCh4g7VDM27EXiEZ27VCbIh/T5wY5ByOJzvsY2SSvN0zpvJ0MNPpNoQuDkVTht6e6P9zJV28A==}
+  vite-plugin-pagefind@0.2.8:
+    resolution: {integrity: sha512-lTfbfeYWd5mjeji4bQPxjyt/BWI2CnkpcCtlyJu3GHTr7uWkauvcyS/98Ys/CHV95CLCis2po8J9i1+H4VIqZg==}
 
   vite-plugin-remix-router@2.0.0:
     resolution: {integrity: sha512-db4aWk9MAVqcfpOwZsMaOR0xFRSeSmSj4B043f22Z+CeK5WHS7HZYBCqjkC1sdJqUfsf2kCK2cb5a7CMZE+Mlg==}
@@ -13772,7 +13772,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-pagefind@0.2.7:
+  vite-plugin-pagefind@0.2.8:
     dependencies:
       colorette: 2.0.20
       valibot: 0.31.0-rc.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,8 +413,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0
       vite-plugin-pagefind:
-        specifier: ^0.2.6
-        version: 0.2.6
+        specifier: ^0.2.7
+        version: 0.2.7
       vite-plugin-tw-plugin-watcher:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-tw-plugin-watcher
@@ -6225,8 +6225,8 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-plugin-pagefind@0.2.6:
-    resolution: {integrity: sha512-EufB02LIj93vUpcObxZWB/T6D2wDs6d+z0tzn2BfAurahWBKCid5CMQVoU8P0C4zGkMxIaA/J2maO8S7Prl6zw==}
+  vite-plugin-pagefind@0.2.7:
+    resolution: {integrity: sha512-4jHhdcoHWvfBLUCh4g7VDM27EXiEZ27VCbIh/T5wY5ByOJzvsY2SSvN0zpvJ0MNPpNoQuDkVTht6e6P9zJV28A==}
 
   vite-plugin-remix-router@2.0.0:
     resolution: {integrity: sha512-db4aWk9MAVqcfpOwZsMaOR0xFRSeSmSj4B043f22Z+CeK5WHS7HZYBCqjkC1sdJqUfsf2kCK2cb5a7CMZE+Mlg==}
@@ -13772,7 +13772,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-pagefind@0.2.6:
+  vite-plugin-pagefind@0.2.7:
     dependencies:
       colorette: 2.0.20
       valibot: 0.31.0-rc.4

--- a/sites/next.skeleton.dev/package.json
+++ b/sites/next.skeleton.dev/package.json
@@ -54,7 +54,7 @@
 		"pagefind": "^1.1.0",
 		"prettier": "^3.2.5",
 		"prettier-plugin-astro": "^0.13.0",
-		"vite-plugin-pagefind": "^0.2.6",
+		"vite-plugin-pagefind": "^0.2.7",
 		"vite-plugin-tw-plugin-watcher": "workspace:*"
 	}
 }

--- a/sites/next.skeleton.dev/package.json
+++ b/sites/next.skeleton.dev/package.json
@@ -54,7 +54,7 @@
 		"pagefind": "^1.1.0",
 		"prettier": "^3.2.5",
 		"prettier-plugin-astro": "^0.13.0",
-		"vite-plugin-pagefind": "^0.2.7",
+		"vite-plugin-pagefind": "^0.2.8",
 		"vite-plugin-tw-plugin-watcher": "workspace:*"
 	}
 }


### PR DESCRIPTION
## Description

Plugin had a bug causing errors, this has been resolved in 0.2.7. This PR simply bumps the dep

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
