### PR TITLE
refactor: remove tabindex from button - it is part of the tab order b…

### DIFF
--- a/packages/skeleton-svelte/src/lib/components/Switch/Switch.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Switch/Switch.svelte
@@ -74,7 +74,6 @@
 	aria-checked={checked}
 	aria-labelledby={labelledby}
 	aria-describedby={describedby}
-	tabindex="0"
 	onclick={toggle}
 	data-testid="switch"
 >


### PR DESCRIPTION
Sync between Svelte and React components. Removed redundant tabindex from button.