### PR TITLE
Increase default transition duration to 300ms to avoid a white flash

### DIFF
--- a/.changeset/mean-schools-double.md
+++ b/.changeset/mean-schools-double.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Increased the default animation duration of inputs to avoid a white flash

--- a/.changeset/mean-schools-double.md
+++ b/.changeset/mean-schools-double.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-bugfix: Increased the default animation duration of inputs to avoid a white flash
+bugfix: Increased the default animation duration of inputs and changed the transition to avoid a white flash

--- a/packages/skeleton/src/plugin/components/forms.css
+++ b/packages/skeleton/src/plugin/components/forms.css
@@ -45,7 +45,7 @@
 .select {
 	@apply field-outter field-inner;
 	@apply border-none;
-	@apply transition-[all] duration-100;
+	@apply transition-[all] duration-300;
 }
 
 /* Select --- */

--- a/packages/skeleton/src/plugin/components/forms.css
+++ b/packages/skeleton/src/plugin/components/forms.css
@@ -45,7 +45,7 @@
 .select {
 	@apply field-outter field-inner;
 	@apply border-none;
-	@apply transition-shadow duration-200;
+	@apply transition duration-200;
 }
 
 /* Select --- */

--- a/packages/skeleton/src/plugin/components/forms.css
+++ b/packages/skeleton/src/plugin/components/forms.css
@@ -45,7 +45,7 @@
 .select {
 	@apply field-outter field-inner;
 	@apply border-none;
-	@apply transition-[all] duration-300;
+	@apply transition-shadow duration-200;
 }
 
 /* Select --- */


### PR DESCRIPTION
## Linked Issue

Closes #2665 

## Description

The default transition duration was 100ms, making it too fast to see properly. See the issue for before and after videos

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
