### PR TITLE
NEXT Popovers - added base classes to Svelte Popover components

### DIFF
--- a/.changeset/hip-poems-perform.md
+++ b/.changeset/hip-poems-perform.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+chore: Added base style prop classes to Svelte Popover, Tooltip, and Modal components

--- a/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
@@ -7,6 +7,9 @@
 
 	let {
 		open = $bindable(false),
+		// Base
+		base = '',
+		classes = '',
 		// Trigger
 		triggerBase = '',
 		triggerBackground = '',
@@ -61,7 +64,7 @@
 	const api = $derived(dialog.connect(snapshot, send, normalizeProps));
 </script>
 
-<span data-testid="modal">
+<span class="{base} {classes}" data-testid="modal">
 	<!-- Trigger -->
 	{#if trigger}
 		<button {...api.getTriggerProps()} class="{triggerBase} {triggerBackground} {triggerClasses}">

--- a/packages/skeleton-svelte/src/lib/components/Modal/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Modal/types.ts
@@ -6,6 +6,12 @@ export interface ModalProps extends Omit<dialog.Context, 'id' | 'open'> {
 	/** Set the open state of the dialog. */
 	open?: boolean;
 
+	// Base ---
+	// Set base classes for the root element.
+	base?: string;
+	// Provide arbitrary classes for the root element.
+	classes?: string;
+
 	// Trigger ---
 	/** Set base classes for the trigger. */
 	triggerBase?: string;

--- a/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
@@ -9,6 +9,9 @@
 	let {
 		open = $bindable(false),
 		arrow = false,
+		// Base
+		base = '',
+		classes = '',
 		// Trigger
 		triggerBase = '',
 		triggerBackground = '',
@@ -53,7 +56,7 @@
 	const api = $derived(popover.connect(snapshot, send, normalizeProps));
 </script>
 
-<span data-testid="popover">
+<span class="{base} {classes}" data-testid="popover">
 	<!-- Snippet: Trigger -->
 	<button {...api.getTriggerProps()} class="{triggerBase} {triggerBackground} {triggerClasses}">
 		{@render trigger?.()}

--- a/packages/skeleton-svelte/src/lib/components/Popover/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Popover/types.ts
@@ -7,6 +7,12 @@ export interface PopoverProps extends Omit<popover.Context, 'id' | 'open'> {
 	/** Enable display of the popover arrow. */
 	arrow?: boolean;
 
+	// Base ---
+	// Set base classes for the root element.
+	base?: string;
+	// Provide arbitrary classes for the root element.
+	classes?: string;
+
 	// Trigger ---
 	/** Set base classes for the trigger. */
 	triggerBase?: string;

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
@@ -8,6 +8,9 @@
 
 	let {
 		open = $bindable(false),
+		// Base
+		base = '',
+		classes = '',
 		// Trigger
 		triggerBase = '',
 		triggerBackground = '',
@@ -48,7 +51,7 @@
 	const api = $derived(tooltip.connect(snapshot, send, normalizeProps));
 </script>
 
-<span data-testid="tooltip">
+<span class="{base} {classes}" data-testid="tooltip">
 	<!-- Snippet: Trigger -->
 	<button {...api.getTriggerProps()} class="{triggerBase} {triggerBackground} {triggerClasses}">
 		{@render trigger?.()}

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/types.ts
@@ -5,6 +5,12 @@ export interface TooltipProps extends Omit<tooltip.Context, 'id' | 'open'> {
 	/** Set the open state of the tooltip. */
 	open?: boolean;
 
+	// Base ---
+	// Set base classes for the root element.
+	base?: string;
+	// Provide arbitrary classes for the root element.
+	classes?: string;
+
 	// Trigger ---
 	/** Set base styles for the trigger. */
 	triggerBase?: string;


### PR DESCRIPTION
## Linked Issue

Closes #2988

## Description

Added `base` and `classes` style props to the root element in the following Svelte Popover components:

- Popover
- Tooltip
- Modal

> NOTE: Combobox already had these in place.

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](http://localhost:4321/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
