### PR TITLE
Fix typo in docs (fundamentals page)

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/get-started/fundamentals.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/fundamentals.mdx
@@ -10,7 +10,7 @@ import NavGrid from '@components/docs/NavGrid.astro';
 
 {/* prettier-ignore */}
 <p class="type-scale-5"> Skeleton is comprised of three pillars - the design system, Tailwind utilities, and framework-specific components.
-	Together these form a comprehensive solution for designing and implementing implementing complex web interfaces at scale.</p>
+	Together these form a comprehensive solution for designing and implementing complex web interfaces at scale.</p>
 
 ---
 


### PR DESCRIPTION
## Linked Issue

No issue created as very minor thing.

## Description

Fixes "implementing" being there twice in the fundamentals section of the docs

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
