### PR TITLE
chore: Simplify CI and add `packageManager` field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -48,8 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -79,8 +75,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Use PNPM v8
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Use Node v18
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Use PNPM v8
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Use Node v18
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
 		"shelljs": "^0.8.5"
 	},
 	"engines": {
-		"pnpm": ">=9.2.0"
+		"pnpm": ">=9.3.0"
 	},
+	"packageManager": "pnpm@9.3.0",
 	"type": "module"
 }


### PR DESCRIPTION
## Description

CI workflows can be simplified further by add the `packageManager` field to the root `package.json`, removing the need to specify a pnpm version for it's action. This also fixes our failing ecosystem-ci tests too.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
