### PR TITLE
use current svelte-add syntax to install tailwind

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
@@ -41,8 +41,8 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         ## Install Tailwind
         Install Tailwind using [Svelte-Add](https://svelte-add.com/) to automate the process.
         ```console
-        npx @svelte-add/tailwindcss@latest --typography false
-        npm install
+        npx svelte-add@latest tailwindcss
+        # choose to not install typography
         ```
         > NOTE: if you see "something went wrong", everything will work as expected. Please proceed to the next step.
     </ProcessStep>

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
@@ -41,8 +41,7 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         ## Install Tailwind
         Install Tailwind using [Svelte-Add](https://svelte-add.com/) to automate the process.
         ```console
-        npx svelte-add@latest tailwindcss
-        # choose to not install typography
+        npx svelte-add@latest tailwindcss --tailwindcss-typography false
         ```
         > NOTE: if you see "something went wrong", everything will work as expected. Please proceed to the next step.
     </ProcessStep>


### PR DESCRIPTION
## Linked Issue

Closes #2798 

## Description

The @svelte-add/tailwindcss package is deprecated and recommends using `svelte-add tailwindcss`: https://github.com/svelte-add/tailwindcss

