### PR TITLE
docs(themes): update `Preloading Fonts` section

### DIFF
--- a/.changeset/stupid-lizards-happen.md
+++ b/.changeset/stupid-lizards-happen.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+docs: Update `Preloading Fonts` section in the themes page to use a css solution to reduce LCP.

--- a/.changeset/stupid-lizards-happen.md
+++ b/.changeset/stupid-lizards-happen.md
@@ -1,5 +1,0 @@
----
-"skeleton.dev": patch
----
-
-docs: Update `Preloading Fonts` section in the themes page to use a css solution to reduce LCP.

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -173,7 +173,7 @@ plugins: [
 		<CodeBlock language="html" code={`<html class="dark">`} />
 		<p>
 			Note that Skeleton also provides a <a class="anchor" href="/docs/dark-mode#via-selector" target="_blank">Lightswitch</a> utility if you
-			wish toggle between light and dark modes.
+			wish to toggle between light and dark modes.
 		</p>
 	</section>
 

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -172,8 +172,8 @@ plugins: [
 		</p>
 		<CodeBlock language="html" code={`<html class="dark">`} />
 		<p>
-			Note that Skeleton also provides a <a class="anchor" href="/docs/dark-mode#via-selector" target="_blank">Lightswitch</a> utility if you wish
-			toggle between light and dark modes.
+			Note that Skeleton also provides a <a class="anchor" href="/docs/dark-mode#via-selector" target="_blank">Lightswitch</a> utility if you
+			wish toggle between light and dark modes.
 		</p>
 	</section>
 
@@ -310,21 +310,27 @@ body {
 					<!-- 5 -->
 					<h3 class="h3" data-toc-ignore>5. Preloading Fonts.</h3>
 					<p>
-						To avoid your page flickering during hydration, consider preloading fonts within the <code class="code">head</code>
-						tag in <code class="code">app.html</code>
+						To avoid your page flickering during hydration, consider using the <code class="code">font-display</code> descriptor for the
+						<code class="code">@font-face</code>
+						at-rule that determines how a font face is displayed based on whether and when it is downloaded and ready to use.
+						<br />
+						<br />Replace your <code class="code">@font-face</code> at-rule with the following:
+						<!-- consider preloading fonts within the <code class="code">head</code> -->
+						<!-- tag in <code class="code">app.html</code> -->
 					</p>
 					{#each activeFonts as f}
 						<CodeBlock
-							language="html"
+							language="css"
 							code={`
-<link
-	rel="preload"
-	href="%sveltekit.assets%/fonts/${f.file}"
-	as="font"
-	type="font/ttf"
-	crossorigin
-/>
-                        	`}
+@font-face {
+	/* Reference name */
+	font-family: '${f.name}';
+	/* For multiple files use commas, ex: url(), url(), ... */
+	src: url('/fonts/${f.file}');
+	/* Gives the font face an extremely small block period and an infinite swap period. */
+	font-display: swap;
+}
+					`}
 						/>
 					{/each}
 				{:else if tabsFontImport === 1}

--- a/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/themes/+page.svelte
@@ -308,15 +308,13 @@ body {
 						/>
 					{/each}
 					<!-- 5 -->
-					<h3 class="h3" data-toc-ignore>5. Preloading Fonts.</h3>
+					<h3 class="h3" data-toc-ignore>5. Handle Font Flickering.</h3>
 					<p>
 						To avoid your page flickering during hydration, consider using the <code class="code">font-display</code> descriptor for the
 						<code class="code">@font-face</code>
 						at-rule that determines how a font face is displayed based on whether and when it is downloaded and ready to use.
 						<br />
 						<br />Replace your <code class="code">@font-face</code> at-rule with the following:
-						<!-- consider preloading fonts within the <code class="code">head</code> -->
-						<!-- tag in <code class="code">app.html</code> -->
 					</p>
 					{#each activeFonts as f}
 						<CodeBlock


### PR DESCRIPTION
- use css property `font-face: swap` instead of preloading the font to not block rendering

## Linked Issue

Closes #2835

## Description

Following the previously recommended guide to Preload fonts makes the font loading event block the rendering of the website and heavily affect LCP. Removing it and using the CSS property `font-face` to handle events on font loading leads to no flickering, and doesn't affect LCP.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [X] This PR targets the `dev` branch (NEVER `master`)
- [X] Documentation reflects all relevant changes
- [X] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [X] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [X] Ensure Prettier linting is current - run `pnpm format`
- [X] All test cases are passing - run `pnpm test`
- [X] Includes a changeset (if relevant; see above)
