### PR TITLE
paginator text not NAN if setting.size value is not number

### DIFF
--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -220,7 +220,7 @@
 		{#if showNumerals === false}
 			<!-- Details -->
 			<button type="button" class="{buttonClasses} pointer-events-none !text-sm">
-				{settings.page * settings.limit + 1}-{Math.min(settings.page * settings.limit + settings.limit, settings.size)}&nbsp;<span
+				{settings.page * settings.limit + 1}-{Math.min(settings.page * settings.limit + settings.limit, typeof settings.size === 'number' ? settings.size : Infinity)}&nbsp;<span
 					class="opacity-50">{separatorText} {settings.size}</span
 				>
 			</button>


### PR DESCRIPTION
## Linked Issue

Closes #2831

## Description

Bugfix for paginator text not NAN if setting.size value is not number

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
