### PR TITLE
Feat: Necroparser, resolve `Snippet` to `primitive` typeKind instead of `function`

### DIFF
--- a/.changeset/sweet-apes-fix.md
+++ b/.changeset/sweet-apes-fix.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/necroparser': patch
+---
+
+Add `transformProperty` option to alter the output of `getInterfaces`.

--- a/packages/necroparser/__mocks__/fs.cjs
+++ b/packages/necroparser/__mocks__/fs.cjs
@@ -1,0 +1,2 @@
+const { fs } = require('memfs');
+module.exports = fs;

--- a/packages/necroparser/package.json
+++ b/packages/necroparser/package.json
@@ -20,6 +20,7 @@
 	],
 	"devDependencies": {
 		"@zag-js/accordion": "^0.78.3",
+		"memfs": "^4.15.0",
 		"unbuild": "^2.0.0",
 		"vite": "^6.0.4",
 		"vitest": "^2.1.8"

--- a/packages/necroparser/test/options.test.ts
+++ b/packages/necroparser/test/options.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getInterfaces } from '../src/index.js';
+import { fs, vol } from 'memfs';
+
+vi.mock('node:fs');
+
+beforeEach(() => {
+	vol.reset();
+});
+
+describe('options', () => {
+	describe('matcher', () => {
+		test('should only match interfaces with the given name', () => {
+			fs.writeFileSync(
+				'/matcher.ts',
+				`
+interface FooProps {
+	foo: string;
+}
+interface BarProps {
+	bar: number;
+}
+`
+			);
+			const interfaces = getInterfaces('/matcher.ts', {
+				matcher: /^FooProps$/
+			});
+			expect(interfaces).toStrictEqual([
+				{
+					name: 'FooProps',
+					properties: [
+						{
+							documentation: {
+								tags: [],
+								text: null
+							},
+							name: 'foo',
+							type: 'string',
+							typeKind: 'primitive',
+							required: true
+						}
+					]
+				}
+			]);
+		});
+	});
+	describe('transformProperty', () => {
+		test('should transform properties', () => {
+			fs.writeFileSync(
+				'/transformProperty.ts',
+				`
+interface FooProps {
+	foo: string;
+	bar: string;
+}
+`
+			);
+
+			const interfaces = getInterfaces('/transformProperty.ts', {
+				transformProperty(property) {
+					if (property.name === 'foo') {
+						return {
+							...property,
+							type: 'number'
+						};
+					}
+					return property;
+				}
+			});
+			expect(interfaces).toStrictEqual([
+				{
+					name: 'FooProps',
+					properties: [
+						{
+							documentation: {
+								tags: [],
+								text: null
+							},
+							name: 'foo',
+							type: 'number',
+							typeKind: 'primitive',
+							required: true
+						},
+						{
+							documentation: {
+								tags: [],
+								text: null
+							},
+							name: 'bar',
+							type: 'string',
+							typeKind: 'primitive',
+							required: true
+						}
+					]
+				}
+			]);
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@zag-js/accordion':
         specifier: ^0.78.3
         version: 0.78.3
+      memfs:
+        specifier: ^4.15.0
+        version: 4.15.0
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.6.3)
@@ -1857,6 +1860,24 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@jsonjoy.com/base64@1.1.2':
+    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@1.1.1':
+    resolution: {integrity: sha512-osjeBqMJ2lb/j/M8NCPjs1ylqWIcTRTycIhVB5pt6LgzgeRSb0YRZ7j9RfA8wIUrsr/medIuhVyonXRZWLyfdw==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@1.5.0':
+    resolution: {integrity: sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -3991,6 +4012,10 @@ packages:
   human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
 
+  hyperdyperid@1.2.0:
+    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
+    engines: {node: '>=10.18'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -4522,6 +4547,10 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  memfs@4.15.0:
+    resolution: {integrity: sha512-q9MmZXd2rRWHS6GU3WEm3HyiXZyyoA1DqdOhEq0lxPBmKb5S7IAOwX0RgUCwJfqjelDCySa5h8ujOy24LqsWcw==}
+    engines: {node: '>= 4.0.0'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -5955,6 +5984,12 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thingies@1.21.0:
+    resolution: {integrity: sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      tslib: ^2
+
   tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
 
@@ -6012,6 +6047,12 @@ packages:
   tr46@5.0.0:
     resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
     engines: {node: '>=18'}
+
+  tree-dump@1.0.2:
+    resolution: {integrity: sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -7953,6 +7994,22 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
     optional: true
+
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@1.1.1(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.5.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 1.21.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@1.5.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -10832,6 +10889,8 @@ snapshots:
 
   human-id@1.0.2: {}
 
+  hyperdyperid@1.2.0: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -11434,6 +11493,13 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.0.30: {}
+
+  memfs@4.15.0:
+    dependencies:
+      '@jsonjoy.com/json-pack': 1.1.1(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.5.0(tslib@2.8.1)
+      tree-dump: 1.0.2(tslib@2.8.1)
+      tslib: 2.8.1
 
   merge2@1.4.1: {}
 
@@ -13125,6 +13191,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thingies@1.21.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   tiny-glob@0.2.9:
     dependencies:
       globalyzer: 0.1.0
@@ -13174,6 +13244,10 @@ snapshots:
   tr46@5.0.0:
     dependencies:
       punycode: 2.3.1
+
+  tree-dump@1.0.2(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
 
   tree-kill@1.2.2: {}
 

--- a/sites/next.skeleton.dev/scripts/generate-schemas.ts
+++ b/sites/next.skeleton.dev/scripts/generate-schemas.ts
@@ -21,7 +21,18 @@ async function processFile(path: string): Promise<number> {
 	}
 	const outPath = join(OUTPUT_DIR, framework, `${toKebabCase(component)}.json`);
 	await mkdir(dirname(outPath), { recursive: true });
-	const interfaces = getInterfaces(path).filter((i) => i.name.match(/^[\w-]+Props$/));
+	const interfaces = getInterfaces(path, {
+		matcher: /^[\w-]+Props$/,
+		transformProperty(property) {
+			if (property.type.startsWith('Snippet')) {
+				return {
+					...property,
+					typeKind: 'primitive'
+				};
+			}
+			return property;
+		}
+	});
 	await writeFile(outPath, JSON.stringify(interfaces, null, 2));
 	return Object.keys(interfaces).length;
 }


### PR DESCRIPTION
## Linked Issue

Continuation of #3068 

## Description

Adds `transformProperty` callback to alter the output, we use this for `Snippet` so that they are treated as primitives instead of functions.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
