### PR TITLE
NEXT fix empty switch padding (fixes #3010)

### DIFF
--- a/.changeset/weak-items-destroy.md
+++ b/.changeset/weak-items-destroy.md
@@ -1,0 +1,6 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+'@skeletonlabs/skeleton-react': patch
+---
+
+bugfix: empty padding when switch has no children

--- a/packages/skeleton-react/src/lib/components/Switch/Switch.tsx
+++ b/packages/skeleton-react/src/lib/components/Switch/Switch.tsx
@@ -112,9 +112,11 @@ export const Switch: React.FC<SwitchProps> = ({
 				</span>
 			</span>
 			{/* Label */}
-			<span {...api.getLabelProps()} className={`${labelBase} ${labelClasses}`} data-testid="switch-label">
-				{children}
-			</span>
+			{children ? (
+				<span {...api.getLabelProps()} className={`${labelBase} ${labelClasses}`} data-testid="switch-label">
+					{children}
+				</span>
+			) : null}
 		</label>
 	);
 };

--- a/packages/skeleton-svelte/src/lib/components/Switch/Switch.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Switch/Switch.svelte
@@ -124,7 +124,9 @@
 		</span>
 	</span>
 	<!-- Label -->
-	<span {...api.getLabelProps()} class="{labelBase} {labelClasses}" data-testid="switch-label">
-		{@render children?.()}
-	</span>
+	{#if children}
+		<span {...api.getLabelProps()} class="{labelBase} {labelClasses}" data-testid="switch-label">
+			{@render children()}
+		</span>
+	{/if}
 </label>


### PR DESCRIPTION
## Linked Issue

Fixes #3010 

## Description

Fixes the Switch component having some extra padding to the right when there is no child (they're shown as a label)

**before**
![before, there is some extra padding that off-centers the switch and leaves some padding when aligned to the right](https://github.com/user-attachments/assets/dcafd8c6-c4f8-40ab-93b1-76116bdc6ee6)

**after**
![the switch is now centered or doesn't have empty space to the right](https://github.com/user-attachments/assets/37a89df8-b920-426d-894e-214e601dd5be)
