### PR TITLE
Bugfix/combobox multiple display

### DIFF
--- a/.changeset/kind-bananas-perform.md
+++ b/.changeset/kind-bananas-perform.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+bugfix: display Svelte's Combobox value when `multiple` is enabled

--- a/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
@@ -38,6 +38,8 @@
 		optionClasses = '',
 		// Snippets
 		arrow,
+		// Customization
+		transformFunction = (values) => (values ? values.join(', ') : ''),
 		// Zag ---
 		...zagProps
 	}: ComboboxProps = $props();
@@ -82,6 +84,12 @@
 		}
 	);
 	const api = $derived(combobox.connect(snapshot, send, normalizeProps));
+
+	const selectedLabels = $derived.by(() => {
+		if (snapshot.context.multiple) {
+			return transformFunction(snapshot.context.value.map((item) => data.find((option) => option.value === item)?.label));
+		}
+	});
 </script>
 
 <span {...api.getRootProps()} class="{base} {width} {classes}" data-testid="combobox">
@@ -91,7 +99,13 @@
 		<!-- Input Group -->
 		<div {...api.getControlProps()} class="{inputGroupBase} {inputGroupClasses}">
 			<!-- Input -->
-			<input {...api.getInputProps()} class={inputGroupInput} />
+			{#if snapshot.context.multiple}
+				<!-- https://zagjs.com/components/svelte/combobox#selecting-multiple-values -->
+				<!-- Zag requires us to handle this on our own -->
+				<input {...api.getInputProps()} class={inputGroupInput} value={selectedLabels} />
+			{:else}
+				<input {...api.getInputProps()} class={inputGroupInput} />
+			{/if}
 			<!-- Arrow -->
 			<button {...api.getTriggerProps()} class={inputGroupButton}>
 				{#if arrow}

--- a/packages/skeleton-svelte/src/lib/components/Combobox/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/types.ts
@@ -5,7 +5,7 @@ export interface ComboboxProps extends Omit<combobox.Context, 'id' | 'collection
 	/** Provide the list of label and value data */
 	data?: { label: string; value: string }[];
 	/** Bind the selected value. */
-	value?: string[] | undefined;
+	value?: string[];
 	/** Set the label to display. */
 	label?: string;
 
@@ -66,4 +66,8 @@ export interface ComboboxProps extends Omit<combobox.Context, 'id' | 'collection
 	// Snippets ---
 	/** Provide a custom arrow icon. */
 	arrow?: Snippet;
+
+	// Customization ---
+	/** Transform function. Used to transform values when multiple is enabled */
+	transformFunction?: (value: (string | undefined)[]) => string;
 }


### PR DESCRIPTION
## Linked Issue

Closes #2963 

## Description

In Zag's documentation:

![image](https://github.com/user-attachments/assets/bee6a486-0392-46bf-b4db-dc67a2884059)

This leave values to be handled on our own. `selectedLabels` does that. I provided a transform function as a prop in case user wanted to customize it.

I think this is an OK solution since the component is temporary. There are limitations when multiple is set now, such as manually wiping the input value (not using the dropdown) doesn't reset the value (if it's supposed to do so even).

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
