### PR TITLE
Fix/combobox-options-button-type

### DIFF
--- a/.changeset/honest-bears-learn.md
+++ b/.changeset/honest-bears-learn.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+Set button type to **button** for Svelte's combobox options

--- a/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
@@ -93,7 +93,7 @@
 			<!-- Input -->
 			<input {...api.getInputProps()} class={inputGroupInput} />
 			<!-- Arrow -->
-			<button {...api.getTriggerProps()} class={inputGroupButton} type="button">
+			<button {...api.getTriggerProps()} class={inputGroupButton}>
 				{#if arrow}
 					{@render arrow()}
 				{:else}
@@ -126,7 +126,8 @@
 						{@const isChecked = api.getItemProps({ item })['data-state'] === 'checked'}
 						{@const displayClass = isChecked ? optionActive : optionHover}
 						<!-- Option -->
-						<button {...api.getItemProps({ item })} class="{optionBase} {displayClass} {optionClasses}">
+						<!-- ZagJs should have set button type to "button" here. See https://github.com/skeletonlabs/skeleton/pull/2998#discussion_r1855511385 -->
+						<button {...api.getItemProps({ item })} class="{optionBase} {displayClass} {optionClasses}" type="button">
 							{item.label}
 						</button>
 					{/each}

--- a/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
@@ -93,7 +93,7 @@
 			<!-- Input -->
 			<input {...api.getInputProps()} class={inputGroupInput} />
 			<!-- Arrow -->
-			<button {...api.getTriggerProps()} class={inputGroupButton}>
+			<button {...api.getTriggerProps()} class={inputGroupButton} type="button">
 				{#if arrow}
 					{@render arrow()}
 				{:else}


### PR DESCRIPTION
## Linked Issue

Closes #2962

## Description

Set Svelte's Combobox options to button type. [The default type was submit](https://www.w3schools.com/jsref/prop_pushbutton_type.asp) and it caused undesired behavior with forms (see linked issue) 

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
