### PR TITLE
patch: buttonTextSubmit param not working in modal component example

### DIFF
--- a/sites/skeleton.dev/src/lib/modals/examples/ModalExampleForm.svelte
+++ b/sites/skeleton.dev/src/lib/modals/examples/ModalExampleForm.svelte
@@ -53,7 +53,7 @@
 		<!-- prettier-ignore -->
 		<footer class="modal-footer {parent.regionFooter}">
 			<button class="btn {parent.buttonNeutral}" on:click={parent.onClose}>{parent.buttonTextCancel}</button>
-			<button class="btn {parent.buttonPositive}" on:click={onFormSubmit}>Submit Form</button>
+			<button class="btn {parent.buttonPositive}" on:click={onFormSubmit}>{parent.buttonTextSubmit}</button>
 		</footer>
 	</div>
 {/if}


### PR DESCRIPTION
## Linked Issue

not relevant

## Description

example modal with custom component from docs had a missing prop.

## Changesets
bugfix: in modal component example; added dynamic buttonTextSubmit param from parent

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [nc ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [nc ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [nc ] Ensure Prettier linting is current - run `pnpm format`
- [nc ] All test cases are passing - run `pnpm test`
- [nc ] Includes a changeset (if relevant; see above)
nc = non compat with github quick pr feature
