### PR TITLE
NEXT disable combobox multiple prop

### DIFF
--- a/.changeset/slimy-keys-bathe.md
+++ b/.changeset/slimy-keys-bathe.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+chore: Disabled the unsupported Svelte Combobox multiple property

--- a/packages/skeleton-svelte/src/lib/components/Combobox/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/types.ts
@@ -1,7 +1,7 @@
 import type { Snippet } from 'svelte';
 import * as combobox from '@zag-js/combobox';
 
-export interface ComboboxProps extends Omit<combobox.Context, 'id' | 'collection' | 'value' | 'label'> {
+export interface ComboboxProps extends Omit<combobox.Context, 'id' | 'collection' | 'value' | 'label' | 'multiple'> {
 	/** Provide the list of label and value data */
 	data?: { label: string; value: string }[];
 	/** Bind the selected value. */


### PR DESCRIPTION
## Linked Issue

Closes #2963

## Description

Disables the Zag-based `multiple` prop for the Svelte Combobox, as this is an unsupported feature.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)