### PR TITLE
Feature: Name, description and version are now pulled from the `package.json`.

### DIFF
--- a/.changeset/tender-bees-allow.md
+++ b/.changeset/tender-bees-allow.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-cli': patch
+---
+
+Feature: Name, description and version are now pulled from the `package.json`.

--- a/packages/skeleton-cli/README.md
+++ b/packages/skeleton-cli/README.md
@@ -1,6 +1,6 @@
 # Skeleton CLI
 
-The Skeleton CLI is a command-line tool that helps you create and manage your Skeleton projects.
+The CLI for Skeleton related tooling.
 
 ## Usage
 
@@ -16,6 +16,8 @@ npx @skeletonlabs/skeleton-cli [command] [args]
 
 The `skeleton-3` migration will migrate your project from V2 to V3, this includes:
 
-- All tailwind classes
+- Tailwind classes
+- Import statements
+- Component names
 - Your `package.json`
-- Your `tailwind.config.[js|ts]`
+- Your `tailwind.config`

--- a/packages/skeleton-cli/src/index.ts
+++ b/packages/skeleton-cli/src/index.ts
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 import { intro, log, outro } from '@clack/prompts';
-import { migrate } from './commands/migrate/index.js';
+import { migrate } from './commands/migrate';
 import { bgBlueBright, bgGreenBright, black, dim, red } from 'colorette';
 import { Command } from 'commander';
+import { getOurPackageJson } from './utility/get-our-package-json';
+
+const pkg = await getOurPackageJson();
 
 const cli = new Command()
-	.name('@skeletonlabs/skeleton-cli')
-	.description('The CLI for Skeleton related tooling.')
+	.name(pkg.name)
+	.description(pkg.description)
+	.version(pkg.version)
 	.addCommand(migrate)
 	.copyInheritedSettings(migrate)
 	.configureOutput({
@@ -15,10 +19,6 @@ const cli = new Command()
 			outro(red(str.replace('\n', ' ')));
 			process.exit(1);
 		}
-	})
-	.addHelpText('afterAll', () => {
-		outro(bgGreenBright(black(' All Done! ')));
-		return '';
 	})
 	.hook('preAction', (_, ctx) => {
 		const args = ctx.args.join(' ');
@@ -34,6 +34,6 @@ async function main() {
 	outro(bgGreenBright(black(' All Done! ')));
 }
 
-main();
+await main();
 
 export { cli };

--- a/packages/skeleton-cli/src/utility/get-our-package-json.ts
+++ b/packages/skeleton-cli/src/utility/get-our-package-json.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { PackageJson } from 'type-fest';
+import { readFile } from 'node:fs/promises';
+
+async function getOurPackageJson(): Promise<Required<PackageJson>> {
+	const packageJsonPath = join(dirname(fileURLToPath(import.meta.url)), '../package.json');
+	const content = await readFile(packageJsonPath, 'utf-8');
+	return JSON.parse(content);
+}
+
+export { getOurPackageJson };


### PR DESCRIPTION
This PR implements that the name, description and version are pulled from the package.json so we only need to define it once.
This removes the need to maintain these in 2 places, since the code/CLI pulls it from the package.json.

```js
const pkg = await getOurPackageJson();

const cli = new Command()
	.name(pkg.name)
	.description(pkg.description)
	.version(pkg.version)
```