### PR TITLE
docs: fixes invalid links

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/actions/filters/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/actions/filters/+page.svelte
@@ -127,7 +127,7 @@ only utilize theme on this doc page.
 				<svelte:fragment slot="panel">
 					{#if method === 0}
 						<p>
-							Use the following <a class="anchor" href="https://svelte.dev/tutorial/actions" target="_blank" rel="noreferrer"
+							Use the following <a class="anchor" href="https://v4.svelte.dev/tutorial/actions" target="_blank" rel="noreferrer"
 								>Svelte action</a
 							> to filter any element. Pass the filter name as the only parameter.
 						</p>

--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -43,11 +43,11 @@
 				<h3 class="h3" data-toc-ignore>Deprecated</h3>
 				<!-- prettier-ignore -->
 				<p>
-					This feature is being phased out as we transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This component will remain functional for all 2.x releases. However, we recommend you migrate to <a class="underline" href="https://next.skeleton.dev/docs/guides/layouts" target="_blank">custom layouts</a> as soon as possible. While this guide is provided for Skeleton v3, the only prerequisite is Tailwind. Which means you can use these techniques today!
+					This feature is being phased out as we transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This component will remain functional for all 2.x releases. However, we recommend you migrate to <a class="underline" href="https://skeleton.dev/docs/guides/layouts" target="_blank">custom layouts</a> as soon as possible. While this guide is provided for Skeleton v3, the only prerequisite is Tailwind. Which means you can use these techniques today!
 				</p>
 			</div>
 			<div class="alert-actions">
-				<a class="btn variant-filled" href="https://next.skeleton.dev/docs/guides/layouts" target="_blank">Layout Guide</a>
+				<a class="btn variant-filled" href="https://skeleton.dev/docs/guides/layouts" target="_blank">Layout Guide</a>
 			</div>
 		</aside>
 		<div class="space-y-2">

--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -43,7 +43,7 @@
 				<h3 class="h3" data-toc-ignore>Deprecated</h3>
 				<!-- prettier-ignore -->
 				<p>
-					This feature is being phased out as we transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This component will remain functional for all 2.x releases. However, we recommend you migrate to <a class="underline" href="https://next.skeleton.dev/docs/get-started/layouts" target="_blank">custom layouts</a> as soon as possible. While this guide is provided for Skeleton v3, the only prerequisite is Tailwind. Which means you can use these techniques today!
+					This feature is being phased out as we transition to <a class="underline" href="https://github.com/skeletonlabs/skeleton/discussions/2375" target="_blank">Skeleton v3</a>. This component will remain functional for all 2.x releases. However, we recommend you migrate to <a class="underline" href="https://next.skeleton.dev/docs/guides/layouts" target="_blank">custom layouts</a> as soon as possible. While this guide is provided for Skeleton v3, the only prerequisite is Tailwind. Which means you can use these techniques today!
 				</p>
 			</div>
 			<div class="alert-actions">

--- a/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/components/app-shell/+page.svelte
@@ -47,7 +47,7 @@
 				</p>
 			</div>
 			<div class="alert-actions">
-				<a class="btn variant-filled" href="https://next.skeleton.dev/docs/get-started/layouts" target="_blank">Layout Guide</a>
+				<a class="btn variant-filled" href="https://next.skeleton.dev/docs/guides/layouts" target="_blank">Layout Guide</a>
 			</div>
 		</aside>
 		<div class="space-y-2">

--- a/sites/skeleton.dev/src/routes/(inner)/docs/transitions/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/transitions/+page.svelte
@@ -8,7 +8,7 @@
 		<h1 class="h1">Transitions</h1>
 		<!-- prettier-ignore -->
 		<p>
-			Skeleton provides a simple interface for modifying Svelte component transitions. This supports <a class="anchor" href="https://svelte.dev/docs#run-time-svelte-transition" target="_blank" rel="noreferrer">Svelte-provided transitions</a>, such as: <code class="code">fade</code>, <code class="code">blur</code>, <code class="code">fly</code>, <code class="code">slide</code>, and <code class="code">scale</code>. As well as custom <a class="anchor" href="https://svelte.dev/tutorial/custom-css-transitions" target="_blank" rel="noreferrer">CSS</a> and <a class="anchor" href="https://svelte.dev/tutorial/custom-js-transitions" target="_blank" rel="noreferrer">Javascript</a> transitions.
+			Skeleton provides a simple interface for modifying Svelte component transitions. This supports <a class="anchor" href="https://svelte.dev/docs#run-time-svelte-transition" target="_blank" rel="noreferrer">Svelte-provided transitions</a>, such as: <code class="code">fade</code>, <code class="code">blur</code>, <code class="code">fly</code>, <code class="code">slide</code>, and <code class="code">scale</code>. As well as custom <a class="anchor" href="https://v4.svelte.dev/tutorial/custom-css-transitions" target="_blank" rel="noreferrer">CSS</a> and <a class="anchor" href="https://v4.svelte.dev/tutorial/custom-js-transitions" target="_blank" rel="noreferrer">Javascript</a> transitions.
 		</p>
 	</header>
 

--- a/sites/skeleton.dev/src/routes/(inner)/elements/alerts/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/elements/alerts/+page.svelte
@@ -109,7 +109,7 @@
 		<section class="space-y-4">
 			<h2 class="h2">Animation</h2>
 			<!-- prettier-ignore -->
-			<p><a class="anchor" href="https://svelte.dev/tutorial/transition" target="_blank" rel="noreferrer">Svelte Transitions</a> can provide smooth transition animations when the alert state changes.</p>
+			<p><a class="anchor" href="https://v4.svelte.dev/tutorial/transition" target="_blank" rel="noreferrer">Svelte Transitions</a> can provide smooth transition animations when the alert state changes.</p>
 			<CodeBlock language="html" code={`<aside class="alert" transition:fade={{ duration: 200 }}>(content)</aside>`} />
 		</section>
 	</svelte:fragment>

--- a/sites/skeleton.dev/src/routes/(inner)/utilities/table-of-contents/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/utilities/table-of-contents/+page.svelte
@@ -128,7 +128,7 @@
 			<p>
 				In some situations you may want to force the crawler action to update on demand. Use the <code class="code">key</code> parameter and
 				pass a value that will be modified, which operates similar to Svelte's
-				<a class="anchor" href="https://svelte.dev/tutorial/key-blocks" target="_blank">key blocks</a>. This can be useful for scanning for
+				<a class="anchor" href="https://v4.svelte.dev/tutorial/key-blocks" target="_blank">key blocks</a>. This can be useful for scanning for
 				new page headers for tabbed content.
 			</p>
 			<CodeBlock


### PR DESCRIPTION
## Linked Issue

Fix invalided link

## Description

This updates the link from https://next.skeleton.dev/docs/get-started/layouts to https://next.skeleton.dev/docs/guides/layouts

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
