### PR TITLE
fix: add restProps to InputChip

### DIFF
--- a/.changeset/chatty-ties-sell.md
+++ b/.changeset/chatty-ties-sell.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Added restProps to InputChip

--- a/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
+++ b/packages/skeleton/src/lib/components/InputChip/InputChip.svelte
@@ -268,6 +268,12 @@
 		dispatch('removeManually', { chipValue: chip });
 	}
 
+	// Pruned RestProps
+	function prunedRestProps() {
+		delete $$restProps.class;
+		return $$restProps;
+	}
+
 	// State
 	$: classesInvalid = inputValid === false ? invalid : '';
 	// Reactive
@@ -303,6 +309,7 @@
 			on:focus
 			on:blur
 			disabled={$$restProps.disabled}
+			{...prunedRestProps()}
 		/>
 		<!-- Chip List -->
 		{#if chipValues.length}


### PR DESCRIPTION
## Linked Issue

Closes #2737

## Description

I added the same code FileDropzone uses to add restProps

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
