### PR TITLE
Solved the feature request to hide first/last page button if page length is less then or 2 

### DIFF
--- a/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
+++ b/packages/skeleton/src/lib/components/Paginator/Paginator.svelte
@@ -193,7 +193,7 @@
 			<button
 				type="button"
 				aria-label={labelFirst}
-				class={buttonClasses}
+				class="{buttonClasses} {lastPage <= 1 ? '!hidden' : ''}"
 				on:click={() => {
 					gotoPage(0);
 				}}
@@ -251,7 +251,7 @@
 			<button
 				type="button"
 				aria-label={labelLast}
-				class={buttonClasses}
+				class="{buttonClasses} {lastPage <= 1 ? '!hidden' : ''}"
 				on:click={() => {
 					gotoPage(lastPage);
 				}}


### PR DESCRIPTION
Added the feature to hide first/last page button if page length is less then or 2

Closes #2993 

## Implemented a feature to hide the first and last page buttons when the total page count is 2 or less. It was a great experience diving into the fluent codebase and getting hands-on with Svelte and a monorepo setup for the first time. Looking forward to making more contributions to Skeleton!

## minor:changeset

## TestList
If there is only 2 or less page like in example, First/Last button is hidden
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/8dc19f55-1517-456b-8af7-ffd0775866fa">
If there is above then 2 page like in example, First/Last button is active
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/21e86bdb-4f09-4e7b-ad5a-a561cbd20b7d">

