### PR TITLE
Feat/show-first-last-buttons-props-pagination

### DIFF
--- a/.changeset/cuddly-dingos-sell.md
+++ b/.changeset/cuddly-dingos-sell.md
@@ -3,5 +3,4 @@
 '@skeletonlabs/skeleton-react': patch
 ---
 
-Show first and last button to be an optional props.
-Adjust test-id for buttons.
+feature: Show first and last button to be an optional props.

--- a/.changeset/cuddly-dingos-sell.md
+++ b/.changeset/cuddly-dingos-sell.md
@@ -1,0 +1,7 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+'@skeletonlabs/skeleton-react': patch
+---
+
+Show first and last button to be an optional props.
+Adjust test-id for buttons.

--- a/packages/skeleton-react/src/lib/components/Pagination/Pagination.test.tsx
+++ b/packages/skeleton-react/src/lib/components/Pagination/Pagination.test.tsx
@@ -54,4 +54,12 @@ describe('<Pagination>', () => {
 		const component = getByTestId('pagination');
 		expect(component).toHaveClass(testClass);
 	});
+
+	it('should render first and last buttons if required', () => {
+		const { getByTestId } = render(<Pagination {...commonProps} showFirstLastButtons />);
+		const firstButton = getByTestId('pagination-button-first');
+		const lastButton = getByTestId('pagination-button-last');
+		expect(firstButton).toBeInTheDocument();
+		expect(lastButton).toBeInTheDocument();
+	});
 });

