### PR TITLE
Fixed conflicting build artifacts

### DIFF
--- a/.changeset/little-glasses-drive.md
+++ b/.changeset/little-glasses-drive.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton': patch
+---
+
+Fix conflicting build artifacts

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -55,19 +55,34 @@
 	"types": "./dist/core/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/core/index.d.ts",
-			"require": "./dist/core/index.cjs",
-			"default": "./dist/core/index.js"
+			"import": {
+				"types": "./dist/core/index.d.ts",
+				"default": "./dist/core/index.js"
+			},
+			"require": {
+				"types": "./dist/core/index.d.cts",
+				"default": "./dist/core/index.cjs"
+			}
 		},
 		"./plugin": {
-			"types": "./dist/plugin/index.d.ts",
-			"require": "./dist/plugin/index.cjs",
-			"default": "./dist/plugin/index.js"
+			"import": {
+				"types": "./dist/plugin/index.d.ts",
+				"default": "./dist/plugin/index.js"
+			},
+			"require": {
+				"types": "./dist/plugin/index.d.cts",
+				"default": "./dist/plugin/index.cjs"
+			}
 		},
 		"./themes": {
-			"types": "./dist/themes/index.d.ts",
-			"require": "./dist/themes/index.cjs",
-			"default": "./dist/themes/index.js"
+			"import": {
+				"types": "./dist/themes/index.d.ts",
+				"default": "./dist/themes/index.js"
+			},
+			"require": {
+				"types": "./dist/themes/index.d.cts",
+				"default": "./dist/themes/index.cjs"
+			}
 		}
 	},
 	"files": [

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -56,14 +56,17 @@
 	"exports": {
 		".": {
 			"types": "./dist/core/index.d.ts",
+			"require": "./dist/core/index.cjs",
 			"default": "./dist/core/index.js"
 		},
 		"./plugin": {
 			"types": "./dist/plugin/index.d.ts",
-			"require": "./dist/plugin/index.cjs"
+			"require": "./dist/plugin/index.cjs",
+			"default": "./dist/plugin/index.js"
 		},
 		"./themes": {
 			"types": "./dist/themes/index.d.ts",
+			"require": "./dist/themes/index.cjs",
 			"default": "./dist/themes/index.js"
 		}
 	},

--- a/packages/skeleton/tsup.config.ts
+++ b/packages/skeleton/tsup.config.ts
@@ -16,7 +16,7 @@ export default defineConfig([
 		...base,
 		entry: ['src/plugin/index.ts'],
 		outDir: 'dist/plugin',
-		format: ['cjs'],
+		format: ['esm', 'cjs'],
 		tsconfig: 'src/plugin/tsconfig.json'
 	},
 	{
@@ -24,7 +24,7 @@ export default defineConfig([
 		...base,
 		entry: ['src/plugin/themes/index.ts'],
 		outDir: 'dist/themes',
-		format: ['esm'],
+		format: ['esm', 'cjs'],
 		tsconfig: 'src/plugin/tsconfig.json'
 	},
 	{
@@ -32,7 +32,7 @@ export default defineConfig([
 		...base,
 		entry: ['src/core/index.ts'],
 		outDir: 'dist/core',
-		format: ['esm'],
+		format: ['esm', 'cjs'],
 		tsconfig: 'src/core/tsconfig.json'
 	}
 ]);


### PR DESCRIPTION
Unifies build output by outputting both cjs and esm as tailwind now supports both too.
Also points to correct declaration file in `package.json`.