### PR TITLE
Set unique key on outmost element for Rating

### DIFF
--- a/.changeset/wild-wolves-wink.md
+++ b/.changeset/wild-wolves-wink.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-react': patch
+---
+
+bugfix: Set unique `key` properly for React's Rating component

--- a/packages/skeleton-react/src/lib/components/Rating/Rating.tsx
+++ b/packages/skeleton-react/src/lib/components/Rating/Rating.tsx
@@ -65,7 +65,6 @@ export const Rating: FC<RatingProps> = ({
 				className={`${controlBase} ${controlGap} ${rxInteractive} ${rxReadOnly} ${rxDisabled} ${controlClasses}`}
 				data-testid="rating-control"
 			>
-				{/* FIXME: `item` is causing React key error; is not unique on re-render? */}
 				{api.items.map((item) => {
 					const itemState = api.getItemState({ index: item });
 					const icon = (() => {
@@ -78,12 +77,10 @@ export const Rating: FC<RatingProps> = ({
 						}
 					})();
 					return (
-						<>
+						<span key={item} {...api.getItemProps({ index: item })} className={`${itemBase} ${itemClasses}`} data-testid="rating-item">
 							{/* Item */}
-							<span key={item} {...api.getItemProps({ index: item })} className={`${itemBase} ${itemClasses}`} data-testid="rating-item">
-								{icon}
-							</span>
-						</>
+							{icon}
+						</span>
 					);
 				})}
 			</div>


### PR DESCRIPTION
## Linked Issue

Closes #3037 

## Description

The original issue seem to be caused because the span element containing the `key` property wasn't the outmost element, as it was wrapped by an empty element. After removing the empty wrapper element, seems like the warning went away from the console.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
