### PR TITLE
Input group example code changes

### DIFF
--- a/sites/next.skeleton.dev/src/examples/tailwind/forms/Example.astro
+++ b/sites/next.skeleton.dev/src/examples/tailwind/forms/Example.astro
@@ -1,11 +1,11 @@
 <form class="card border-[1px] border-surface-200-800 preset-filled-surface-100-900 w-full max-w-md space-y-4 p-4">
 	<fieldset class="space-y-4">
-		{/* Input */}
+		<!-- Input -->
 		<label class="label">
 			<span class="label-text">Input</span>
 			<input class="input" type="text" placeholder="Input" />
 		</label>
-		{/* Select */}
+		<!-- Select -->
 		<label class="label">
 			<span class="label-text">Select</span>
 			<select class="select">
@@ -16,7 +16,7 @@
 				<option value="5">Option 5</option>
 			</select>
 		</label>
-		{/* Textarea */}
+		<!-- Textarea -->
 		<label class="label">
 			<span class="label-text">Textarea</span>
 			<textarea class="textarea rounded-container" rows="4" placeholder="Lorem ipsum dolor sit amet consectetur adipisicing elit."
@@ -24,7 +24,7 @@
 		</label>
 	</fieldset>
 	<fieldset class="flex justify-end">
-		{/* Button */}
+		<!-- Button -->
 		<button type="button" class="btn preset-outlined-surface-300-700">Submit</button>
 	</fieldset>
 </form>

--- a/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleGroups.astro
+++ b/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleGroups.astro
@@ -1,5 +1,5 @@
 ---
-import { CircleDollarSign, Check, Search } from 'lucide-svelte';
+import { CircleDollarSign, Check, Search } from 'lucide-react';
 ---
 
 <form class="mx-auto w-full max-w-md space-y-8">

--- a/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleGroups.astro
+++ b/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleGroups.astro
@@ -1,14 +1,14 @@
 ---
-import { CircleDollarSign, Check, Search } from 'lucide-react';
+import { CircleDollarSign, Check, Search } from 'lucide-svelte';
 ---
 
 <form class="mx-auto w-full max-w-md space-y-8">
-	{/* Website */}
+	<!-- Website -->
 	<div class="input-group divide-surface-200-800 grid-cols-[auto_1fr_auto] divide-x">
 		<div class="input-group-cell preset-tonal-surface">https://</div>
 		<input type="text" placeholder="www.example.com" />
 	</div>
-	{/* Amount */}
+	<!-- Amount -->
 	<div class="input-group divide-surface-200-800 grid-cols-[auto_1fr_auto] divide-x">
 		<div class="input-group-cell preset-tonal-surface">
 			<CircleDollarSign size={16} />
@@ -17,17 +17,17 @@ import { CircleDollarSign, Check, Search } from 'lucide-react';
 		<select>
 			<option>USD</option>
 			<option>CAD</option>
-			<option>EURO</option>
+			<option>EUR</option>
 		</select>
 	</div>
-	{/* Username */}
+	<!-- Username -->
 	<div class="input-group divide-surface-200-800 grid-cols-[1fr_auto] divide-x">
 		<input type="text" placeholder="Enter Username..." />
 		<button class="btn preset-filled" title="Username already in use.">
 			<Check size={16} />
 		</button>
 	</div>
-	{/* Search */}
+	<!-- Search -->
 	<div class="input-group divide-surface-200-800 grid-cols-[auto_1fr_auto] divide-x">
 		<div class="input-group-cell">
 			<Search size={16} />

--- a/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleSelection.astro
+++ b/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleSelection.astro
@@ -1,5 +1,5 @@
 <form class="mx-auto w-full max-w-md space-y-4">
-	{/* Default */}
+	<!-- Default -->
 	<select class="select">
 		<option value="1">Option 1</option>
 		<option value="2">Option 2</option>
@@ -7,7 +7,7 @@
 		<option value="4">Option 4</option>
 		<option value="5">Option 5</option>
 	</select>
-	{/* Size */}
+	<!-- Size -->
 	<select class="select rounded-container" size="4" value="1">
 		<option value="1">Option 1</option>
 		<option value="2">Option 2</option>
@@ -15,8 +15,8 @@
 		<option value="4">Option 4</option>
 		<option value="5">Option 5</option>
 	</select>
-	{/* Mutiple */}
-	<select class="select rounded-container" multiple value={['1', '2']}>
+	<!-- Multiple -->
+	<select class="select rounded-container" multiple value="['1', '2']">
 		<option value="1">Option 1</option>
 		<option value="2">Option 2</option>
 		<option value="3">Option 3</option>

--- a/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleSpecial.astro
+++ b/sites/next.skeleton.dev/src/examples/tailwind/forms/ExampleSpecial.astro
@@ -1,28 +1,28 @@
 <form class="mx-auto w-full max-w-md space-y-4">
-	{/* Search */}
+	<!-- Search -->
 	<input class="input" type="search" placeholder="Search..." />
-	{/* Date Picker */}
+	<!-- Date Picker -->
 	<label class="label">
 		<span class="label-text">Date</span>
 		<input class="input" type="date" />
 	</label>
-	{/* File Input */}
+	<!-- File Input -->
 	<label class="label">
 		<span class="label-text">File Input</span>
 		<input class="input" type="file" />
 	</label>
-	{/* Range */}
+	<!-- Range -->
 	<label class="label">
 		<span class="label-text">Range</span>
 		<input class="input" type="range" value="75" max="100" />
 	</label>
-	{/* Progress */}
+	<!-- Progress -->
 	<label class="label">
 		<span class="label-text">Progress</span>
 		<progress class="progress" value="50" max="100"></progress>
 	</label>
-	{/* Color */}
-	{/* TODO: convert to mini-component for reactive value */}
+	<!-- Color -->
+	<!-- TODO: convert to mini-component for reactive value -->
 	<div class="grid grid-cols-[auto_1fr] gap-2">
 		<input class="input" type="color" value="#bada55" />
 		<input class="input" type="text" value="#bada55" readonly tabindex="-1" />


### PR DESCRIPTION
## Linked Issue

Closes #3087

## Description

Astro apparently does complain about an invalid attribute (`className`) being put onto HTML elements so it might just be beneficial to stick to Svelte syntax since it aligns more closely to bare HTML code. Replaced JSX comments with HTML comments and fix an import from `lucide-react` to `lucide-svelte`.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
