### PR TITLE
Chore/revert tile click event

### DIFF
--- a/.changeset/clean-ducks-mix.md
+++ b/.changeset/clean-ducks-mix.md
@@ -2,4 +2,4 @@
 "@skeletonlabs/skeleton": patch
 ---
 
-chore: Revert AppRailTile onclick event
+chore: Resolve missing onclick events for AppRailTile and AppRailAnchor.

--- a/.changeset/clean-ducks-mix.md
+++ b/.changeset/clean-ducks-mix.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: Revert AppRailTile onclick event

--- a/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailAnchor.svelte
@@ -45,7 +45,7 @@
 	}
 </script>
 
-<a class="app-rail-anchor {classesBase}" href={$$props.href} {...prunedRestProps()} data-testid="app-rail-anchor">
+<a class="app-rail-anchor {classesBase}" href={$$props.href} {...prunedRestProps()} data-testid="app-rail-anchor" on:click>
 	<div class="app-rail-wrapper {classesWrapper}">
 		{#if $$slots.lead}<div class="app-rail-lead {classesLead}"><slot name="lead" /></div>{/if}
 		<div class="app-rail-label {classesLabel}"><slot /></div>

--- a/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
+++ b/packages/skeleton/src/lib/components/AppRail/AppRailTile.svelte
@@ -82,7 +82,7 @@
 	<!-- A11y attributes are not allowed on <label> -->
 	<!-- FIXME: resolve a11y warnings -->
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
-	<button class="app-rail-wrapper {classesWrapper}" tabindex="0" on:click={selectElemInput} on:keydown={onKeyDown} on:keyup on:keypress>
+	<button class="app-rail-wrapper {classesWrapper}" tabindex="0" on:click={selectElemInput} on:click on:keydown={onKeyDown} on:keyup on:keypress>
 		<!-- NOTE: Don't use `hidden` as it prevents `required` from operating -->
 		<div class="h-0 w-0 overflow-hidden">
 			<input bind:this={elemInput} type="radio" bind:group {name} {value} {...prunedRestProps()} tabindex="-1" on:click on:change />


### PR DESCRIPTION
## Linked Issue

Closes #2740
Closes #2742

## Description

Resolved missing `on:click` events for both the `<AppRailTile>` and `<AppRailAnchor>` components.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
