### PR TITLE
Add Lucide iconography callout to Fundamentals page

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/get-started/fundamentals.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/fundamentals.mdx
@@ -20,6 +20,10 @@ import NavGrid from '@components/docs/NavGrid.astro';
 
 A fully featured [Figma UI Kit](/docs/get-started/figma) is available to designers, allowing them to quickly draft visual concept of your project.
 
+### Iconography
+
+Skeleton is icon agnostic, meaning you may bring your own iconography solution. However, all code examples in this documentation website default to [Lucide](https://lucide.dev/). See our integration guides for [React](/docs/integrations/iconography/react) or [Svelte](/docs/integrations/iconography/react) if you wish to follow our lead.
+
 ### Systems
 
 A number of helpful design systems provided courtesy of the Skeleton Tailwind plugin.


### PR DESCRIPTION
## Linked Issue

Closes #3041

## Description

Update fundamentals doc to reference our use of Lucide for iconography