### PR TITLE
Fixes invalid link in v2 Docs

### DIFF
--- a/.changeset/eighty-teachers-itch.md
+++ b/.changeset/eighty-teachers-itch.md
@@ -1,0 +1,5 @@
+---
+"skeleton.dev": patch
+---
+
+Redirect invalid link from get-started to guides

--- a/.changeset/slow-dancers-stare.md
+++ b/.changeset/slow-dancers-stare.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": minor
+---
+
+Fix CloseQuery has no effect and popup disappear on click

--- a/packages/skeleton/src/lib/utilities/Popup/popup.ts
+++ b/packages/skeleton/src/lib/utilities/Popup/popup.ts
@@ -138,7 +138,7 @@ export function popup(triggerNode: HTMLElement, args: PopupSettings) {
 	}
 
 	function handleMouseUp(event: MouseEvent) {
-		if (!triggerNode.contains(event.target as Node)) close();
+		if (!triggerNode.contains(event.target as Node) && !elemPopup.contains(event.target as Node)) close();
 	}
 
 	function onWindowClick(event: any): void {

--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -43,7 +43,7 @@
 				<h3 class="h3" data-toc-ignore>Deprecated</h3>
 				<!-- prettier-ignore -->
 				<p>
-					This feature is being phased out as we transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This component will remain functional for all 2.x releases. However, we recommend you migrate to <a class="underline" href="https://next.skeleton.dev/docs/get-started/layouts" target="_blank">custom layouts</a> as soon as possible. While this guide is provided for Skeleton v3, the only prerequisite is Tailwind. Which means you can use these techniques today!
+					This feature is being phased out as we transition to <a class="underline" href="https://next.skeleton.dev/docs/guides/layouts" target="_blank">custom layouts</a> as soon as possible. While this guide is provided for Skeleton v3, the only prerequisite is Tailwind. Which means you can use these techniques today!
 				</p>
 			</div>
 			<div class="alert-actions">


### PR DESCRIPTION
## Linked Issue

Invalid Link

## Description

This updates the link from https://next.skeleton.dev/docs/get-started/layouts to https://next.skeleton.dev/docs/guides/layouts

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
