### PR TITLE
Only render `<button>` when trigger is present

### DIFF
--- a/.changeset/fluffy-rockets-call.md
+++ b/.changeset/fluffy-rockets-call.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+Only render `<button>` when `trigger` snippet is defined.

--- a/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
@@ -60,10 +60,12 @@
 </script>
 
 <span>
-	<!-- Trigger -->
-	<button {...api.getTriggerProps()} class="{triggerBase} {triggerBackground} {triggerClasses}">
-		{@render trigger?.()}
-	</button>
+	{#if trigger}
+		<!-- Trigger -->
+		<button {...api.getTriggerProps()} class="{triggerBase} {triggerBackground} {triggerClasses}">
+			{@render trigger()}
+		</button>
+	{/if}
 	{#if api.open}
 		<!-- Backdrop -->
 		<div

--- a/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
@@ -60,8 +60,8 @@
 </script>
 
 <span>
+	<!-- Trigger -->
 	{#if trigger}
-		<!-- Trigger -->
 		<button {...api.getTriggerProps()} class="{triggerBase} {triggerBackground} {triggerClasses}">
 			{@render trigger()}
 		</button>


### PR DESCRIPTION
## Linked Issue

Closes #2944

## Description

Adds an `if` statement around the button to only render it if the snippet is actually passed, this was previously posing an a11y hazard.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
