### PR TITLE
feat: `contentPath` utility for tailwind's `content` globs

### DIFF
--- a/.changeset/heavy-bugs-obey.md
+++ b/.changeset/heavy-bugs-obey.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton': patch
+---
+
+feature: Added a `contentPath` utility function for tailwind content paths

--- a/packages/skeleton/src/plugin/index.ts
+++ b/packages/skeleton/src/plugin/index.ts
@@ -51,8 +51,6 @@ const skeleton = plugin.withOptions<ConfigOptions>(
 
 /**
  * Assembles content glob patterns for skeleton component packages
- * @param fileURL
- * @param framework
  * @example
  * const config = {
  * 	// ...

--- a/packages/skeleton/src/plugin/index.ts
+++ b/packages/skeleton/src/plugin/index.ts
@@ -1,3 +1,6 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import plugin from 'tailwindcss/plugin.js';
 import postcssJs from 'postcss-js';
 import { coreConfig, coreUtilities, getSkeletonClasses } from './core.js';
@@ -45,6 +48,37 @@ const skeleton = plugin.withOptions<ConfigOptions>(
 		return { ...coreConfig };
 	}
 );
+
+/**
+ * Assembles content glob patterns for skeleton component packages
+ * @param fileURL
+ * @param framework
+ * @example
+ * const config = {
+ * 	// ...
+ * 	content: [
+ * 		// ...
+ * 		contentPath(import.meta.url, "svelte")
+ * 	]
+ * }
+ */
+export function contentPath(fileURL: URL, framework: 'svelte' | 'react') {
+	const configPath = fileURLToPath(fileURL);
+	// resolve framework package path
+	const require = createRequire(fileURL);
+	const packageEntryPath = require.resolve(`@skeletonlabs/skeleton-${framework}`, { paths: [configPath] });
+	const packagePath = path.resolve(packageEntryPath, '..');
+
+	// assemble glob (globs use posix file seporators)
+	const relative = path.relative(configPath, packagePath).split(path.sep).join('/');
+	const glob = relative + fileExtensions[framework];
+	return glob;
+}
+
+const fileExtensions = {
+	react: '/**/*.{html,js,ts,jsx,tsx}',
+	svelte: '/**/*.{html,js,ts,svelte}'
+};
 
 export { skeleton };
 export type { ConfigOptions, Theme };

--- a/packages/skeleton/src/plugin/index.ts
+++ b/packages/skeleton/src/plugin/index.ts
@@ -67,9 +67,8 @@ export function contentPath(fileURL: URL, framework: 'svelte' | 'react') {
 	const packageEntryPath = require.resolve(`@skeletonlabs/skeleton-${framework}`, { paths: [configPath] });
 	const packagePath = path.resolve(packageEntryPath, '..');
 
-	// assemble glob (globs use posix file seporators)
-	const relative = path.relative(configPath, packagePath).split(path.sep).join('/');
-	const glob = relative + fileExtensions[framework];
+	// assemble glob
+	const glob = path.join(packagePath, fileExtensions[framework]);
 	return glob;
 }
 

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
@@ -35,14 +35,12 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
     <ProcessStep step="4">
         ## Configure Tailwind
         Open `tailwind.config` in the root of your project and make these changes:
-        ```js title="tailwind.config" {3-5, 13, 19-22}
+        ```js title="tailwind.config" {3-4, 11, 17-20}
         import type { Config } from 'tailwindcss';
 
-        import { join } from "path";
         import { skeleton, contentPath } from "@skeletonlabs/skeleton/plugin";
         import * as themes from "@skeletonlabs/skeleton/themes";
 
-        /** @type {import('tailwindcss').Config} \*/
         export default {
             content: [
                 "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
@@ -59,7 +57,7 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
                     themes: [ themes.cerberus, themes.rose ]
                 })
             ]
