### PR TITLE
Remove `reactCompose` utility

### DIFF
--- a/.changeset/stale-poets-sell.md
+++ b/.changeset/stale-poets-sell.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton-react": patch
 ---
 
-chore: updated all multipart React components to use the reactCompose function
+chore: remove reactCompose utility

--- a/.changeset/stale-poets-sell.md
+++ b/.changeset/stale-poets-sell.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton-react": patch
 ---
 
-Updated all multipart React components to use the reactCompose function
+chore: updated all multipart React components to use the reactCompose function

--- a/.changeset/stale-poets-sell.md
+++ b/.changeset/stale-poets-sell.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton-react": patch
+---
+
+Updated all multipart React components to use the reactCompose function

--- a/.changeset/stale-poets-sell.md
+++ b/.changeset/stale-poets-sell.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton-react": patch
 ---
 
-chore: remove reactCompose utility
+chore: Remove `reactCompose` utility, added `$lib` alias path.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,5 +13,7 @@
 		"dbaeumer.vscode-eslint"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": []
+	"unwantedRecommendations": [
+		"heybourn.headwind"
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
 		"mdx": "html"
 	},
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"headwind.runOnSave": false,
 	"[svelte]": {
 		"editor.defaultFormatter": "svelte.svelte-vscode"
 	}

--- a/packages/skeleton-react/src/lib/components/Accordion/Accordion.tsx
+++ b/packages/skeleton-react/src/lib/components/Accordion/Accordion.tsx
@@ -1,6 +1,10 @@
 'use client';
 
+import { motion, AnimatePresence } from 'framer-motion';
 import React, { createContext, useContext, useEffect, useState } from 'react';
