### PR TITLE
chore: add publish script

### DIFF
--- a/.github/workflows/release-next.yaml
+++ b/.github/workflows/release-next.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           commit: 'chore(next-release): version package'
           title: 'chore(next-release): version package'
-          publish: pnpm changeset publish
+          publish: pnpm ci:publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	"license": "MIT",
 	"type": "module",
 	"scripts": {
+		"ci:publish": "changeset publish",
 		"dev": "pnpm --filter @skeletonlabs/docs-next dev",
 		"build": "pnpm --recursive build",
 		"package": "pnpm --recursive package",


### PR DESCRIPTION
Re-implements a missing `ci:` command for triggering Changesets for the release process.