-        }
+        } satisfies Config
         ```
     </ProcessStep>
     <ProcessStep step="5">

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
@@ -39,7 +39,7 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         import type { Config } from 'tailwindcss';
 
         import { join } from "path";
-        import { skeleton } from "@skeletonlabs/skeleton/plugin";
+        import { skeleton, contentPath } from "@skeletonlabs/skeleton/plugin";
         import * as themes from "@skeletonlabs/skeleton/themes";
 
         /** @type {import('tailwindcss').Config} \*/
@@ -48,7 +48,7 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
                 "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
                 "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
                 "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-                join(require.resolve('@skeletonlabs/skeleton-react'), '../**/*.{html,js,jsx,tsx,ts}')
+                contentPath(import.meta.url, 'react')
             ],
             theme: {
                 extend: {},

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
@@ -41,14 +41,12 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         npm i --save-dev @types/node
         ```
         Open `tailwind.config` in the root of your project and make these changes:
-        ```js title="tailwind.config" {3-5, 11, 17-20}
+        ```ts title="tailwind.config" {3-4, 9, 15-18}
         import type { Config } from 'tailwindcss';
 
-        import { join } from 'path';
         import { skeleton, contentPath } from '@skeletonlabs/skeleton/plugin';
         import * as themes from '@skeletonlabs/skeleton/themes';
 
-        /** @type {import('tailwindcss').Config} \*/
         export default {
             content: [
                 './src/**/*.{html,js,svelte,ts}',
@@ -63,7 +61,7 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
                     themes: [ themes.cerberus, themes.rose ]
                 })
             ]
-        }
+        } satisfies Config
         ```
     </ProcessStep>
     <ProcessStep step="4">

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
@@ -45,14 +45,14 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         import type { Config } from 'tailwindcss';
 
         import { join } from 'path';
-        import { skeleton } from '@skeletonlabs/skeleton/plugin';
+        import { skeleton, contentPath } from '@skeletonlabs/skeleton/plugin';
         import * as themes from '@skeletonlabs/skeleton/themes';
 
         /** @type {import('tailwindcss').Config} \*/
         export default {
             content: [
                 './src/**/*.{html,js,svelte,ts}',
-                join(require.resolve('@skeletonlabs/skeleton-svelte'), '../**/*.{html,js,svelte,ts}')
+                contentPath(import.meta.url, 'svelte')
             ],
             theme: {
                 extend: {},

--- a/sites/next.skeleton.dev/tailwind.config.js
+++ b/sites/next.skeleton.dev/tailwind.config.js
@@ -1,21 +1,17 @@
 // import { skeleton } from '../../packages/skeleton/dist/plugin/index.cjs'
 // NOTE: Do not delete the above comment. It's required for local HMR on plugin changes.
 
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { skeleton } from '@skeletonlabs/skeleton/plugin';
+import { skeleton, contentPath } from '../../packages/skeleton/dist/plugin/index.js';
 import * as themes from '@skeletonlabs/skeleton/themes';
 import forms from '@tailwindcss/forms';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('tailwindcss').Config} */
 export default {
 	darkMode: 'class',
 	content: [
 		'./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-		join(__dirname, 'node_modules/@skeletonlabs/skeleton-react/dist/**/*.{html,js,ts,jsx,tsx}'),
-		join(__dirname, 'node_modules/@skeletonlabs/skeleton-svelte/dist/**/*.{html,js,ts,svelte}')
+		contentPath(import.meta.url, 'svelte'),
+		contentPath(import.meta.url, 'react')
 	],
 	theme: {
 		extend: {}

--- a/sites/themes.skeleton.dev/tailwind.config.js
+++ b/sites/themes.skeleton.dev/tailwind.config.js
@@ -3,14 +3,13 @@
 
 import forms from '@tailwindcss/forms';
 
-import { join } from 'path';
-import { skeleton } from '@skeletonlabs/skeleton/plugin';
+import { skeleton, contentPath } from '../../packages/skeleton/dist/plugin/index.js';
 import * as themes from '@skeletonlabs/skeleton/themes';
 
 /** @type {import('tailwindcss').Config}*/
 export default {
 	darkMode: 'class',
-	content: ['./src/**/*.{html,js,svelte,ts}', join(require.resolve('@skeletonlabs/skeleton-svelte'), '../**/*.{html,js,svelte,ts}')],
+	content: ['./src/**/*.{html,js,svelte,ts}', contentPath(import.meta.url, 'svelte')],
 	theme: {
 		extend: {}
 	},


### PR DESCRIPTION
## Description

Adds a utility function for assembling content globs for skeleton component packages.
