### PR TITLE
Added onclose handlers for dialog

### DIFF
--- a/sites/next.skeleton.dev/src/components/docs/Search.svelte
+++ b/sites/next.skeleton.dev/src/components/docs/Search.svelte
@@ -60,6 +60,7 @@
 	});
 
 	const openDialog = () => dialog && dialog.showModal();
+	const closeDialog = () => dialog && dialog.close();
 
 	const onClickOutside = (node: HTMLDialogElement) => {
 		const onclick = (event: MouseEvent) => {
@@ -176,6 +177,7 @@
 							<a
 								class="card preset-outlined-surface-100-900 hover:preset-tonal grid grid-cols-[auto_1fr_auto] gap-4 items-center p-4"
 								href={result.url}
+								onclick={closeDialog}
 							>
 								<span><IconBook class="size-6 opacity-60" /></span>
 								<div class="space-y-1">
@@ -192,6 +194,7 @@
 									<a
 										class="card preset-outlined-surface-100-900 hover:preset-tonal grid grid-cols-[auto_1fr_auto] gap-4 items-center p-4 space-y-1"
 										href={subResult.url}
+										onclick={closeDialog}
 									>
 										<span class="hidden md:block">
 											<IconHash class="size-4 opacity-60" />


### PR DESCRIPTION
## Description

Fixed a small oversight with the search feature for the doc site.
For example when I was on `/docs/components/accordion/svelte` and I opened to search modal to go to: `/docs/components/accordion/svelte#api` the modal would stay open. To fix this I added a `onclick` to all `a` tags in the search modal that close the modal upon clicking any result.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
