### PR TITLE
tailwind/forms: Install Tailwind Plugin instructions

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/tailwind/forms.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/tailwind/forms.mdx
@@ -61,7 +61,7 @@ Install the `@tailwindcss/forms` package.
 npm install -D @tailwindcss/forms
 ```
 
-Impleme the plugin in your `tailwind.config`, ideally before the Skeleton plugin.
+Implement the plugin in your `tailwind.config`, ideally before the Skeleton plugin.
 
 ```js {1,5}
 import forms from '@tailwindcss/forms';

--- a/sites/next.skeleton.dev/src/content/docs/tailwind/forms.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/tailwind/forms.mdx
@@ -1,6 +1,6 @@
 ---
 layout: '@layouts/LayoutDoc.astro'
-title: Forms & Inputs
+title: Forms and Inputs
 description: Various form and input styles.
 srcCore: '/plugin/components/forms.css'
 showDocsUrl: true
@@ -34,23 +34,42 @@ import ExampleGroupsRaw from '@examples/tailwind/forms/ExampleGroups.astro?raw';
 	</div>
 </Preview>
 
-## Install the Forms Plugin
-The Tailwind Forms plugin normalizes form field styles, making them easier to customize and providing some rudimentary styles. It is required for the components on this page to work correctly. See [Tailwind's video tutorial](https://www.youtube.com/watch?v=pONeWAzDsQg) for more information.
+## Prerequisites
 
-Firstly, install the `@tailwindcss/forms` package using your package manager:
+Skeleton relies on the official [Tailwind Forms](https://github.com/tailwindlabs/tailwindcss-forms) plugin to normalize form styling. This implements rudamentary base styles, while also making it easier to customize each element. If you plan to implement forms in your project, make sure this plugin is installed.
+
+<figure class="card-enhanced-gradient flex justify-center gap-4 p-8">
+	<a
+		class="btn preset-filled"
+		href="https://github.com/tailwindlabs/tailwindcss-forms"
+		target="_blank"
+	>
+		Plugin Doc
+	</a>
+	<a
+		class="btn preset-outlined"
+		href="https://www.youtube.com/watch?v=pONeWAzDsQg"
+		target="_blank"
+	>
+		Video Guide
+	</a>
+</figure>
+
+Install the `@tailwindcss/forms` package.
+
 ```sh
 npm install -D @tailwindcss/forms
 ```
 
-Prepend the [Tailwind Forms plugin](https://github.com/tailwindlabs/tailwindcss-forms) to your `tailwind.config.[ts|js]`:
-```js
+Impleme the plugin in your `tailwind.config`, ideally before the Skeleton plugin.
+
+```js {1,5}
 import forms from '@tailwindcss/forms';
 
 export default {
-	//...
 	plugins: [
 		forms,
-		//...
+		// skeleton()
 	]
 };
 ```

--- a/sites/next.skeleton.dev/src/content/docs/tailwind/forms.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/tailwind/forms.mdx
@@ -34,6 +34,27 @@ import ExampleGroupsRaw from '@examples/tailwind/forms/ExampleGroups.astro?raw';
 	</div>
 </Preview>
 
+## Install the Forms Plugin
+The Tailwind Forms plugin normalizes form field styles, making them easier to customize and providing some rudimentary styles. It is required for the components on this page to work correctly. See [Tailwind's video tutorial](https://www.youtube.com/watch?v=pONeWAzDsQg) for more information.
+
+Firstly, install the `@tailwindcss/forms` package using your package manager:
+```sh
+npm install -D @tailwindcss/forms
+```
+
+Prepend the [Tailwind Forms plugin](https://github.com/tailwindlabs/tailwindcss-forms) to your `tailwind.config.[ts|js]`:
+```js
+import forms from '@tailwindcss/forms';
+
+export default {
+	//...
+	plugins: [
+		forms,
+		//...
+	]
+};
+```
+
 ## Select
 
 <Preview client:load>


### PR DESCRIPTION
## Linked Issue

Followup of https://github.com/skeletonlabs/skeleton/discussions/2765

## Description

Adds instructions on how to install the Tailwind Forms plugin as it is required for Skeleton's styles to work correctly.
I mostly copied the v2 docs, with some minor changes.

![new docs page vs v2](https://github.com/user-attachments/assets/e71abd02-96cb-4851-a244-1b2ff90e0a4a)
*new v3 docs vs v2*


## Closing thoughts
The "contributing" page is awesome, never seen such a well-written guide!
In case I should change anything about this PR, please let me know. Edits by maintainers are enabled too.