### PR TITLE
Fix typo Initilize -> Initialize

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/dark-mode/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/dark-mode/+page.svelte
@@ -133,7 +133,7 @@ onMount(() => {
 				</p>
 				<!-- prettier-ignore -->
 			</aside>
-			<h3 class="h3">Initilize</h3>
+			<h3 class="h3">Initialize</h3>
 			<p>
 				Import and add the following within your component. This will set the <code class="code">.dark</code> class on the root HTML element
 				in a highly performant manner. Please note that the CLI installer inserts <code class="code">class="dark"</code>


### PR DESCRIPTION
## Linked Issue

Closes #2917

## Description

Easy enough to spot. Fix typo **Initilize** -> **Initialize**

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