--- a/packages/skeleton-react/src/lib/components/Pagination/Pagination.tsx
+++ b/packages/skeleton-react/src/lib/components/Pagination/Pagination.tsx
@@ -10,6 +10,7 @@ export const Pagination: FC<PaginationProps> = ({
 	data,
 	alternative = false,
 	textSeparator = 'of',
+	showFirstLastButtons = false,
 	// Titles
 	titleFirst,
 	titlePrevious,
@@ -63,14 +64,14 @@ export const Pagination: FC<PaginationProps> = ({
 					data-testid="pagination"
 				>
 					{/* Button: First Page */}
-					{alternative && (
+					{showFirstLastButtons && (
 						<button
 							type="button"
 							onClick={api.goToFirstPage}
 							className={`${buttonBase} ${buttonInactive} ${buttonHover} ${buttonClasses}`}
 							title={titleFirst}
 							disabled={api.page === 1}
-							data-testid="pagination-button-previous"
+							data-testid="pagination-button-first"
 						>
 							{labelFirst}
 						</button>
@@ -139,14 +140,14 @@ export const Pagination: FC<PaginationProps> = ({
 						{labelNext}
 					</button>
 					{/* Button: Last Page */}
-					{alternative && (
+					{showFirstLastButtons && (
 						<button
 							type="button"
 							onClick={api.goToLastPage}
 							className={`${buttonBase} ${buttonInactive} ${buttonHover} ${buttonClasses}`}
 							title={titleLast}
 							disabled={!api.nextPage}
-							data-testid="pagination-button-previous"
+							data-testid="pagination-button-last"
 						>
 							{labelLast}
 						</button>

--- a/packages/skeleton-react/src/lib/components/Pagination/schema.json
+++ b/packages/skeleton-react/src/lib/components/Pagination/schema.json
@@ -136,6 +136,11 @@
 					"description": "Sets border radius classes for the list.",
 					"type": "string"
 				},
+				"showFirstLastButtons": {
+					"default": false,
+					"description": "Show first and last page button.",
+					"type": "boolean"
+				},
 				"siblingCount": {
 					"default": 1,
 					"description": "Number of pages to show beside active page",

--- a/packages/skeleton-react/src/lib/components/Pagination/types.ts
+++ b/packages/skeleton-react/src/lib/components/Pagination/types.ts
@@ -4,10 +4,12 @@ import * as pagination from '@zag-js/pagination';
 export interface PaginationProps extends Omit<pagination.Context, 'id'> {
 	// Provide source data as an array.
 	data: unknown[];
-	// Enables altnerative display with stats and first/last buttons.
+	// Enables alternative display with stats and first/last buttons.
 	alternative?: boolean;
 	/** Set the separator text or character, such as "of" in "X of Y". */
 	textSeparator?: string;
+	/** Show first and last page button. */
+	showFirstLastButtons?: boolean;
 
 	/** Set an optional title for the first button. */
 	titleFirst?: string;

--- a/packages/skeleton-svelte/src/lib/components/Pagination/Pagination.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Pagination/Pagination.svelte
@@ -11,6 +11,7 @@
 		data = $bindable([]),
 		alternative = false,
 		textSeparator = 'of',
+		showFirstLastButtons = false,
 		// Root
 		base = 'inline-flex items-stretch overflow-hidden',
 		background = 'preset-outlined-surface-200-800',
@@ -79,14 +80,14 @@
 {#if api.totalPages > 1}
 	<div {...api.getRootProps()} class="{base} {background} {border} {gap} {padding} {rounded} {classes}" data-testid="pagination">
 		<!-- Button: First Page -->
-		{#if alternative}
+		{#if showFirstLastButtons}
 			<button
 				type="button"
 				onclick={api.goToFirstPage}
 				class="{buttonBase} {buttonInactive} {buttonHover} {buttonClasses}"
 				title={titleFirst}
 				disabled={api.page === 1}
-				data-testid="pagination-button-previous"
+				data-testid="pagination-button-first"
 			>
 				{#if labelFirst}{@render labelFirst()}{:else}&laquo;{/if}
 			</button>
@@ -153,14 +154,14 @@
 			{#if labelNext}{@render labelNext()}{:else}&rarr;{/if}
 		</button>
 		<!-- Button: Last Page -->
-		{#if alternative}
+		{#if showFirstLastButtons}
 			<button
 				type="button"
 				onclick={api.goToLastPage}
 				class="{buttonBase} {buttonInactive} {buttonHover} {buttonClasses}"
 				title={titleLast}
 				disabled={!api.nextPage}
-				data-testid="pagination-button-previous"
+				data-testid="pagination-button-last"
 			>
 				{#if labelLast}{@render labelLast()}{:else}&raquo;{/if}
 			</button>

--- a/packages/skeleton-svelte/src/lib/components/Pagination/Pagination.test.ts
+++ b/packages/skeleton-svelte/src/lib/components/Pagination/Pagination.test.ts
@@ -54,4 +54,12 @@ describe('Pagination', () => {
 			expect(component).toHaveClass(value);
 		});
 	}
+
+	it('should render first and last buttons if required', () => {
+		render(Pagination, { ...commonProps, showFirstLastButtons: true });
+		const firstButton = screen.getByTestId('pagination-button-first');
+		const lastButton = screen.getByTestId('pagination-button-last');
+		expect(firstButton).toBeInTheDocument();
+		expect(lastButton).toBeInTheDocument();
+	});
 });

--- a/packages/skeleton-svelte/src/lib/components/Pagination/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Pagination/types.ts
@@ -9,10 +9,12 @@ export interface PaginationProps extends Omit<pagination.Context, 'id' | 'page' 
 
 	// Provide source data as an array.
 	data: unknown[];
-	// Enables altnerative display with stats and first/last buttons.
+	// Enables alternative display with stats and first/last buttons.
 	alternative?: boolean;
 	/** Set the separator text or character, such as "of" in "X of Y". */
 	textSeparator?: string;
+	/** Show first and last page button. */
+	showFirstLastButtons?: boolean;
 
 	// Root ---
 	/** Sets base classes for the list. */


### PR DESCRIPTION
Implment showFirstLastButtons as an option for Pagination componenet. Wrote testcases and fix buttons data-test-id

## Linked Issue

Closes #2993

## Description

Made showFirstLastButtons a new prop, new testcases for them and adjust data-test-id (assuming they were wrong).

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
