### PR TITLE
NEXT: Improved focus states

### DIFF
--- a/.changeset/wicked-seahorses-itch.md
+++ b/.changeset/wicked-seahorses-itch.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+"@skeletonlabs/skeleton-react": patch
+"@skeletonlabs/skeleton": patch
+---
+
+chore: Improved global and per component focus state styles

--- a/packages/skeleton-react/src/lib/components/Segment/Segment.tsx
+++ b/packages/skeleton-react/src/lib/components/Segment/Segment.tsx
@@ -90,6 +90,7 @@ const SegmentItem: FC<SegmentItemsProps> = ({
 	labelClasses = '',
 	// State
 	stateDisabled = 'disabled',
+	stateFocused = 'focused',
 	// Children
 	children,
 	// Zag
@@ -102,9 +103,10 @@ const SegmentItem: FC<SegmentItemsProps> = ({
 	// Reactive
 	const rxDisabled = state.disabled ? stateDisabled : '';
 	const rxActiveText = state.checked ? ctx.indicatorText : '';
+	const rxFocused = state.focused ? stateFocused : '';
 
 	return (
-		<label {...ctx.api.getItemProps(zagProps)} className={`${base} ${rxDisabled} ${classes}`} data-testid="segment-item">
+		<label {...ctx.api.getItemProps(zagProps)} className={`${base} ${rxDisabled} ${rxFocused} ${classes}`} data-testid="segment-item">
 			{/* Label */}
 			<span
 				{...ctx.api.getItemTextProps(zagProps)}

--- a/packages/skeleton-react/src/lib/components/Segment/types.ts
+++ b/packages/skeleton-react/src/lib/components/Segment/types.ts
@@ -71,6 +71,8 @@ export interface SegmentItemsProps extends React.PropsWithChildren, Omit<radio.I
 
 	/** Set claseses for the disabled state. */
 	stateDisabled?: string;
+	/** Set claseses for the focus state. */
+	stateFocused?: string;
 
 	// Label ---
 	/** Sets base classes for the label element. */

--- a/packages/skeleton-react/src/lib/components/Switch/Switch.tsx
+++ b/packages/skeleton-react/src/lib/components/Switch/Switch.tsx
@@ -13,6 +13,8 @@ export const Switch: React.FC<SwitchProps> = ({
 	compact = false,
 	// Root (Track)
 	base = 'inline-flex items-center gap-4',
+	// State
+	stateFocused = '[&>span]:focused',
 	classes = '',
 	// Control
 	controlBase = 'cursor-pointer transition duration-200',
@@ -77,9 +79,10 @@ export const Switch: React.FC<SwitchProps> = ({
 	const rxTrackState = api.checked ? controlActive : controlInactive;
 	const rxThumbState = api.checked ? `${thumbActive} ${thumbTranslateX}` : thumbInactive;
 	const rxDisabled = api.disabled ? controlDisabled : '';
+	const rxFocused = api.focused ? stateFocused : '';
 
 	return (
-		<label {...api.getRootProps()} className={`${base} ${classes}`} data-testid="switch">
+		<label {...api.getRootProps()} className={`${base} ${rxFocused} ${classes}`} data-testid="switch">
 			{/* Input */}
 			<input {...api.getHiddenInputProps()} data-testid="switch-input" />
 			{/* Control */}

--- a/packages/skeleton-react/src/lib/components/Switch/types.ts
+++ b/packages/skeleton-react/src/lib/components/Switch/types.ts
@@ -17,6 +17,10 @@ export interface SwitchProps extends React.PropsWithChildren, Omit<zagSwitch.Con
 	/** Provide arbitrary classes to the root element. */
 	classes?: string;
 
+	// State ---
+	/** Set claseses for the focus state. */
+	stateFocused?: string;
+
 	// Control ---
 	/** Set base classes for the control element. */
 	controlBase?: string;

--- a/packages/skeleton-svelte/src/lib/components/Segment/SegmentItem.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Segment/SegmentItem.svelte
@@ -8,6 +8,7 @@
 		classes = '',
 		// State
 		stateDisabled = 'disabled',
+		stateFocused = 'focused',
 		// Label
 		labelBase = 'pointer-events-none transition-colors duration-100',
 		labelClasses = '',
@@ -24,11 +25,12 @@
 	const state = $derived(ctx.api.getItemState(zagProps));
 	const rxDisabled = $derived(state.disabled ? stateDisabled : '');
 	const rxActiveText = $derived(state.checked ? ctx.indicatorText : '');
+	const rxFocused = $derived(state.focused ? stateFocused : '');
 </script>
 
 <!-- @component An individual Segment option. -->
 
-<label {...ctx.api.getItemProps(zagProps)} class="{base} {rxDisabled} {classes}" data-testid="segment-item">
+<label {...ctx.api.getItemProps(zagProps)} class="{base} {rxDisabled} {rxFocused} {classes}" data-testid="segment-item">
 	<!-- Label -->
 	<span {...ctx.api.getItemTextProps(zagProps)} class="{labelBase} {rxActiveText} {labelClasses}" data-testid="segment-item-label">
 		{@render children?.()}

--- a/packages/skeleton-svelte/src/lib/components/Segment/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Segment/types.ts
@@ -36,11 +36,13 @@ export interface SegmentControl extends Omit<radio.Context, 'id' | 'orientation'
 	/** Provide arbitrary CSS classes. */
 	classes?: string;
 
-	// States ---
+	// Orientation---
 	/** Set classes to provide a vertical layout. */
 	orientVertical?: string;
 	/** Set classes to provide a horizintal layout. */
 	orientHorizontal?: string;
+
+	// States ---
 	/** Set claseses for the disabled state. */
 	stateDisabled?: string;
 	/** Set claseses for the read-only state. */
@@ -72,6 +74,8 @@ export interface SegmentItemProps extends Omit<radio.ItemProps, 'invalid'> {
 
 	/** Set claseses for the disabled state. */
 	stateDisabled?: string;
+	/** Set claseses for the focus state. */
+	stateFocused?: string;
 
 	// Label ---
 	/** Sets base classes for the label element. */

--- a/packages/skeleton-svelte/src/lib/components/Switch/Switch.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Switch/Switch.svelte
@@ -12,6 +12,8 @@
 		// Root (Track)
 		base = 'inline-flex items-center gap-4',
 		classes = '',
+		// State
+		stateFocused = '[&>span]:focused',
 		// Control
 		controlBase = 'cursor-pointer transition duration-200',
 		controlInactive = 'preset-filled-surface-200-800',
@@ -90,11 +92,12 @@
 	const rxTrackState = $derived(api.checked ? controlActive : controlInactive);
 	const rxThumbState = $derived(api.checked ? `${thumbActive} ${thumbTranslateX}` : thumbInactive);
 	const rxDisabled = $derived(api.disabled ? controlDisabled : '');
+	const rxFocused = $derived(api.focused ? stateFocused : '');
 </script>
 
 <!-- @component A control for toggling between checked states. -->
 
-<label {...api.getRootProps()} class="{base} {classes}" data-testid="switch">
+<label {...api.getRootProps()} class="{base} {rxFocused} {classes}" data-testid="switch">
 	<!-- Input -->
 	<input {...api.getHiddenInputProps()} data-testid="switch-input" />
 	<!-- Control -->

--- a/packages/skeleton-svelte/src/lib/components/Switch/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Switch/types.ts
@@ -17,6 +17,10 @@ export interface SwitchProps extends Omit<zagSwitch.Context, 'id'> {
 	/** Provide arbitrary classes to the root element. */
 	classes?: string;
 
+	// State ---
+	/** Set claseses for the focus state. */
+	stateFocused?: string;
+
 	// Control ---
 	/** Set base classes for the control element. */
 	controlBase?: string;

--- a/packages/skeleton/src/plugin/base/core.css
+++ b/packages/skeleton/src/plugin/base/core.css
@@ -38,17 +38,18 @@ html {
 }
 
 /* Outlines and Focus --- */
+
 /*
-	REMINDER: never disabled focus or outlines
+	REMINDER: Never disabled focus and outlines
 	as this would be harmful to accessibility!
 	Source: http://www.outlinenone.com/
+
+	EXAMPLE: Set a global focus style.
+	Apply this in your app's global stylesheet:
+	:focus { @apply focus:outline-primary-50; }
 */
 
-/* Global Focus */
-:focus {
-	@apply focus:outline-surface-950 dark:focus:outline-surface-50;
-}
-/* Focus Class (for components) */
+/* Component Focus Utility */
 .focused {
 	@apply ring-[2px] ring-surface-950 dark:ring-surface-50 ring-inset;
 }

--- a/packages/skeleton/src/plugin/base/core.css
+++ b/packages/skeleton/src/plugin/base/core.css
@@ -37,12 +37,21 @@ html {
 	scrollbar-width: thin;
 }
 
-/* Focus & Outlines --- */
+/* Outlines and Focus --- */
 /*
 	REMINDER: never disabled focus or outlines
 	as this would be harmful to accessibility!
 	Source: http://www.outlinenone.com/
 */
+
+/* Global Focus */
+:focus {
+	@apply focus:outline-surface-950 dark:focus:outline-surface-50;
+}
+/* Focus Class (for components) */
+.focused {
+	@apply ring-[2px] ring-surface-950 dark:ring-surface-50 ring-inset;
+}
 
 /* Disabled States --- */
 


### PR DESCRIPTION
## Linked Issue

Closes #2806

## Description

~~Resolve global focus states for native elements and Zag-based components.~~

Implements a common global `.focused` class that can be used to visualize focus state within Zag-base components.

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](http://localhost:4321/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
