### PR TITLE
Analytics tag added to v3 docs and theme genererator

### DIFF
--- a/sites/next.skeleton.dev/src/layouts/LayoutRoot.astro
+++ b/sites/next.skeleton.dev/src/layouts/LayoutRoot.astro
@@ -22,11 +22,13 @@ const pageTitle = `${title ? title + ' - ' : ''}Skeleton`;
 		<title>{pageTitle}</title>
 		<!-- Analytics -->
 		<script defer data-domain="next.skeleton.dev" src="https://events.plygrnd.org/js/script.outbound-links.js"></script>
-		<!-- @ts-ignore -->
 		<script>
+			// @ts-expect-error for window.plausible
 			window.plausible =
+				// @ts-expect-error for window.plausible
 				window.plausible ||
 				function () {
+					// @ts-expect-error for window.plausible
 					(window.plausible.q = window.plausible.q || []).push(arguments);
 				};
 		</script>

--- a/sites/next.skeleton.dev/src/layouts/LayoutRoot.astro
+++ b/sites/next.skeleton.dev/src/layouts/LayoutRoot.astro
@@ -20,6 +20,16 @@ const pageTitle = `${title ? title + ' - ' : ''}Skeleton`;
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{pageTitle}</title>
+		<!-- Analytics -->
+		<script defer data-domain="next.skeleton.dev" src="https://events.plygrnd.org/js/script.outbound-links.js"></script>
+		<!-- @ts-ignore -->
+		<script>
+			window.plausible =
+				window.plausible ||
+				function () {
+					(window.plausible.q = window.plausible.q || []).push(arguments);
+				};
+		</script>
 	</head>
 	<body class:list={[classList]} data-theme="cerberus">
 		<slot />

--- a/sites/themes.skeleton.dev/src/app.html
+++ b/sites/themes.skeleton.dev/src/app.html
@@ -6,6 +6,15 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 		<title>Themes - Skeleton</title>
+		<!-- Analytics -->
+		<script defer data-domain="themes.skeleton.dev" src="https://events.plygrnd.org/js/script.outbound-links.js"></script>
+		<script>
+			window.plausible =
+				window.plausible ||
+				function () {
+					(window.plausible.q = window.plausible.q || []).push(arguments);
+				};
+		</script>
 	</head>
 	<body data-sveltekit-preload-data="hover" data-theme="cerberus" class="bg-gradient-skeleton">
 		<div style="display: contents">%sveltekit.body%</div>


### PR DESCRIPTION
## Linked Issue

#2907

## Description

Implements analytics tracking code to the following sites:

- v3 doc site (Astro)
- v3 theme generator (SvelteKit)

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset
