### PR TITLE
FIX: Typography list ordered example list-disc to list-decimal.

### DIFF
--- a/sites/next.skeleton.dev/src/examples/design/typography/ListOrdered.astro
+++ b/sites/next.skeleton.dev/src/examples/design/typography/ListOrdered.astro
@@ -1,4 +1,4 @@
-<ul class="list-inside list-disc space-y-2">
+<ul class="list-inside list-decimal space-y-2">
 	<li>Id maxime optio soluta placeat ea eaque similique consectetur dicta tempore.</li>
 	<li>Repellat veritatis et harum ad sint reprehenderit tenetur, possimus tempora.</li>
 	<li>Lorem ipsum dolor sit amet consectetur adipisicing elit harum ad sint.</li>


### PR DESCRIPTION
## Linked Issue

Not applicable 

## Description

Fix the typography docs in `next`. The list ordered was not displaying as an ordered list.

Before:
![image](https://github.com/user-attachments/assets/4c170d2f-c4b8-43f1-b7c6-de801506f7a6)

After:
![image](https://github.com/user-attachments/assets/9cbb7fd4-c863-4932-b37a-2905e937bf51)


## Changsets

Not applicable as it lives within the sites directory.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`) -- Incorrect it targets the `next` branch
- [x] Documentation reflects all relevant changes -- The documentation was updated
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check` -- This command does not exist in the `next` branch so I ran `check` instead.
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
