### PR TITLE
Bugfix: schema script directory

### DIFF
--- a/sites/next.skeleton.dev/scripts/generate-schemas.ts
+++ b/sites/next.skeleton.dev/scripts/generate-schemas.ts
@@ -15,7 +15,7 @@ function toKebabCase(str: string) {
 
 async function processFile(path: string): Promise<number> {
 	const component = basename(dirname(path));
-	const framework = path.match(/skeleton-([^/]+)/)?.[1];
+	const framework = path.match(/skeleton-([^/]+)(?=\/src\/lib\/components)/)?.[1];
 	if (!framework) {
 		throw new Error(`Invalid framework path: ${path}`);
 	}

--- a/sites/next.skeleton.dev/scripts/generate-schemas.ts
+++ b/sites/next.skeleton.dev/scripts/generate-schemas.ts
@@ -15,7 +15,9 @@ function toKebabCase(str: string) {
 
 async function processFile(path: string): Promise<number> {
 	const component = basename(dirname(path));
-	const framework = path.match(/skeleton-([^/]+)(?=\/src\/lib\/components)/)?.[1];
+	const matches = path.match(/skeleton-([^/]+)(?=\/|$)/g);
+	const match = matches?.at(-1);
+	const framework = match?.replace('skeleton-', '');
 	if (!framework) {
 		throw new Error(`Invalid framework path: ${path}`);
 	}


### PR DESCRIPTION
## Linked Issue

Closes #3165

## Description

The original regex matches the first `skeleton-*`, which can lead to incorrect matches (e.g., "next" instead of "svelte" in `/home/louis/skeleton-next/.../skeleton-svelte/...`). This update ensures it targets the correct package name (e.g., "svelte") by anchoring the match to `/src/lib/components`.

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
