### PR TITLE
Remove extra height class from NavBar

### DIFF
--- a/.changeset/sweet-pens-compare.md
+++ b/.changeset/sweet-pens-compare.md
@@ -3,4 +3,4 @@
 '@skeletonlabs/skeleton-react': patch
 ---
 
-Remove extra height class from NavBar
+chore: Remove extra height class from NavBar

--- a/.changeset/sweet-pens-compare.md
+++ b/.changeset/sweet-pens-compare.md
@@ -1,0 +1,6 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+'@skeletonlabs/skeleton-react': patch
+---
+
+Remove extra height class from NavBar

--- a/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
+++ b/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
@@ -18,7 +18,7 @@ export const NavRail: React.FC<NavRailProps> = ({
 	value = '',
 	expanded = false,
 	// Root
-	base = 'h-full flex flex-col',
+	base = 'flex flex-col',
 	background = 'preset-filled-surface-100-900',
 	padding = 'p-1',
 	width = 'w-24',

--- a/packages/skeleton-svelte/src/lib/components/Navigation/NavBar.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Navigation/NavBar.svelte
@@ -5,7 +5,7 @@
 	let {
 		value = $bindable(''),
 		// Root
-		base = 'h-full flex flex-col',
+		base = 'flex flex-col',
 		background = 'preset-filled-surface-100-900',
 		width = 'min-w-[320px] w-full',
 		height = 'h-20',

--- a/sites/next.skeleton.dev/src/content/docs/components/navigation/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/navigation/meta.mdx
@@ -1,7 +1,7 @@
 ---
 title: Navigation
 description: Provides navigation inerfaces for large, medium, and small screens.
-srcSvelte: '/src/lib/components/Nav'
-srcReact: '/src/lib/components/Nav'
+srcSvelte: '/src/lib/components/Navigation'
+srcReact: '/src/lib/components/Navigation'
 showDocsUrl: true
 ---


### PR DESCRIPTION
## Linked Issue

None

## Description

The NavBar currently has both `h-full` & `h-20` applied by default. This means that its height is determined by which class ends up earlier in the CSS. Seems like this was probably an oversight to have both?

## Checklist

Please read and apply all [contribution requirements](https://next.skeleton.dev/docs/resources/contribute).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](http://localhost:4321/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.