### PR TITLE
NEXT Theme Generator double quote import fix

### DIFF
--- a/sites/themes.skeleton.dev/src/lib/utils/importer/import-file.ts
+++ b/sites/themes.skeleton.dev/src/lib/utils/importer/import-file.ts
@@ -21,10 +21,15 @@ export async function importThemeFile(file: File) {
 
 	// Format each line
 	const lineMapped = linesFiltered.map((line) => {
+		// prettier-ignore
 		return (line = line
+			.trim() // trim whitespace
 			.replaceAll('\t', '') // tabbing
-			.replaceAll(`',`, '') // final comma
-			.replaceAll(`'`, '')); // open/close quotes
+			.replaceAll(`',`, '') // final comma (single quote)
+			.replaceAll(`",`, '') // final comma (double quote)
+			.replaceAll(`'`, '') // open/close (single quotes)
+			.replaceAll(`"`, '') // open/close (double quote)
+		);
 	});
 
 	// Create key/value object


### PR DESCRIPTION
## Linked Issue

Closes #2914

## Description

Resolves two issues for theme files generated using the generator itself:

1. Trims whitespace
2. Accounts for double quotes (not just single-quotes) for key/values

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](http://localhost:4321/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
