### PR TITLE
fix: adjust arg type for `contentPath`

### DIFF
--- a/.changeset/swift-students-confess.md
+++ b/.changeset/swift-students-confess.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton': patch
+---
+
+fix: add `string` type to `contentPath` args

--- a/packages/skeleton/src/plugin/index.ts
+++ b/packages/skeleton/src/plugin/index.ts
@@ -60,7 +60,7 @@ const skeleton = plugin.withOptions<ConfigOptions>(
  * 	]
  * }
  */
-export function contentPath(fileURL: URL, framework: 'svelte' | 'react') {
+export function contentPath(fileURL: string | URL, framework: 'svelte' | 'react') {
 	const configPath = fileURLToPath(fileURL);
 	// resolve framework package path
 	const require = createRequire(fileURL);

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
@@ -36,10 +36,6 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
     </ProcessStep>
     <ProcessStep step="3">
         ## Configure Tailwind
-        You may optionally install the `@types/node` package to prevent LSP errors in your Tailwind config.
-        ```console
-        npm i --save-dev @types/node
-        ```
         Open `tailwind.config` in the root of your project and make these changes:
         ```ts title="tailwind.config" {3-4, 9, 15-18}
         import type { Config } from 'tailwindcss';


### PR DESCRIPTION
Includes two changes:

1. Addresses the type issue with `contentPath` > `fileURL`
2. Updates the Svelte onboarding docs to remove the node types requirement