### PR TITLE
fix: prettier mdx

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,5 +16,6 @@ pnpm-lock.yaml
 **/static/font-awesome
 **/static/fonts
 
-# Ignore .mdx files as codeblocks are broken
+# Ignore .mdx files because codeblocks indside .mdx files are broken with prettier
+# See: https://github.com/prettier/prettier/issues/12209
 sites/next.skeleton.dev/**/*.mdx

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,6 @@ pnpm-lock.yaml
 
 **/static/font-awesome
 **/static/fonts
+
+# Ignore .mdx files as codeblocks are broken
+sites/next.skeleton.dev/**/*.mdx

--- a/sites/next.skeleton.dev/src/content/docs/design/presets.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/design/presets.mdx
@@ -27,7 +27,7 @@ export const components = componentSet;
 			<div class="preset-filled-primary-300-700 flex items-center justify-center p-4">300-700</div>
 			<div class="preset-filled-primary-200-800 flex items-center justify-center p-4">200-800</div>
 			<div class="preset-filled-primary-100-900 flex items-center justify-center p-4">100-900</div>
-			<div class="prcleareset-filled-primary-50-950 flex items-center justify-center p-4">50-950</div>
+			<div class="preset-filled-primary-50-950 flex items-center justify-center p-4">50-950</div>
 		</div>
 	</Fragment>
 	<Fragment slot="code">

--- a/sites/next.skeleton.dev/src/content/docs/design/presets.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/design/presets.mdx
@@ -27,11 +27,12 @@ export const components = componentSet;
 			<div class="preset-filled-primary-300-700 flex items-center justify-center p-4">300-700</div>
 			<div class="preset-filled-primary-200-800 flex items-center justify-center p-4">200-800</div>
 			<div class="preset-filled-primary-100-900 flex items-center justify-center p-4">100-900</div>
-			<div class="preset-filled-primary-50-950 flex items-center justify-center p-4">50-950</div>
+			<div class="prcleareset-filled-primary-50-950 flex items-center justify-center p-4">50-950</div>
 		</div>
 	</Fragment>
 	<Fragment slot="code">
-		```css .preset-filled-{color}-{shade}-{shade}
+		```css 
+		.preset-filled-{color}-{shade}-{shade}
 		```
 	</Fragment>
 </Preview>
@@ -52,7 +53,8 @@ export const components = componentSet;
 		</div>
 	</Fragment>
 	<Fragment slot="code">
-		```css .preset-tonal-{color}
+		```css 
+		.preset-tonal-{color}
 		```
 	</Fragment>
 </Preview>
@@ -79,7 +81,8 @@ export const components = componentSet;
 		</div>
 	</Fragment>
 	<Fragment slot="code">
-		```css .preset-outlined-{color}-{shade}-{shade}
+		```css 
+		.preset-outlined-{color}-{shade}-{shade}
 		```
 	</Fragment>
 </Preview>


### PR DESCRIPTION
Added `.mdx` files to `.prettierignore` by adding it to the root.
As @endigo9740 attempted before, nested `.prettierignore` files don't work with prettier as per: https://github.com/prettier/prettier/issues/4081.

The CI passing in this PR should prove that it works as expected since the codeblocks are working and prettier is passing, which wasn't the case before.