### PR TITLE
Resolve A11y errors for AppRailAnchor

### DIFF
--- a/.changeset/unlucky-keys-brake.md
+++ b/.changeset/unlucky-keys-brake.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Removed invalid role and forward events on AppRailAnchor component

--- a/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
@@ -45,21 +45,7 @@
 	}
 </script>
 
-<a
-	class="app-rail-anchor {classesBase}"
-	href={$$props.href}
-	{...prunedRestProps()}
-	role="button"
-	on:click
-	on:keydown
-	on:keyup
-	on:keypress
-	on:mouseover
-	on:mouseleave
-	on:focus
-	on:blur
-	data-testid="app-rail-anchor"
->
+<a class="app-rail-anchor {classesBase}" href={$$props.href} {...prunedRestProps()} data-testid="app-rail-anchor">
 	<div class="app-rail-wrapper {classesWrapper}">
 		{#if $$slots.lead}<div class="app-rail-lead {classesLead}"><slot name="lead" /></div>{/if}
 		<div class="app-rail-label {classesLabel}"><slot /></div>


### PR DESCRIPTION
## Linked Issue

Closes #2662

## Description

Removes the extra role and forward events from the `<AppRailAnchor>` component. Svelte was throwing a11y errors for these because they are invalid on an anchor element.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
