### PR TITLE
Bugfix: Event handlers and bindings.

### DIFF
--- a/.changeset/dirty-fans-tap.md
+++ b/.changeset/dirty-fans-tap.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+bugfix: Call custom event handlers provided in ZagJs's internal handlers

--- a/.changeset/twenty-planes-argue.md
+++ b/.changeset/twenty-planes-argue.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+Bugfix: `bind:pageSize` now correctly updates in combination with `onPageSizeChange` handler.

--- a/packages/skeleton-svelte/src/lib/components/Accordion/Accordion.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Accordion/Accordion.svelte
@@ -28,6 +28,7 @@
 		accordion.machine({
 			id: useId(),
 			onValueChange(details) {
+				zagProps.onValueChange?.(details);
 				value = details.value;
 			}
 		}),

--- a/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
@@ -60,16 +60,19 @@
 			collection,
 			value: $state.snapshot(value),
 			loopFocus: true,
-			onOpenChange() {
+			onOpenChange(details) {
+				zagProps.onOpenChange?.(details);
 				options = data;
 			},
-			onInputValueChange({ inputValue }) {
-				const filtered = data.filter((item) => item.label.toLowerCase().includes(inputValue.toLowerCase()));
+			onInputValueChange(details) {
+				zagProps.onInputValueChange?.(details);
+				const filtered = data.filter((item) => item.label.toLowerCase().includes(details.inputValue.toLowerCase()));
 				const newOptions = filtered.length > 0 ? filtered : data;
 				collection.setItems(newOptions);
 				options = newOptions;
 			},
 			onValueChange(event) {
+				zagProps.onValueChange?.(event);
 				value = event.value;
 			}
 		}),

--- a/packages/skeleton-svelte/src/lib/components/Pagination/Pagination.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Pagination/Pagination.svelte
@@ -46,19 +46,19 @@
 	const [snapshot, send] = useMachine(
 		pagination.machine({
 			id: useId(),
-			count: data.length,
-			onPageChange(details) {
-				zagProps.onPageChange?.(details);
-				page = details.page;
-			},
-			onPageSizeChange(details) {
-				zagProps.onPageSizeChange?.(details);
-				pageSize = details.pageSize;
-			}
+			count: data.length
 		}),
 		{
 			context: {
 				...zagProps,
+				onPageChange(details) {
+					zagProps.onPageChange?.(details);
+					page = details.page;
+				},
+				onPageSizeChange(details) {
+					zagProps.onPageSizeChange?.(details);
+					pageSize = details.pageSize;
+				},
 				get page() {
 					return page;
 				},

--- a/packages/skeleton-svelte/src/lib/components/Pagination/Pagination.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Pagination/Pagination.svelte
@@ -48,9 +48,11 @@
 			id: useId(),
 			count: data.length,
 			onPageChange(details) {
+				zagProps.onPageChange?.(details);
 				page = details.page;
 			},
 			onPageSizeChange(details) {
+				zagProps.onPageSizeChange?.(details);
 				pageSize = details.pageSize;
 			}
 		}),

--- a/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
@@ -43,6 +43,7 @@
 			id: useId(),
 			open,
 			onOpenChange(details) {
+				zagProps.onOpenChange?.(details);
 				open = details.open;
 			}
 		}),

--- a/packages/skeleton-svelte/src/lib/components/Rating/Rating.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Rating/Rating.svelte
@@ -4,7 +4,6 @@
 	import { useId } from '$lib/internal/use-id.js';
 	import { starEmpty, starHalf, starFull } from '$lib/internal/snippets.js';
 	import type { RatingProps } from './types.js';
-	import { noop } from '$lib/internal/noop.js';
 
 	// Props
 	let {
@@ -32,8 +31,6 @@
 		iconFull = starFull,
 		// Children
 		label,
-		// Events
-		onValueChange = noop,
 		// Zag
 		...zagProps
 	}: RatingProps = $props();
