### PR TITLE
Fix tailwind config content path to only include `dist`.

### DIFF
--- a/sites/next.skeleton.dev/tailwind.config.js
+++ b/sites/next.skeleton.dev/tailwind.config.js
@@ -14,8 +14,8 @@ export default {
 	darkMode: 'class',
 	content: [
 		'./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-		join(__dirname, 'node_modules/@skeletonlabs/skeleton-react/**/*.{html,js,ts,jsx,tsx}'),
-		join(__dirname, 'node_modules/@skeletonlabs/skeleton-svelte/**/*.{html,js,ts,svelte}')
+		join(__dirname, 'node_modules/@skeletonlabs/skeleton-react/dist/**/*.{html,js,ts,jsx,tsx}'),
+		join(__dirname, 'node_modules/@skeletonlabs/skeleton-svelte/dist/**/*.{html,js,ts,svelte}')
 	],
 	theme: {
 		extend: {}


### PR DESCRIPTION
## Linked Issue

Closes #2945 

## Description

Adjusts glob matcher to only grab content from `dist`.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
