### PR TITLE
NEXT fix opengraph

### DIFF
--- a/sites/next.skeleton.dev/src/layouts/LayoutDoc.astro
+++ b/sites/next.skeleton.dev/src/layouts/LayoutDoc.astro
@@ -44,6 +44,7 @@ const { frontmatter, headings } = Astro.props satisfies Props;
 // Layout Props
 const layoutProps = {
 	title: frontmatter.title,
+	description: frontmatter.description,
 	classList: 'grid grid-rows-[auto_1fr] xl:grid-rows-[auto_1fr_auto]'
 };
 // GitHub Settings

--- a/sites/next.skeleton.dev/src/layouts/LayoutRoot.astro
+++ b/sites/next.skeleton.dev/src/layouts/LayoutRoot.astro
@@ -18,6 +18,7 @@ const pageDescription = description ? description : 'Skeleton is a fully feature
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="description" content={pageDescription} />
+		<meta name="og:image" content="https://user-images.githubusercontent.com/1509726/212382766-f29b9c9a-82e3-44c2-b911-b17a9197e5b9.jpg" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		<meta name="generator" content={Astro.generator} />

--- a/sites/next.skeleton.dev/src/layouts/LayoutRoot.astro
+++ b/sites/next.skeleton.dev/src/layouts/LayoutRoot.astro
@@ -3,19 +3,21 @@ import '@styles/app.css';
 
 interface Props {
 	title?: string;
+	description?: string;
 	classList?: string;
 }
 
-const { title, classList } = Astro.props satisfies Props;
+const { title, description, classList } = Astro.props satisfies Props;
 
 const pageTitle = `${title ? title + ' - ' : ''}Skeleton`;
+const pageDescription = description ? description : 'Skeleton is a fully featured UI Toolkit for building reactive interfaces quickly using Svelte and Tailwind.';
 ---
 
 <!doctype html>
 <html lang="en" class="dark">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="description" content="Astro description" />
+		<meta name="description" content={pageDescription} />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/png" href="/favicon.png" />
 		<meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
## Description

Fixes next.skeleton.dev previews on Discord just showing "Astro description"

![discord preview](https://github.com/user-attachments/assets/4b952d0b-c88e-458c-9fec-326abdc4768d)

Additionally, I set the `og:image` property to the same value as in the v2 site - which is a hard-coded GitHub banner. Let me know in case we should revamp this (for example by passing the `LayoutDoc#docSite` to `LayoutRoot` to construct an absolute URL to the `/favicon.png`).

![discord preview w/ image](https://github.com/user-attachments/assets/e1f01189-2a61-4bd8-9eee-139f96281201)

## Help wanted
Checking the inspector, it appears the `LayoutDoc` doesn't work as expected. There's two `LayoutRoot` instances nested within each other, leading to the default page title being left in the `<head>`, with the correct one all the way down in the `body > div.container`.
Despite some debugging, I couldn't find out how to fix this - maybe someone knows?

![HTML containing the default and correct <title>](https://github.com/user-attachments/assets/e71fa744-e284-4509-abb4-73c9d2042fa2)