### PR TITLE
Bugfix (migrate/skeleton-3): Remove `fixUnusedIdentifiers`

### DIFF
--- a/.changeset/unlucky-poems-rest.md
+++ b/.changeset/unlucky-poems-rest.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-cli': patch
+---
+
+Bugfix (migrate/skeleton-3): Remove `fixUnusedIdentifiers` calls to reduce migration noise.

--- a/packages/skeleton-cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-module.ts
+++ b/packages/skeleton-cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-module.ts
@@ -5,13 +5,8 @@ import { Node } from 'ts-morph';
 import { addNamedImport } from '../../../../../utility/ts-morph/add-named-import';
 import { parseSourceFile } from '../../../../../utility/ts-morph/parse-source-file';
 
-interface TransformModuleOptions {
-	fixUnusedIdentifiers?: boolean;
-}
-
-function transformModule(code: string, options: TransformModuleOptions = {}) {
+function transformModule(code: string) {
 	const file = parseSourceFile(code);
-	const fixUnusedIdentifiers = options.fixUnusedIdentifiers ?? true;
 	file.forEachDescendant((node) => {
 		if (Node.isImportDeclaration(node)) {
 			const moduleSpecifier = node.getModuleSpecifier();
@@ -49,9 +44,6 @@ function transformModule(code: string, options: TransformModuleOptions = {}) {
 			node.setLiteralValue(transformClasses(node.getLiteralValue()).code);
 		}
 	});
-	if (fixUnusedIdentifiers) {
-		file.fixUnusedIdentifiers();
-	}
 	return {
 		code: file.getFullText()
 	};

--- a/packages/skeleton-cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-svelte.ts
+++ b/packages/skeleton-cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-svelte.ts
@@ -25,9 +25,7 @@ function transformScript(s: MagicString, script: AST.Script) {
 		throw new Error('Script tags not found in content');
 	}
 	const codeContent = content.slice(openingTag.length, content.length - closingTag.length);
-	const transformed = transformModule(codeContent, {
-		fixUnusedIdentifiers: false
-	});
+	const transformed = transformModule(codeContent);
 	if (!transformed.code.trim()) {
 		s.overwrite(script.start, script.end, '');
 	} else {

--- a/packages/skeleton-cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-tailwind-config.ts
+++ b/packages/skeleton-cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-tailwind-config.ts
@@ -232,7 +232,6 @@ function transformTailwindConfig(code: string) {
 	const file = parseSourceFile(code);
 	transformTailwindContentOption(file);
 	const themes = transformSkeletonThemesOption(file);
-	file.fixUnusedIdentifiers();
 	return {
 		code: file.getFullText(),
 		meta: {

--- a/packages/skeleton-cli/test/migrate/skeleton-3/fixtures/tailwind-config/no-themes
+++ b/packages/skeleton-cli/test/migrate/skeleton-3/fixtures/tailwind-config/no-themes
@@ -1,4 +1,3 @@
-import { join } from "path";
 import { skeleton } from "@skeletonlabs/tw-plugin";
 
 export default {

--- a/packages/skeleton-cli/test/migrate/skeleton-3/fixtures/tailwind-config/perserve-config
+++ b/packages/skeleton-cli/test/migrate/skeleton-3/fixtures/tailwind-config/perserve-config
@@ -1,4 +1,3 @@
-import { join } from "path";
 import { skeleton } from "@skeletonlabs/tw-plugin";
 
 export default {

--- a/packages/skeleton-cli/test/migrate/skeleton-3/results/tailwind-config/content-path
+++ b/packages/skeleton-cli/test/migrate/skeleton-3/results/tailwind-config/content-path
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { contentPath } from "@skeletonlabs/skeleton/plugin";
 
 export default {

--- a/packages/skeleton-cli/test/migrate/skeleton-3/results/tailwind-config/content-path-different-index
+++ b/packages/skeleton-cli/test/migrate/skeleton-3/results/tailwind-config/content-path-different-index
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { contentPath } from "@skeletonlabs/skeleton/plugin";
 
 export default {

--- a/packages/skeleton-cli/test/migrate/skeleton-3/results/tailwind-config/custom-theme
+++ b/packages/skeleton-cli/test/migrate/skeleton-3/results/tailwind-config/custom-theme
@@ -8,6 +8,8 @@
  *
  * See https://github.com/skeletonlabs/skeleton/discussions/2921 for info on how to migrate these yourself.
  */
+import myCustomTheme from "./my-custom-theme.js";
+import myCustomThemeTwo from "./my-custom-theme-two.js";
 import { skeleton } from "@skeletonlabs/skeleton/plugin";
 import * as themes from "@skeletonlabs/skeleton/themes";
 

--- a/packages/skeleton-cli/test/migrate/skeleton-3/results/tailwind-config/preset-theme-object-notation
+++ b/packages/skeleton-cli/test/migrate/skeleton-3/results/tailwind-config/preset-theme-object-notation
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { skeleton } from "@skeletonlabs/skeleton/plugin";
 import * as themes from "@skeletonlabs/skeleton/themes";
 


### PR DESCRIPTION
Removes `fixUnusedIdentifiers` calls to lessen the migration noise and edit non skeleton parts of your app.