### PR TITLE
docs/ported purgeCSS documentation from v2

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/get-started/purgecss.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/purgecss.mdx
@@ -66,7 +66,7 @@ export const components = componentSet;
 
 ### Installation
 
-```shell title="Terminal"
+```console
 npm i -D vite-plugin-tailwind-purgecss
 ```
 

--- a/sites/next.skeleton.dev/src/content/docs/get-started/purgecss.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/purgecss.mdx
@@ -1,0 +1,99 @@
+---
+layout: '@layouts/LayoutDoc.astro'
+title: PurgeCSS
+description: Reducing your TailwindCSS bundle size using PurgeCSS
+showDocsUrl: false
+order: 30
+---
+
+export const components = componentSet;
+
+{/* prettier-ignore */}
+<p class="type-scale-5">Skeleton can be easily paired with PurgeCSS to help keep your TailwindCSS bundle size small and performant. 
+	Below you'll find information on why this is helpful, along with installation and usage details.</p>
+
+---
+
+## Introduction
+
+### Motivation
+
+<p>
+	Tailwind UI component libraries like Skeleton and Flowbite provide a number of benefits, but come with an important caveat – Tailwind generates classes for <em>all</em> imported components, even those unused in your project. This leads to a larger than necessary CSS bundle.
+</p>
+
+<p>
+	Unfortunately, this is a limitation of how Tailwind implements its <a class="anchor" href="https://tailwindcss.com/docs/content-configuration" target="_blank">Content Configuration</a>. Tailwind searches through all files specified in <code class="code">content</code>, uses a regex to locate possible selectors, then generates their respective classes. The key takeaway is that this occurs <em>before</em> the build process, meaning there is no built-in CSS treeshaking or purging against your production assets.
+</p>
+
+### How it Works
+
+<p>
+	Ideally, you only want selectors for classes you actually use. This is where <a class="anchor" href="https://purgecss.com/" target="_blank">PurgeCSS</a> comes in. We analyze the files that are part of your project's module graph and extract the utilized Tailwind classes. From there, the plugin passes them along to PurgeCSS for final processing.
+</p>
+
+<aside class="alert variant-filled-secondary mt-6">
+	<strong>Notice: Tailwind v4</strong>
+	<p class="mt-2">
+		This plugin will no longer be necessary after the release of <a class="anchor" href="https://tailwindcss.com/blog/tailwindcss-v4-alpha" target="_blank">Tailwind v4</a>, which introduces a new <a class="anchor" href="https://tailwindcss.com/blog/tailwindcss-v4-alpha#zero-configuration-content-detection" target="_blank">Vite plugin</a> that auto-detects classes from the module graph. As such, <strong>this plugin only supports Tailwind v3</strong>.
+	</p>
+</aside>
+
+---
+
+## Usage
+
+<aside class="alert variant-ghost">
+	<p>
+		Last updated for <code class="code">vite-plugin-tailwind-purgecss v0.3.0</code>. Check the plugin’s <a class="anchor" href="https://github.com/AdrianGonz97/vite-plugin-tailwind-purgecss" target="_blank">GitHub</a> for the latest instructions.
+	</p>
+</aside>
+
+### Supported Frameworks
+
+<p>
+	This plugin supports the following Vite-based frameworks:
+</p>
+
+- SvelteKit
+- Vite + Svelte
+- Vite + React
+- Astro
+
+<p>
+	Next.js is <strong>not supported</strong> because it does not use Vite.
+</p>
+
+### Installation
+
+```shell title="Terminal"
+npm i -D vite-plugin-tailwind-purgecss
+```
+
+### Add to Vite
+
+<p>
+	Below is a minimal example of how to integrate this plugin in <code class="code">vite.config.ts</code>, using Vite 6+ format.
+</p>
+
+```ts title="vite.config.ts"
+import { defineConfig } from 'vite';
+import { purgeCss } from 'vite-plugin-tailwind-purgecss';
+
+// Other Vite plugins here, e.g. SvelteKit or React plugin
+
+export default defineConfig({
+  plugins: [
+    // existing plugins
+    purgeCss()
+  ]
+});
+```
+
+---
+
+## Attribution
+
+<p>
+	This plugin is provided courtesy of Skeleton co-maintainer <a class="anchor" href="https://github.com/AdrianGonz97" target="_blank" rel="noreferrer">Adrian (aka CokaKoala)</a>. Feel free to explore and contribute to <a class="anchor" href="https://github.com/AdrianGonz97/vite-plugin-tailwind-purgecss" target="_blank" rel="noreferrer">vite-plugin-tailwind-purgecss</a> on GitHub.
+</p>


### PR DESCRIPTION
## Linked Issue

Closes #2881

## Description

Ported documentation from [v2 docs](https://www.skeleton.dev/docs/purgecss) with updated changes such as Vite 6 config format.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)  (targets next but ok)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
