### PR TITLE
NEXT Improve button hover state brightness

### DIFF
--- a/.changeset/lovely-walls-push.md
+++ b/.changeset/lovely-walls-push.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton': patch
+---
+
+chore: Improved button hover state brightness effect

--- a/packages/skeleton/src/plugin/components/buttons.css
+++ b/packages/skeleton/src/plugin/components/buttons.css
@@ -4,7 +4,10 @@
 .btn-icon {
 	@apply rounded font-medium no-underline;
 	@apply inline-flex items-center justify-center gap-4 whitespace-nowrap;
-	@apply transition-all hover:brightness-90 dark:hover:brightness-110;
+	@apply transition-all;
+
+	/* hover:brightness-90 dark:hover:brightness-150; */
+	@apply hover:brightness-105 dark:hover:brightness-75;
 }
 
 /* Button Sizes --- */


### PR DESCRIPTION
## Linked Issue

Closes #2938

## Description

Improve button hover state brightness. I'll note this is a subtle change, but likely we can do with the potentially infinite combination of colors and luminosity. If this continues to be an issue, the next step might be to remove the built-in hover state and leave this up to end users. That way they can tailor it to their individual theme requirements.

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](http://localhost:4321/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
