### PR TITLE
feat: remove/sync base classes switch

### DIFF
--- a/packages/skeleton-react/src/lib/components/Switch/Switch.tsx
+++ b/packages/skeleton-react/src/lib/components/Switch/Switch.tsx
@@ -13,7 +13,7 @@ export const Switch: React.FC<SwitchProps> = ({
 	labelledby = undefined,
 	describedby = undefined,
 	// Root (Track)
-	base = 'flex cursor-pointer transition duration-200',
+	base = 'cursor-pointer transition duration-200',
 	stateInactive = 'preset-filled-surface-200-800',
 	stateActive = 'preset-filled-primary-500',
 	stateDisabled = 'opacity-50 cursor-not-allowed',

--- a/packages/skeleton-svelte/src/lib/components/Switch/Switch.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Switch/Switch.svelte
@@ -11,7 +11,7 @@
 		labelledby = undefined,
 		describedby = undefined,
 		// Root (Track)
-		base = 'inline cursor-pointer transition duration-200',
+		base = 'cursor-pointer transition duration-200',
 		stateInactive = 'preset-filled-surface-200-800',
 		stateActive = 'preset-filled-primary-500',
 		stateDisabled = 'opacity-50 cursor-not-allowed',


### PR DESCRIPTION
Svelte used `inline`, React used `flex`, removing both has the same result.