### PR TITLE
Small fixed for next docs #3015 & #3016

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/resources/cookbook/dialog.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/resources/cookbook/dialog.mdx
@@ -35,5 +35,5 @@ Animating `display: none` with CSS alone has limited browser support. However, p
 
 If you need finer grain control, consider Skeleton's integration guides for [Floating UI](https://floating-ui.com/).
 
-- [React Popovers](http://localhost:4321/docs/integrations/popover/react) - powered by Floating UI React.
-- [Svelte Popovers](http://localhost:4321/docs/integrations/popover/svelte) - powered by Floating UI Svelte.
+- [React Popovers](/docs/integrations/popover/react) - powered by Floating UI React.
+- [Svelte Popovers](/docs/integrations/popover/svelte) - powered by Floating UI Svelte.

--- a/sites/next.skeleton.dev/src/content/docs/resources/cookbook/stepper.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/resources/cookbook/stepper.mdx
@@ -4,7 +4,7 @@ title: Stepper
 description: Divide and present content in sequenced steps.
 showDocsUrl: true
 pubDate: 2024-11-19
-tags: ['presetnation', 'navigation', 'ux']
+tags: ['presentation', 'navigation', 'ux']
 ---
 
 export const components = componentSet;

--- a/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleSpecial.astro
+++ b/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleSpecial.astro
@@ -1,7 +1,7 @@
 <form class="mx-auto w-full max-w-md space-y-4">
 	{/* Search */}
 	<input class="input" type="search" placeholder="Search..." />
-	{/* File Input */}
+	{/* Date Picker */}
 	<label class="label">
 		<span class="label-text">Date</span>
 		<input class="input" type="date" />


### PR DESCRIPTION
Fixed links & typo

## Linked Issue

Closes #3015 
Closes #3016 
Closes #3018 

## Description

- Removed  `http://localhost:4321` so that the redirects are correct in dialog.mdx
- Fixed small typo `presetnation` in the tags of stepper.mdx
- Fixed small mislabeling of `Date Picker` input as `File Input`