### PR TITLE
Chore/improve ratings half star SVG

### DIFF
--- a/.changeset/healthy-onions-hide.md
+++ b/.changeset/healthy-onions-hide.md
@@ -1,0 +1,6 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+'@skeletonlabs/skeleton-react': patch
+---
+
+chore: Improved Ratings component default half star SVG

--- a/packages/skeleton-react/src/lib/internal/nodes.tsx
+++ b/packages/skeleton-react/src/lib/internal/nodes.tsx
@@ -9,7 +9,12 @@ export const starEmpty = (
 );
 
 export const starHalf = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" height="24" width="24">
+	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" height="24" width="24">
+		<path
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
+		/>
 		<defs>
 			<linearGradient id="half-fill">
 				<stop offset="50%" stopColor="currentColor" />

--- a/packages/skeleton-svelte/src/lib/internal/snippets.ts
+++ b/packages/skeleton-svelte/src/lib/internal/snippets.ts
@@ -17,8 +17,13 @@ export const starEmpty = createRawSnippet(() => {
 export const starHalf = createRawSnippet(() => {
 	return {
 		render: () => /*html*/ `
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" height="24" width="24">
-                <defs>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" height="24" width="24">
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
+                />
+				<defs>
                     <linearGradient id="half-fill">
                         <stop offset="50%" stop-color="currentColor" />
                         <stop offset="50%" stop-color="transparent" />
@@ -28,7 +33,7 @@ export const starHalf = createRawSnippet(() => {
                     fill="url(#half-fill)"
                     d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z"
                 />
-            </svg>
+	        </svg>
         `
 	};
 });


### PR DESCRIPTION
## Linked Issue

Closes #2808

## Description

Improves the Ratings component half star SVG for React and Svelte.

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](http://localhost:4321/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
