### PR TITLE
Bugfix: Exclude checkbox and radio from input-group styles

### DIFF
--- a/.changeset/polite-lions-camp.md
+++ b/.changeset/polite-lions-camp.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/tw-plugin": patch
+---
+
+bugfix: Excluded checkbox and radio from input group styles

--- a/packages/plugin/src/styles/components/forms.css
+++ b/packages/plugin/src/styles/components/forms.css
@@ -129,7 +129,7 @@
 	.input-group {
 		@apply grid overflow-hidden;
 	}
-	.input-group input,
+	.input-group input:not([type="checkbox"]):not([type="radio"]),
 	.input-group select {
 		@apply border-0 !ring-0 bg-transparent;
 	}


### PR DESCRIPTION
## Description

Fixes wrong displayed checkbox inside input-group.

#### Before fix
![Bildschirmfoto von 2025-01-18 22 09 02](https://github.com/user-attachments/assets/1f26b8b0-e7a5-4acc-8458-cddac92ef794)

#### After fix
![Bildschirmfoto von 2025-01-18 22 08 44](https://github.com/user-attachments/assets/c32ad565-2d0e-4eb6-ac85-8cfed4b38b4d)

## Changsets

Bugfix: Exclude checkbox and radio from input-group styles

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