+
+import { reactCompose } from '@/lib/utils/react-compose.js';
+
 import {
 	AccordionContextState,
 	AccordionControlProps,
@@ -9,7 +13,6 @@ import {
 	AccordionPanelProps,
 	AccordionProps
 } from './types.js';
-import { motion, AnimatePresence } from 'framer-motion';
 
 // Contexts ---
 
@@ -185,7 +188,7 @@ const AccordionPanel: React.FC<AccordionPanelProps> = ({
 	);
 };
 
-export const Accordion = Object.assign(AccordionRoot, {
+export const Accordion = reactCompose(AccordionRoot, {
 	Item: AccordionItem,
 	Control: AccordionControl,
 	Panel: AccordionPanel

--- a/packages/skeleton-react/src/lib/components/Accordion/Accordion.tsx
+++ b/packages/skeleton-react/src/lib/components/Accordion/Accordion.tsx
@@ -3,8 +3,6 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-import { reactCompose } from '@/lib/utils/react-compose.js';
-
 import {
 	AccordionContextState,
 	AccordionControlProps,
@@ -188,7 +186,7 @@ const AccordionPanel: React.FC<AccordionPanelProps> = ({
 	);
 };
 
-export const Accordion = reactCompose(AccordionRoot, {
+export const Accordion = Object.assign(AccordionRoot, {
 	Item: AccordionItem,
 	Control: AccordionControl,
 	Panel: AccordionPanel

--- a/packages/skeleton-react/src/lib/components/AppBar/AppBar.tsx
+++ b/packages/skeleton-react/src/lib/components/AppBar/AppBar.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { reactCompose } from '@/lib/utils/react-compose.js';
-
 import { ToolbarCenterProps, AppBarHeadlineProps, ToolbarLeadProps, AppBarProps, ToolBarProps, ToolbarTrailProps } from './types.js';
 
 // Components ---
@@ -82,7 +80,7 @@ const AppBarHeadline: React.FC<AppBarHeadlineProps> = ({
 	return <div className={`${base} ${classes}`}>{children}</div>;
 };
 
-export const AppBar = reactCompose(AppBarRoot, {
+export const AppBar = Object.assign(AppBarRoot, {
 	Toolbar: Toolbar,
 	ToolbarLead: ToolbarLead,
 	ToolbarCenter: ToolbarCenter,

--- a/packages/skeleton-react/src/lib/components/AppBar/AppBar.tsx
+++ b/packages/skeleton-react/src/lib/components/AppBar/AppBar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { ToolbarCenterProps, AppBarHeadlineProps, ToolbarLeadProps, AppBarProps, ToolBarProps, ToolbarTrailProps } from './types.js';
 
-// React Compose ---
-import { reactCompose } from '../../utils/react-compose.js';
+import { reactCompose } from '@/lib/utils/react-compose.js';
+
+import { ToolbarCenterProps, AppBarHeadlineProps, ToolbarLeadProps, AppBarProps, ToolBarProps, ToolbarTrailProps } from './types.js';
 
 // Components ---
 const AppBarRoot: React.FC<AppBarProps> = ({

--- a/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
+++ b/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import React, { createContext, useContext } from 'react';
+
+import { reactCompose } from '@/lib/utils/react-compose.js';
+
 import { NavContextState, NavRailProps, NavBarProps, NavTileProps } from './types.js';
 
 // Contexts ---
@@ -194,7 +197,7 @@ export const NavTile: React.FC<NavTileProps> = ({
 
 // Exports ---
 
-export const Nav = Object.assign(() => null, {
+export const Nav = reactCompose(() => null, {
 	Rail: NavRail,
 	Bar: NavBar,
 	Tile: NavTile

--- a/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
+++ b/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
@@ -2,8 +2,6 @@
 
 import React, { createContext, useContext } from 'react';
 
-import { reactCompose } from '@/lib/utils/react-compose.js';
-
 import { NavContextState, NavRailProps, NavBarProps, NavTileProps } from './types.js';
 
 // Contexts ---
@@ -197,7 +195,7 @@ export const NavTile: React.FC<NavTileProps> = ({
 
 // Exports ---
 
-export const Nav = reactCompose(() => null, {
+export const Nav = Object.assign(() => null, {
 	Rail: NavRail,
 	Bar: NavBar,
 	Tile: NavTile

--- a/packages/skeleton-react/src/lib/components/Tabs/Tabs.tsx
+++ b/packages/skeleton-react/src/lib/components/Tabs/Tabs.tsx
@@ -1,4 +1,9 @@
+'use client';
+
 import React, { useEffect, useRef, useState } from 'react';
+
+import { reactCompose } from '@/lib/utils/react-compose.js';
+
 import { TabsProps, TabsListProps, TabsControlProps, TabsControlItemProps, TabsPanelItemProps } from './types.js';
 
 // Components ---
@@ -160,7 +165,7 @@ const TabsControl: React.FC<TabsControlProps> = ({
 				onKeyUp={onKeyup}
 			>
 				{/* Keep these classes on wrapping element */}
-				<div className="h-0 w-0 flex-none overflow-hidden">
+				<div className="flex-none w-0 h-0 overflow-hidden">
 					<input
 						ref={elemInputRef}
 						type="radio"
@@ -215,7 +220,7 @@ const TabsPanelItem: React.FC<TabsPanelItemProps> = ({
 	);
 };
 
-export const Tabs = Object.assign(TabsRoot, {
+export const Tabs = reactCompose(TabsRoot, {
 	List: TabsList,
 	Control: TabsControl,
 	Panel: TabsPanelItem,

--- a/packages/skeleton-react/src/lib/components/Tabs/Tabs.tsx
+++ b/packages/skeleton-react/src/lib/components/Tabs/Tabs.tsx
@@ -163,7 +163,7 @@ const TabsControl: React.FC<TabsControlProps> = ({
 				onKeyUp={onKeyup}
 			>
 				{/* Keep these classes on wrapping element */}
-				<div className="flex-none w-0 h-0 overflow-hidden">
+				<div className="h-0 w-0 flex-none overflow-hidden">
 					<input
 						ref={elemInputRef}
 						type="radio"

--- a/packages/skeleton-react/src/lib/components/Tabs/Tabs.tsx
+++ b/packages/skeleton-react/src/lib/components/Tabs/Tabs.tsx
@@ -2,8 +2,6 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 
-import { reactCompose } from '@/lib/utils/react-compose.js';
-
 import { TabsProps, TabsListProps, TabsControlProps, TabsControlItemProps, TabsPanelItemProps } from './types.js';
 
 // Components ---
@@ -220,7 +218,7 @@ const TabsPanelItem: React.FC<TabsPanelItemProps> = ({
 	);
 };
 
-export const Tabs = reactCompose(TabsRoot, {
+export const Tabs = Object.assign(TabsRoot, {
 	List: TabsList,
 	Control: TabsControl,
 	Panel: TabsPanelItem,

--- a/packages/skeleton-react/src/lib/utils/react-compose.ts
+++ b/packages/skeleton-react/src/lib/utils/react-compose.ts
@@ -1,7 +1,0 @@
-export function reactCompose<
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	T extends React.FC<any>,
-	U extends Record<string, unknown>
->(root: T, components: { [k in keyof U]: React.FC<U[k]> }) {
-	return Object.assign(root, components);
-}

--- a/packages/skeleton-react/src/routes/components/accordions.tsx
+++ b/packages/skeleton-react/src/routes/components/accordions.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { Accordion } from '../../lib/components/Accordion/Accordion.js';
 import { Skull } from 'lucide-react';
+import { useState } from 'react';
+
+import { Accordion } from '@/lib/components/Accordion/Accordion.js';
 
 export function Component() {
 	const lorem =

--- a/packages/skeleton-react/src/routes/components/accordions.tsx
+++ b/packages/skeleton-react/src/routes/components/accordions.tsx
@@ -1,7 +1,7 @@
 import { Skull } from 'lucide-react';
 import { useState } from 'react';
 
-import { Accordion } from '@/lib/components/Accordion/Accordion.js';
+import { Accordion } from '$lib/components/Accordion/Accordion.js';
 
 export function Component() {
 	const lorem =

--- a/packages/skeleton-react/src/routes/components/app-bars.tsx
+++ b/packages/skeleton-react/src/routes/components/app-bars.tsx
@@ -1,5 +1,6 @@
-import { AppBar } from '../../lib/components/AppBar/AppBar.js';
 import { Skull } from 'lucide-react';
+
+import { AppBar } from '@/lib/components/AppBar/AppBar.js';
 
 function appbar() {
 	return (
@@ -54,7 +55,7 @@ function appbarSticky() {
 	return (
 		<>
 			<h3 className="h3">Sticky</h3>
-			<div className="flex max-h-64 flex-col space-y-4 overflow-y-auto">
+			<div className="flex flex-col space-y-4 overflow-y-auto max-h-64">
 				<AppBar classes="sticky top-0">
 					<AppBar.Toolbar>
 						<AppBar.ToolbarLead>

--- a/packages/skeleton-react/src/routes/components/app-bars.tsx
+++ b/packages/skeleton-react/src/routes/components/app-bars.tsx
@@ -55,7 +55,7 @@ function appbarSticky() {
 	return (
 		<>
 			<h3 className="h3">Sticky</h3>
-			<div className="flex flex-col space-y-4 overflow-y-auto max-h-64">
+			<div className="flex max-h-64 flex-col space-y-4 overflow-y-auto">
 				<AppBar classes="sticky top-0">
 					<AppBar.Toolbar>
 						<AppBar.ToolbarLead>

--- a/packages/skeleton-react/src/routes/components/app-bars.tsx
+++ b/packages/skeleton-react/src/routes/components/app-bars.tsx
@@ -1,6 +1,6 @@
 import { Skull } from 'lucide-react';
 
-import { AppBar } from '@/lib/components/AppBar/AppBar.js';
+import { AppBar } from '$lib/components/AppBar/AppBar.js';
 
 function appbar() {
 	return (

--- a/packages/skeleton-react/src/routes/components/avatars.tsx
+++ b/packages/skeleton-react/src/routes/components/avatars.tsx
@@ -45,7 +45,7 @@ function filterAvatar() {
 		<>
 			{/* Filter example */}
 			{/* NoirLight: `filter: url(#NoirLight)` */}
-			<svg id="svg-filter-noirlight" className="absolute w-0 h-0 -left-full filter">
+			<svg id="svg-filter-noirlight" className="absolute -left-full h-0 w-0 filter">
 				<filter
 					id="NoirLight"
 					x="-20%"

--- a/packages/skeleton-react/src/routes/components/avatars.tsx
+++ b/packages/skeleton-react/src/routes/components/avatars.tsx
@@ -1,5 +1,6 @@
-import { Avatar } from '../../lib/components/Avatar/Avatar.js';
 import { Skull } from 'lucide-react';
+
+import { Avatar } from '@/lib/components/Avatar/Avatar.js';
 
 const imgSrc =
 	'https://images.unsplash.com/photo-1617296538902-887900d9b592?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzExMDB8&ixlib=rb-4.0.3&w=128&h=128&auto=format&fit=crop';
@@ -44,7 +45,7 @@ function filterAvatar() {
 		<>
 			{/* Filter example */}
 			{/* NoirLight: `filter: url(#NoirLight)` */}
-			<svg id="svg-filter-noirlight" className="absolute -left-full h-0 w-0 filter">
+			<svg id="svg-filter-noirlight" className="absolute w-0 h-0 -left-full filter">
 				<filter
 					id="NoirLight"
 					x="-20%"

--- a/packages/skeleton-react/src/routes/components/avatars.tsx
+++ b/packages/skeleton-react/src/routes/components/avatars.tsx
@@ -1,6 +1,6 @@
 import { Skull } from 'lucide-react';
 
-import { Avatar } from '@/lib/components/Avatar/Avatar.js';
+import { Avatar } from '$lib/components/Avatar/Avatar.js';
 
 const imgSrc =
 	'https://images.unsplash.com/photo-1617296538902-887900d9b592?ixid=M3w0Njc5ODF8MHwxfGFsbHx8fHx8fHx8fDE2ODc5NzExMDB8&ixlib=rb-4.0.3&w=128&h=128&auto=format&fit=crop';

--- a/packages/skeleton-react/src/routes/components/navigation.tsx
+++ b/packages/skeleton-react/src/routes/components/navigation.tsx
@@ -72,9 +72,9 @@ export function Component() {
 					<Nav.Rail
 						expanded
 						header={
-							<a href="/" className="flex flex-col items-center justify-center w-full gap-2 aspect-square">
+							<a href="/" className="flex aspect-square w-full flex-col items-center justify-center gap-2">
 								<IconLogo size={48} />
-								<span className="font-bold type-scale-5">Skeleton</span>
+								<span className="type-scale-5 font-bold">Skeleton</span>
 							</a>
 						}
 						footer={

--- a/packages/skeleton-react/src/routes/components/navigation.tsx
+++ b/packages/skeleton-react/src/routes/components/navigation.tsx
@@ -1,7 +1,7 @@
 import { Skull as IconLogo, Menu as IconMenu, Box as IconBox, Settings as IconSettings } from 'lucide-react';
 import { useState } from 'react';
 
-import { Nav } from '@/lib/components/Navigation/Navigation.js';
+import { Nav } from '$lib/components/Navigation/Navigation.js';
 
 export function Component() {
 	const [activeItem, setActiveItem] = useState('0');

--- a/packages/skeleton-react/src/routes/components/navigation.tsx
+++ b/packages/skeleton-react/src/routes/components/navigation.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { Nav } from '../../lib/components/Navigation/Navigation.js';
 import { Skull as IconLogo, Menu as IconMenu, Box as IconBox, Settings as IconSettings } from 'lucide-react';
+import { useState } from 'react';
+
+import { Nav } from '@/lib/components/Navigation/Navigation.js';
 
 export function Component() {
 	const [activeItem, setActiveItem] = useState('0');
@@ -71,9 +72,9 @@ export function Component() {
 					<Nav.Rail
 						expanded
 						header={
-							<a href="/" className="flex aspect-square w-full flex-col items-center justify-center gap-2">
+							<a href="/" className="flex flex-col items-center justify-center w-full gap-2 aspect-square">
 								<IconLogo size={48} />
-								<span className="type-scale-5 font-bold">Skeleton</span>
+								<span className="font-bold type-scale-5">Skeleton</span>
 							</a>
 						}
 						footer={

--- a/packages/skeleton-react/src/routes/components/progress-rings.tsx
+++ b/packages/skeleton-react/src/routes/components/progress-rings.tsx
@@ -1,7 +1,7 @@
 import { ThermometerSun as IconThermometer } from 'lucide-react';
 import { useState } from 'react';
 
-import { ProgressRing } from '@/lib/components/ProgressRing/ProgressRing.js';
+import { ProgressRing } from '$lib/components/ProgressRing/ProgressRing.js';
 
 export function Component() {
 	const [value, setValue] = useState(50);

--- a/packages/skeleton-react/src/routes/components/progress-rings.tsx
+++ b/packages/skeleton-react/src/routes/components/progress-rings.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { ProgressRing } from '../../lib/components/ProgressRing/ProgressRing.js';
 import { ThermometerSun as IconThermometer } from 'lucide-react';
+import { useState } from 'react';
+
+import { ProgressRing } from '@/lib/components/ProgressRing/ProgressRing.js';
 
 export function Component() {
 	const [value, setValue] = useState(50);

--- a/packages/skeleton-react/src/routes/components/progress.tsx
+++ b/packages/skeleton-react/src/routes/components/progress.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Progress } from '@/lib/components/Progress/Progress.js';
+import { Progress } from '$lib/components/Progress/Progress.js';
 
 export function Component() {
 	const [value, setValue] = useState(50);

--- a/packages/skeleton-react/src/routes/components/progress.tsx
+++ b/packages/skeleton-react/src/routes/components/progress.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Progress } from '../../lib/components/Progress/Progress.js';
+
+import { Progress } from '@/lib/components/Progress/Progress.js';
 
 export function Component() {
 	const [value, setValue] = useState(50);

--- a/packages/skeleton-react/src/routes/components/ratings.tsx
+++ b/packages/skeleton-react/src/routes/components/ratings.tsx
@@ -1,7 +1,7 @@
 import { Bone, Skull, Star } from 'lucide-react';
 import { useState } from 'react';
 
-import { Rating } from '@/lib/components/Rating/Rating';
+import { Rating } from '$lib/components/Rating/Rating';
 
 function StaticRatings(value: number) {
 	return (

--- a/packages/skeleton-react/src/routes/components/ratings.tsx
+++ b/packages/skeleton-react/src/routes/components/ratings.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { Rating } from '../../lib/components/Rating/Rating';
 import { Bone, Skull, Star } from 'lucide-react';
+import { useState } from 'react';
+
+import { Rating } from '@/lib/components/Rating/Rating';
 
 function StaticRatings(value: number) {
 	return (

--- a/packages/skeleton-react/src/routes/components/switch.tsx
+++ b/packages/skeleton-react/src/routes/components/switch.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { Switch } from '../../lib/components/Switch/Switch.js';
 import { Check as IconCheck, X as IconX, Moon as IconMoon, Sun as IconSun, Frown as IconFrown, Smile as IconSmile } from 'lucide-react';
+import { useState } from 'react';
+
+import { Switch } from '@/lib/components/Switch/Switch.js';
 
 export function Component() {
 	const [disturb, setDisturb] = useState(false);
@@ -17,22 +18,22 @@ export function Component() {
 			</header>
 			<pre className="pre">{JSON.stringify({ disturb, notifications, disabled, icons, lightswitch, compact }, null, 2)}</pre>
 			<section className="space-y-4">
-				<label htmlFor="disturb" className="label flex items-center justify-between gap-4">
+				<label htmlFor="disturb" className="flex items-center justify-between gap-4 label">
 					<p>Defaults to inactive state.</p>
 					<Switch id="disturb" name="disturb" checked={disturb} onCheckedChange={setDisturb} />
 				</label>
 				<hr className="hr" />
-				<label htmlFor="notifications" className="label flex items-center justify-between gap-4">
+				<label htmlFor="notifications" className="flex items-center justify-between gap-4 label">
 					<p>Defaults to active state.</p>
 					<Switch id="notifications" name="notifications" checked={notifications} onCheckedChange={setNotifications} />
 				</label>
 				<hr className="hr" />
-				<label htmlFor="disabled" className="label flex items-center justify-between gap-4">
+				<label htmlFor="disabled" className="flex items-center justify-between gap-4 label">
 					<p>Uses the disabled state.</p>
 					<Switch id="disabled" name="disabled" checked={disabled} onCheckedChange={setDisabled} disabled />
 				</label>
 				<hr className="hr" />
-				<label htmlFor="icons" className="label flex items-center justify-between gap-4">
+				<label htmlFor="icons" className="flex items-center justify-between gap-4 label">
 					<p>Custom Icons</p>
 					<Switch
 						id="icons"
@@ -45,7 +46,7 @@ export function Component() {
 					/>
 				</label>
 				<hr className="hr" />
-				<label htmlFor="mode" className="label flex items-center justify-between gap-4">
+				<label htmlFor="mode" className="flex items-center justify-between gap-4 label">
 					<p>Lightswitch</p>
 					<Switch
 						id="mode"
@@ -58,7 +59,7 @@ export function Component() {
 					/>
 				</label>
 				<hr className="hr" />
-				<label htmlFor="compact" className="label flex items-center justify-between gap-4">
+				<label htmlFor="compact" className="flex items-center justify-between gap-4 label">
 					<p>Compact</p>
 					<Switch
 						id="compact"

--- a/packages/skeleton-react/src/routes/components/switch.tsx
+++ b/packages/skeleton-react/src/routes/components/switch.tsx
@@ -1,7 +1,7 @@
 import { Check as IconCheck, X as IconX, Moon as IconMoon, Sun as IconSun, Frown as IconFrown, Smile as IconSmile } from 'lucide-react';
 import { useState } from 'react';
 
-import { Switch } from '@/lib/components/Switch/Switch.js';
+import { Switch } from '$lib/components/Switch/Switch.js';
 
 export function Component() {
 	const [disturb, setDisturb] = useState(false);

--- a/packages/skeleton-react/src/routes/components/switch.tsx
+++ b/packages/skeleton-react/src/routes/components/switch.tsx
@@ -18,22 +18,22 @@ export function Component() {
 			</header>
 			<pre className="pre">{JSON.stringify({ disturb, notifications, disabled, icons, lightswitch, compact }, null, 2)}</pre>
 			<section className="space-y-4">
-				<label htmlFor="disturb" className="flex items-center justify-between gap-4 label">
+				<label htmlFor="disturb" className="label flex items-center justify-between gap-4">
 					<p>Defaults to inactive state.</p>
 					<Switch id="disturb" name="disturb" checked={disturb} onCheckedChange={setDisturb} />
 				</label>
 				<hr className="hr" />
-				<label htmlFor="notifications" className="flex items-center justify-between gap-4 label">
+				<label htmlFor="notifications" className="label flex items-center justify-between gap-4">
 					<p>Defaults to active state.</p>
 					<Switch id="notifications" name="notifications" checked={notifications} onCheckedChange={setNotifications} />
 				</label>
 				<hr className="hr" />
-				<label htmlFor="disabled" className="flex items-center justify-between gap-4 label">
+				<label htmlFor="disabled" className="label flex items-center justify-between gap-4">
 					<p>Uses the disabled state.</p>
 					<Switch id="disabled" name="disabled" checked={disabled} onCheckedChange={setDisabled} disabled />
 				</label>
 				<hr className="hr" />
-				<label htmlFor="icons" className="flex items-center justify-between gap-4 label">
+				<label htmlFor="icons" className="label flex items-center justify-between gap-4">
 					<p>Custom Icons</p>
 					<Switch
 						id="icons"
@@ -46,7 +46,7 @@ export function Component() {
 					/>
 				</label>
 				<hr className="hr" />
-				<label htmlFor="mode" className="flex items-center justify-between gap-4 label">
+				<label htmlFor="mode" className="label flex items-center justify-between gap-4">
 					<p>Lightswitch</p>
 					<Switch
 						id="mode"
@@ -59,7 +59,7 @@ export function Component() {
 					/>
 				</label>
 				<hr className="hr" />
-				<label htmlFor="compact" className="flex items-center justify-between gap-4 label">
+				<label htmlFor="compact" className="label flex items-center justify-between gap-4">
 					<p>Compact</p>
 					<Switch
 						id="compact"

--- a/packages/skeleton-react/src/routes/components/tabs.tsx
+++ b/packages/skeleton-react/src/routes/components/tabs.tsx
@@ -1,7 +1,7 @@
 import { Plane, Hotel, Box } from 'lucide-react';
 import { useState } from 'react';
 
-import { Tabs } from '@/lib/components/Tabs/Tabs.js';
+import { Tabs } from '$lib/components/Tabs/Tabs.js';
 
 function Preview(group: string, setGroup: React.Dispatch<React.SetStateAction<string>>) {
 	return (

--- a/packages/skeleton-react/src/routes/components/tabs.tsx
+++ b/packages/skeleton-react/src/routes/components/tabs.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import { Tabs } from '../../lib/components/Tabs/Tabs.js';
 import { Plane, Hotel, Box } from 'lucide-react';
+import { useState } from 'react';
+
+import { Tabs } from '@/lib/components/Tabs/Tabs.js';
 
 function Preview(group: string, setGroup: React.Dispatch<React.SetStateAction<string>>) {
 	return (

--- a/packages/skeleton-react/src/routes/components/test.tsx
+++ b/packages/skeleton-react/src/routes/components/test.tsx
@@ -1,4 +1,4 @@
-import Test from '../../lib/components/Test/Test.js';
+import Test from '@/lib/components/Test/Test.js';
 
 export function Component() {
 	return <Test />;

--- a/packages/skeleton-react/src/routes/components/test.tsx
+++ b/packages/skeleton-react/src/routes/components/test.tsx
@@ -1,4 +1,4 @@
-import Test from '@/lib/components/Test/Test.js';
+import Test from '$lib/components/Test/Test.js';
 
 export function Component() {
 	return <Test />;

--- a/packages/skeleton-react/tsconfig.json
+++ b/packages/skeleton-react/tsconfig.json
@@ -23,7 +23,7 @@
 
 		/* Paths */
 		"paths": {
-			"@/*": ["./src/*"]
+			"$lib/*": ["./src/lib/*"]
 		}
 	},
 	"include": ["src"],

--- a/packages/skeleton-react/tsconfig.json
+++ b/packages/skeleton-react/tsconfig.json
@@ -19,7 +19,12 @@
 		"noFallthroughCasesInSwitch": true,
 
 		/* Types */
-		"types": ["vite-plugin-remix-router/client", "@testing-library/jest-dom", "@testing-library/user-event"]
+		"types": ["vite-plugin-remix-router/client", "@testing-library/jest-dom", "@testing-library/user-event"],
+
+		/* Paths */
+		"paths": {
+			"@/*": ["./src/*"]
+		}
 	},
 	"include": ["src"],
 	"references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/skeleton-react/tsconfig.package.json
+++ b/packages/skeleton-react/tsconfig.package.json
@@ -23,7 +23,12 @@
 		"noFallthroughCasesInSwitch": true,
 
 		/* Types */
-		"types": ["vite-plugin-remix-router/client", "@testing-library/jest-dom", "@testing-library/user-event"]
+		"types": ["vite-plugin-remix-router/client", "@testing-library/jest-dom", "@testing-library/user-event"],
+
+		/* Paths */
+		"paths": {
+			"@/*": ["./src/*"]
+		}
 	},
 	"include": ["src/lib"]
 }

--- a/packages/skeleton-react/tsconfig.package.json
+++ b/packages/skeleton-react/tsconfig.package.json
@@ -27,7 +27,7 @@
 
 		/* Paths */
 		"paths": {
-			"@/*": ["./src/*"]
+			"$lib/*": ["./src/lib/*"]
 		}
 	},
 	"include": ["src/lib"]

--- a/packages/skeleton-react/vite.config.ts
+++ b/packages/skeleton-react/vite.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
 		RemixRouter(),
 		skeletonPluginWatcher(path.resolve(path.join('..', '..', 'packages', 'skeleton', 'src', 'plugin')))
 	],
+	resolve: {
+		alias: {
+			'@': path.resolve(__dirname, './src')
+		}
+	},
 	test: {
 		// https://victorbruce82.medium.com/vitest-with-react-testing-library-in-react-created-with-vite-3552f0a9a19a
 		environment: 'jsdom',

--- a/packages/skeleton-react/vite.config.ts
+++ b/packages/skeleton-react/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
 	],
 	resolve: {
 		alias: {
-			'@': path.resolve(__dirname, './src')
+			$lib: path.resolve(__dirname, './src/lib')
 		}
 	},
 	test: {

--- a/sites/next.skeleton.dev/src/content/docs/resources/contribute/components.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/resources/contribute/components.mdx
@@ -257,16 +257,16 @@ The implementation of this will differ per framework.
 
 ### React
 
-To implement this, first import the `reactCompose` utility into the component file:
+To implement this, we use `Object.assign()`
 
 ```ts
-import { reactCompose } from '../../utils/react-compose';
+Object.assign(RootComponent, { children });
 ```
 
-Then scaffold your component exports at the bottom of the file:
+For example, for the accordion component
 
 ```ts
-export const Accordion = reactCompose(
+export const Accordion = Object.assign(
 	AccordionRoot, // -> <Accordion>
 	{
 		Item: AccordionItem, // -> <Accordion.Item>


### PR DESCRIPTION
## Linked Issue

Addresses one issue raised in #2733  (side note: I will from now on open smaller issues, this was just an easy target)

## Description

This PR makes 2 notable changes. 

1. Adds a path alias to `vite.config.ts`, `tsconfig.json`, and `tsconfig.package.json` to redirect the standard alias `@` to `__dirname/src`.
2. All components that rely on composition and previously used the `reactCompose` function, now instead implement `Object.assign` directly.

It's nice to make a small, easy change this time.

## Changsets

Changesets have been added. I'll just need to push one more commit to update my message (my mistake, I forgot to follow conventional commit standards).

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`) **this PR actually targets `next`**
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
