### PR TITLE
Remove npm install as part of sveltekit installation guide

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
@@ -24,7 +24,6 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         ```console
         npx sv create my-skeleton-app
 		cd my-skeleton-app
-		npm install
         ```
     </ProcessStep>
     <ProcessStep step="2">


### PR DESCRIPTION
## Linked Issue

None

## Description

npm install is not more needed as part of the newest `npx sv` - it's executed automatically as part of npx sv :)

![image](https://github.com/user-attachments/assets/86804540-c007-49ef-a428-3deb7a0fc574)

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `next` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
