### PR TITLE
Make Nav.Tile id mandatory and update examples

### DIFF
--- a/.changeset/tall-pigs-perform.md
+++ b/.changeset/tall-pigs-perform.md
@@ -1,0 +1,6 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+'@skeletonlabs/skeleton-react': patch
+---
+
+bugfix: Make use of `useId` on Navigation component to set default `id` for Tiles if user had not defined it explicitly

--- a/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
+++ b/packages/skeleton-react/src/lib/components/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useId } from 'react';
 import { NavContextState, NavRailProps, NavBarProps, NavTileProps } from './types.js';
 
 // Contexts ---
@@ -186,6 +186,11 @@ export const NavTile: React.FC<NavTileProps> = ({
 }) => {
 	// Get Context
 	const ctx = useContext<NavContextState>(NavContext);
+
+	const generatedId = useId();
+	if (!id) {
+		id = generatedId;
+	}
 
 	// Local
 	const TileElement = href ? 'a' : 'button';

--- a/packages/skeleton-svelte/src/lib/components/Navigation/NavTile.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Navigation/NavTile.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+	import { useId } from '$lib/internal/use-id.js';
 	import { getNavigationContext } from './context.js';
 	import type { NavTileProps } from './types.js';
 
 	let {
-		id,
+		id = useId(),
 		href,
 		target,
 		label,
@@ -57,7 +58,7 @@
 	}
 </script>
 
-<!-- @component An individual Navgiation component tile. -->
+<!-- @component An individual Navigation component tile. -->
 
 <svelte:element
 	this={element}

--- a/packages/skeleton-svelte/src/lib/components/Toast/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Toast/types.ts
@@ -30,7 +30,7 @@ export interface Toast {
 // Context ---
 
 // https://zagjs.com/components/react/toast#programmatic-control
-/** Provides accesss to the Toast Context API. */
+/** Provides access to the Toast Context API. */
 export interface ToastContext {
 	/** Used to create display a new Toast instance. */
 	create: (toast: Toast) => void;


### PR DESCRIPTION
## Linked Issue

Closes #3085 

## Description

Make `id` mandatory on Nav.Tile instances

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
