### PR TITLE
Move `react` and `react-dom` to `peerDependencies`

### DIFF
--- a/.changeset/stale-taxis-kneel.md
+++ b/.changeset/stale-taxis-kneel.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton-react": patch
+---
+
+chore: Move `react` and `react-dom` to `peerDependencies`

--- a/packages/skeleton-react/package.json
+++ b/packages/skeleton-react/package.json
@@ -47,9 +47,11 @@
 		"@zag-js/rating-group": "catalog:",
 		"@zag-js/react": "catalog:",
 		"@zag-js/switch": "catalog:",
-		"@zag-js/tabs": "catalog:",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"@zag-js/tabs": "catalog:"
+	},
+	"peerDependencies": {
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0"
 	},
 	"devDependencies": {
 		"@skeletonlabs/skeleton": "workspace:*",
@@ -71,6 +73,8 @@
 		"vite": "^5.3.4",
 		"vite-plugin-remix-router": "^2.0.0",
 		"vite-plugin-tw-plugin-watcher": "workspace:*",
-		"vitest": "^1.6.0"
+		"vitest": "^1.6.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,12 +217,6 @@ importers:
       '@zag-js/tabs':
         specifier: 'catalog:'
         version: 0.65.0
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@skeletonlabs/skeleton':
         specifier: workspace:*
@@ -260,6 +254,12 @@ importers:
       postcss:
         specifier: ^8.4.39
         version: 8.4.39
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
       react-router-dom:
         specifier: ^6.25.1
         version: 6.25.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Linked Issue

Closes #2829 

## Description

Moves react deps to peerDeps.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `next` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
