### PR TITLE
NEXT Popver - Consistent Positioner and Z-Index Classes

### DIFF
--- a/.changeset/silent-rings-whisper.md
+++ b/.changeset/silent-rings-whisper.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+chore: Added positioner and z-index style props to the Svelte Popover, Tooltip, Combobox, and Modal components

--- a/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
@@ -24,13 +24,15 @@
 		inputGroupButton = 'input-group-cell',
 		inputGroupArrow = '',
 		inputGroupClasses = '',
+		// Positioner
+		positionerBase = '',
+		positionerZIndex = '',
+		positionerClasses = '',
 		// Content
 		contentBase = 'card p-2',
 		contentBackground = 'preset-outlined-surface-200-800 bg-surface-50-950',
+		contentSpaceY = 'space-y-1',
 		contentClasses = '',
-		// List
-		listBase = 'space-y-1',
-		listClasses = '',
 		// Option
 		optionBase = 'btn justify-start w-full',
 		optionHover = 'hover:preset-tonal',
@@ -116,12 +118,12 @@
 			</button>
 		</div>
 	</label>
-	<!-- Content -->
+	<!-- Menu -->
 	{#if api.open}
-		<div {...api.getPositionerProps()} transition:fade={{ duration: 100 }} class="{contentBase} {contentBackground} {contentClasses}">
+		<div {...api.getPositionerProps()} transition:fade={{ duration: 100 }} class="{positionerBase} {positionerZIndex} {positionerClasses}">
 			{#if options.length > 0}
-				<!-- List -->
-				<nav {...api.getContentProps()} class="{listBase} {listClasses}">
+				<!-- Content (list) -->
+				<nav {...api.getContentProps()} class="{contentBase} {contentBackground} {contentSpaceY} {contentClasses}">
 					{#each options as item}
 						{@const isChecked = api.getItemProps({ item })['data-state'] === 'checked'}
 						{@const displayClass = isChecked ? optionActive : optionHover}

--- a/packages/skeleton-svelte/src/lib/components/Combobox/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/types.ts
@@ -37,19 +37,23 @@ export interface ComboboxProps extends Omit<combobox.Context, 'id' | 'collection
 	/** Provide arbitrary classes for the input group. */
 	inputGroupClasses?: string;
 
+	// Positioner ---
+	/** Set base classes for the positioner. */
+	positionerBase?: string;
+	/** Set z-index classes for the positioner. */
+	positionerZIndex?: string;
+	/** Provide arbitrary classes for the positioner. */
+	positionerClasses?: string;
+
 	// Content ---
 	/** Set base classes for the content. */
 	contentBase?: string;
 	/** Set background classes for the content. */
 	contentBackground?: string;
+	/** Set space-y classes for the content. */
+	contentSpaceY?: string;
 	/** Provide arbitrary classes for the content. */
 	contentClasses?: string;
-
-	// List ---
-	/** Set base classes for the list. */
-	listBase?: string;
-	/** Provide arbitrary classes for the list. */
-	listClasses?: string;
 
 	// Option ---
 	/** Set base classes for the option. */

--- a/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
@@ -21,6 +21,7 @@
 		positionerJustify = 'justify-center',
 		positionerAlign = 'items-center',
 		positionerPadding = 'p-4',
+		positionerZIndex = '',
 		positionerClasses = '',
 		// Content
 		contentBase = '',
@@ -80,7 +81,7 @@
 		<div
 			use:portal
 			{...api.getPositionerProps()}
-			class="{positionerBase} {positionerDisplay} {positionerJustify} {positionerAlign} {positionerPadding} {positionerClasses}"
+			class="{positionerBase} {positionerDisplay} {positionerJustify} {positionerAlign} {positionerPadding} {positionerZIndex} {positionerClasses}"
 			in:fly={transitionsPositionerIn}
 			out:fly={transitionsPositionerOut}
 		>

--- a/packages/skeleton-svelte/src/lib/components/Modal/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Modal/types.ts
@@ -33,6 +33,8 @@ export interface ModalProps extends Omit<dialog.Context, 'id' | 'open'> {
 	positionerAlign?: string;
 	/** Set padding classes for the positioner. */
 	positionerPadding?: string;
+	/** Set z-index classes for the positioner. */
+	positionerZIndex?: string;
 	/** Provide arbitrary classes for the positioner. */
 	positionerClasses?: string;
 

--- a/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
@@ -13,6 +13,10 @@
 		triggerBase = '',
 		triggerBackground = '',
 		triggerClasses = '',
+		// Positioner
+		positionerBase = '',
+		positionerZIndex = '',
+		positionerClasses = '',
 		// Content
 		contentBase = '',
 		contentBackground = '',
@@ -55,7 +59,11 @@
 		{@render trigger?.()}
 	</button>
 	<!-- Portal -->
-	<div use:portal={{ disabled: !api.portalled }} {...api.getPositionerProps()}>
+	<div
+		use:portal={{ disabled: !api.portalled }}
+		{...api.getPositionerProps()}
+		class="{positionerBase} {positionerZIndex} {positionerClasses}"
+	>
 		<!-- Popover -->
 		{#if api.open}
 			<div {...api.getContentProps()} transition:fade={{ duration: 100 }}>

--- a/packages/skeleton-svelte/src/lib/components/Popover/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Popover/types.ts
@@ -8,27 +8,35 @@ export interface PopoverProps extends Omit<popover.Context, 'id' | 'open'> {
 	arrow?: boolean;
 
 	// Trigger ---
-	/** Set base styles for the trigger. */
+	/** Set base classes for the trigger. */
 	triggerBase?: string;
-	/** Set background styles for the trigger. */
+	/** Set background classes for the trigger. */
 	triggerBackground?: string;
-	/** Provide arbitrary styles for the trigger. */
+	/** Provide arbitrary classes for the trigger. */
 	triggerClasses?: string;
 
+	// Positioner ---
+	/** Set base classes for the positioner. */
+	positionerBase?: string;
+	/** Set z-index classes for the positioner. */
+	positionerZIndex?: string;
+	/** Provide arbitrary classes for the positioner. */
+	positionerClasses?: string;
+
 	// Content ---
-	/** Set base styles for the content. */
+	/** Set base classes for the content. */
 	contentBase?: string;
-	/** Set background styles for the content. */
+	/** Set background classes for the content. */
 	contentBackground?: string;
-	/** Provide arbitrary styles for the content. */
+	/** Provide arbitrary classes for the content. */
 	contentClasses?: string;
 
 	// Arrow ---
-	/** Set base styles for the arrow. */
+	/** Set base classes for the arrow. */
 	arrowBase?: string;
-	/** Set background styles for the arrow. */
+	/** Set background classes for the arrow. */
 	arrowBackground?: string;
-	/** Provide arbitrary styles for the arrow. */
+	/** Provide arbitrary classes for the arrow. */
 	arrowClasses?: string;
 
 	// Snippets ---

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
@@ -12,6 +12,10 @@
 		triggerBase = '',
 		triggerBackground = '',
 		triggerClasses = '',
+		// Positioner
+		positionerBase = '',
+		positionerZIndex = '',
+		positionerClasses = '',
 		// Content
 		contentBase = '',
 		contentBackground = '',
@@ -51,7 +55,7 @@
 	</button>
 	<!-- Tooltip Content -->
 	{#if api.open}
-		<div {...api.getPositionerProps()} transition:fade={{ duration: 100 }}>
+		<div {...api.getPositionerProps()} transition:fade={{ duration: 100 }} class="{positionerBase} {positionerZIndex} {positionerClasses}">
 			<!-- Snippet Content -->
 			<div {...api.getContentProps()} class="{contentBase} {contentBackground} {contentClasses}">
 				{@render content?.()}

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/types.ts
@@ -13,6 +13,14 @@ export interface TooltipProps extends Omit<tooltip.Context, 'id' | 'open'> {
 	/** Provide arbitrary styles for the trigger. */
 	triggerClasses?: string;
 
+	// Positioner ---
+	/** Set base classes for the positioner. */
+	positionerBase?: string;
+	/** Set z-index classes for the positioner. */
+	positionerZIndex?: string;
+	/** Provide arbitrary classes for the positioner. */
+	positionerClasses?: string;
+
 	// Content ---
 	/** Set base styles for the content. */
 	contentBase?: string;


### PR DESCRIPTION
## Linked Issue

Closes #3009

## Description

Implements consistent Positioner and Z-Index classes to the following Svelte components:

- Popvers
- Tooltips
- Comboboxes
- Modals

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](http://localhost:4321/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