@@ -43,8 +40,8 @@
 		rating.machine({
 			id: useId(),
 			onValueChange: (details) => {
+				zagProps.onValueChange?.(details);
 				value = details.value;
-				onValueChange(details.value);
 			}
 		}),
 		{

--- a/packages/skeleton-svelte/src/lib/components/Rating/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Rating/types.ts
@@ -1,7 +1,7 @@
 import * as rating from '@zag-js/rating-group';
 import type { Snippet } from 'svelte';
 
-export interface RatingProps extends Omit<rating.Context, 'id' | 'onValueChange'> {
+export interface RatingProps extends Omit<rating.Context, 'id'> {
 	// Root ---
 	/** Set root base classes */
 	base?: string;
@@ -47,8 +47,4 @@ export interface RatingProps extends Omit<rating.Context, 'id' | 'onValueChange'
 	iconFull?: Snippet;
 	/** Set the label snippet */
 	label?: Snippet;
-
-	// Events ---
-	/** Set the onValueChange callback */
-	onValueChange?: (value: number) => void;
 }

--- a/packages/skeleton-svelte/src/lib/components/Segment/Segment.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Segment/Segment.svelte
@@ -43,6 +43,7 @@
 		radio.machine({
 			id: useId(),
 			onValueChange(details) {
+				zagProps.onValueChange?.(details);
 				value = details.value;
 			},
 			orientation

--- a/packages/skeleton-svelte/src/lib/components/Segment/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Segment/types.ts
@@ -10,7 +10,7 @@ export interface SegmentContext {
 
 // Components ---
 
-export interface SegmentProps extends Omit<radio.Context, 'id' | 'orientation' | 'onValueChange'> {
+export interface SegmentProps extends Omit<radio.Context, 'id' | 'orientation'> {
 	/** Set the active value. */
 	value?: string;
 	/** Set the orientation. */

--- a/packages/skeleton-svelte/src/lib/components/Slider/Slider.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Slider/Slider.svelte
@@ -57,6 +57,7 @@
 		slider.machine({
 			id: useId(),
 			onValueChange(details) {
+				zagProps.onValueChange?.(details);
 				value = details.value;
 			}
 		}),

--- a/packages/skeleton-svelte/src/lib/components/Tabs/Tabs.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tabs/Tabs.svelte
@@ -33,6 +33,7 @@
 		tabs.machine({
 			id: useId(),
 			onValueChange(details) {
+				zagProps.onValueChange?.(details);
 				value = details.value;
 			}
 		}),

--- a/packages/skeleton-svelte/src/lib/components/Tabs/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Tabs/types.ts
@@ -10,7 +10,7 @@ export interface TabsContextState {
 
 // Components ---
 
-export interface TabsProps extends Omit<tabs.Context, 'id' | 'orientation' | 'onValueChange'> {
+export interface TabsProps extends Omit<tabs.Context, 'id' | 'orientation'> {
 	/** Set the active value. */
 	value?: string;
 	/** Set tabs to stretch to fill the available width. */

--- a/packages/skeleton-svelte/src/lib/components/TagsInput/TagsInput.svelte
+++ b/packages/skeleton-svelte/src/lib/components/TagsInput/TagsInput.svelte
@@ -43,6 +43,7 @@
 		tagsInput.machine({
 			id: useId(),
 			onValueChange: (details) => {
+				zagProps.onValueChange?.(details);
 				value = details.value;
 			}
 		}),

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
@@ -39,6 +39,7 @@
 			id: useId(),
 			open,
 			onOpenChange(details) {
+				zagProps.onOpenChange?.(details);
 				open = details.open;
 			}
 		}),

--- a/packages/skeleton-svelte/src/routes/components/pagination/+page.svelte
+++ b/packages/skeleton-svelte/src/routes/components/pagination/+page.svelte
@@ -33,6 +33,9 @@
 	const slicedSource = $derived((s: SourceData[]) => s.slice((page - 1) * size, page * size));
 </script>
 
+Page: {page}
+Size: {size}
+
 <div class="space-y-10">
 	<header>
 		<h1 class="h1">Pagination</h1>
@@ -70,7 +73,7 @@
 				<option value={sourceData.length}>Show All</option>
 			</select>
 			<!-- Pagination (Alternative) -->
-			<Pagination bind:data={sourceData} bind:page bind:pageSize={size} alternative>
+			<Pagination bind:data={sourceData} bind:page bind:pageSize={size} alternative onPageSizeChange={console.log}>
 				{#snippet labelEllipsis()}<IconEllipsis class="size-4" />{/snippet}
 				{#snippet labelNext()}<IconArrowRight class="size-4" />{/snippet}
 				{#snippet labelPrevious()}<IconArrowLeft class="size-4" />{/snippet}


### PR DESCRIPTION
## Linked Issue

Closes: #3064
Continuation of: #3073

## Description

Both @phamduylong and me came to the same conclusion that and `$effect` is likely needed to sync our internal state and the binding aswell as updating the zagjs API, this is mainly caused by the fact we support `bind:` aswell as `on<Event>`.

