### PR TITLE
docs: Replace usage of deprecated tools in get started page

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionInstall.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionInstall.svelte
@@ -33,8 +33,9 @@ cd my-skeleton-app
 				<CodeBlock
 					language="shell"
 					code={`
-npm create svelte@latest my-skeleton-app
+npx sv create my-skeleton-app
 	- Enable Typescript when prompted (recommended)
+	- Add TailwindCSS to project when prompted (recommended)
 cd my-skeleton-app
 npm install
 		`}

--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/SectionTailwind.svelte
@@ -26,10 +26,8 @@
 			{:else if $storeOnboardMethod === 'manual'}
 				<div class="space-y-4">
 					<!-- prettier-ignore -->
-					<p>
-						<a class="anchor" href="https://github.com/svelte-add/tailwindcss" target="_blank" rel="noreferrer">Svelte-Add</a> automates the process of installing Tailwind in SvelteKit.
-					</p>
-					<CodeBlock language="shell" code={`npx svelte-add@latest tailwindcss\nnpm install`} />
+					<p>In case you have not added Tailwind when creating the project, Svelte CLI can also automates the process of installing Tailwind in your SvelteKit project.<p>
+					<CodeBlock language="shell" code={`npx sv add tailwindcss`} />
 				</div>
 				<h3 class="h3">Tailwind Configuration</h3>
 				<p>


### PR DESCRIPTION

## Linked Issue

Closes #3161

## Checklist

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
