### PR TITLE
Type as props for Nav Tile component

### DIFF
--- a/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
+++ b/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
@@ -157,6 +157,7 @@ export const NavTile: React.FC<NavTileProps> = ({
 	labelExpanded,
 	title,
 	selected = false,
+	type,
 	// Root
 	base = 'flex items-center',
 	width = 'w-full',
@@ -188,7 +189,6 @@ export const NavTile: React.FC<NavTileProps> = ({
 
 	// Local
 	const TileElement = href ? 'a' : 'button';
-	const type = href ? undefined : 'button';
 	const role = href ? undefined : 'button';
 
 	// Reactive
@@ -209,7 +209,7 @@ export const NavTile: React.FC<NavTileProps> = ({
 			className={`${base} ${width} ${rounded} ${rxBackground} ${rxMode}`}
 			href={href}
 			target={target}
-			type={type}
+			type={TileElement === 'button' ? type : undefined}
 			title={title}
 			role={role}
 			onClick={onClickHandler}

--- a/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
+++ b/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
@@ -157,7 +157,7 @@ export const NavTile: React.FC<NavTileProps> = ({
 	labelExpanded,
 	title,
 	selected = false,
-	type,
+	type = 'button',
 	// Root
 	base = 'flex items-center',
 	width = 'w-full',

--- a/packages/skeleton-react/src/lib/components/Navigation/types.ts
+++ b/packages/skeleton-react/src/lib/components/Navigation/types.ts
@@ -110,6 +110,8 @@ export interface NavTileProps {
 	title?: string;
 	/** Enable the active selected state. */
 	selected?: boolean;
+	/** Set button type. */
+	type?: 'button' | 'submit' | 'reset';
 
 	// Root ---
 	/** Set base styles. */

--- a/packages/skeleton-svelte/src/lib/components/Navigation/NavTile.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Navigation/NavTile.svelte
@@ -10,6 +10,7 @@
 		labelExpanded,
 		title,
 		selected = false,
+		type,
 		// Root
 		base = 'flex items-center',
 		width = 'w-full',
@@ -42,7 +43,6 @@
 
 	// Reactive
 	const element = $derived(href ? 'a' : 'button');
-	const type = $derived(href ? undefined : 'button');
 	const role = $derived(href ? undefined : 'button');
 	const rxSize = $derived(ctx.parent === 'bar' ? `h-full` : `${aspect}`);
 	const classesCollapsed = $derived(`${rxSize} ${padding} ${gap} ${classes}`);
@@ -64,7 +64,7 @@
 	class="{base} {width} {rounded} {rxBackground} {rxMode}"
 	{href}
 	{target}
-	{type}
+	type={element === 'button' ? type : undefined}
 	{title}
 	{role}
 	onclick={onClickHandler}

--- a/packages/skeleton-svelte/src/lib/components/Navigation/NavTile.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Navigation/NavTile.svelte
@@ -10,7 +10,7 @@
 		labelExpanded,
 		title,
 		selected = false,
-		type,
+		type = 'button',
 		// Root
 		base = 'flex items-center',
 		width = 'w-full',

--- a/packages/skeleton-svelte/src/lib/components/Navigation/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Navigation/types.ts
@@ -112,6 +112,8 @@ export interface NavTileProps {
 	title?: string;
 	/** Enable the active selected state. */
 	selected?: boolean;
+	/** Set button type. */
+	type?: 'button' | 'submit' | 'reset';
 
 	// Root ---
 	/** Set base styles. */


### PR DESCRIPTION
## Linked Issue

Closes #2934 

## Description

Make type attribute a props of NavTile component

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
