### PR TITLE
NEXT Fix column names in pagination examples

### DIFF
--- a/sites/next.skeleton.dev/src/examples/components/pagination/Example.svelte
+++ b/sites/next.skeleton.dev/src/examples/components/pagination/Example.svelte
@@ -40,9 +40,9 @@
 			<thead>
 				<tr>
 					<th>Position</th>
-					<th>Symbol</th>
 					<th>Name</th>
-					<th class="!text-right">Weight</th>
+					<th>Weight</th>
+					<th class="!text-right">Symbol</th>
 				</tr>
 			</thead>
 			<tbody class="hover:[&>tr]:preset-tonal-primary">

--- a/sites/next.skeleton.dev/src/examples/components/pagination/Example.tsx
+++ b/sites/next.skeleton.dev/src/examples/components/pagination/Example.tsx
@@ -43,9 +43,9 @@ export const Page: React.FC = () => {
 					<thead>
 						<tr>
 							<th>Position</th>
-							<th>Symbol</th>
 							<th>Name</th>
-							<th className="!text-right">Weight</th>
+							<th>Weight</th>
+							<th className="!text-right">Symbol</th>
 						</tr>
 					</thead>
 					<tbody className="hover:[&>tr]:preset-tonal-primary">


### PR DESCRIPTION
## Linked Issue

N/A

## Description

The Skeleton Next's docs pagination examples had their column names in the wrong order so the values did not match up. Before and after:

![image](https://github.com/user-attachments/assets/12573c08-6665-4635-a1ce-098c426cd6c7)
![image](https://github.com/user-attachments/assets/cbddc3b5-b279-4632-9146-b315afebd461)

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](http://localhost:4321/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.

