### PR TITLE
Chore: Updates invalid links in v2 documentations.

### DIFF
--- a/.changeset/shaggy-pants-repair.md
+++ b/.changeset/shaggy-pants-repair.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+Chore: Updates invalid svelte.dev link in documentations

--- a/sites/skeleton.dev/src/routes/(inner)/components/conic-gradients/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/conic-gradients/+page.svelte
@@ -131,7 +131,7 @@ const conicStops: ConicStop[] = [
 				</svelte:fragment>
 			</TabGroup>
 			<!-- prettier-ignore -->
-			<p>This data can be reactive, but be sure to adhere to standard Svelte requirements when <a class="anchor" href="https://svelte.dev/tutorial/updating-arrays-and-objects" target="_blank" rel="noreferrer">updating arrays</a>.</p>
+			<p>This data can be reactive, but be sure to adhere to standard Svelte requirements when <a class="anchor" href="https://v4.svelte.dev/tutorial/updating-arrays-and-objects" target="_blank" rel="noreferrer">updating arrays</a>.</p>
 		</div>
 		<!-- Legend -->
 		<div class="space-y-4">

--- a/sites/skeleton.dev/src/routes/(inner)/docs/contributing/style-guide/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/contributing/style-guide/+page.svelte
@@ -60,7 +60,7 @@
 		<p>
 			Ensure relevant events bubble via <a
 				class="anchor"
-				href="https://svelte.dev/tutorial/dom-event-forwarding"
+				href="https://v4.svelte.dev/tutorial/dom-event-forwarding"
 				target="_blank"
 				rel="noreferrer">event forwarding</a
 			>.

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/+page.svelte
@@ -12,7 +12,7 @@
 		<h1 class="h1">Get Started</h1>
 		<!-- prettier-ignore -->
 		<p>
-			We recommend at least moderate experience with <a class="anchor" href="https://svelte.dev/tutorial/basics" target="_blank" rel="noreferrer">Svelte</a>, <a class="anchor" href="https://learn.svelte.dev/tutorial/welcome-to-svelte" target="_blank" rel="noreferrer">SvelteKit</a>, and <a class="anchor" href="https://tailwindcss.com/docs/utility-first" target="_blank" rel="noreferrer">Tailwind CSS</a> before you proceed.
+			We recommend at least moderate experience with <a class="anchor" href="https://svelte.dev/tutorial/svelte/welcome-to-svelte" target="_blank" rel="noreferrer">Svelte</a>, <a class="anchor" href="https://learn.svelte.dev/tutorial/welcome-to-svelte" target="_blank" rel="noreferrer">SvelteKit</a>, and <a class="anchor" href="https://tailwindcss.com/docs/utility-first" target="_blank" rel="noreferrer">Tailwind CSS</a> before you proceed.
 		</p>
 		<aside class="alert variant-ghost">
 			<i class="fa-solid fa-triangle-exclamation"></i>


### PR DESCRIPTION
## Linked Issue

Closes #2935 

## Description

Updates the invalid svelte.dev links in the documentation

## Changsets

Chore: Updates invalid links in v2 documentations.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
