### PR TITLE
v3 onboading pinned versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7582,7 +7582,7 @@ snapshots:
 
   '@astrojs/svelte@7.0.4(@types/node@22.10.1)(astro@5.0.2(@types/node@22.10.1)(jiti@2.4.2)(rollup@4.31.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1))(jiti@2.4.2)(svelte@5.19.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.0)(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))
       astro: 5.0.2(@types/node@22.10.1)(jiti@2.4.2)(rollup@4.31.0)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.1)
       svelte: 5.19.0
       svelte2tsx: 0.7.34(svelte@5.19.0)(typescript@5.6.3)
@@ -9261,9 +9261,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.0)(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))
       debug: 4.4.0
       svelte: 5.19.0
       vite: 6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1)
@@ -9283,15 +9283,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.0)(vite@6.0.2(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1)))(svelte@5.19.0)(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
       svelte: 5.19.0
-      vite: 6.0.2(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1)
+      vite: 6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1)
       vitefu: 1.0.5(vite@6.0.10(@types/node@22.10.1)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
@@ -31,7 +31,7 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         ### Create a Project
         Start by creating a new project using `create-next-app`, the Next.js CLI:
         ```console
-        npm create next-app@v15.1.6 my-skeleton-app --typescript --tailwind --eslint
+        npm create next-app@15.1.6 my-skeleton-app --typescript --tailwind --eslint
         cd my-skeleton-app
         ```
 		> NOTE: note that we are temporarily pinning `v15.1.6` to ensure Tailwind v3 is the only version available to install. Please note that [Tailwind v4 support is coming soon](https://github.com/skeletonlabs/skeleton/discussions/3175), at which point we'll enable `@latest` again.

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
@@ -29,11 +29,12 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
 <Process>
     <ProcessStep step="1">
         ### Create a Project
-        Start by creating a new project using `create-next-app` (the Next.js CLI):
+        Start by creating a new project using `create-next-app`, the Next.js CLI:
         ```console
-        npm create next-app@latest my-skeleton-app --typescript --tailwind --eslint
+        npm create next-app@v15.1.6 my-skeleton-app --typescript --tailwind --eslint
         cd my-skeleton-app
         ```
+		> NOTE: note that we are temporarily pinning `v15.1.6` to ensure Tailwind v3 is the only version available to install. Please note that [Tailwind v4 support is coming soon](https://github.com/skeletonlabs/skeleton/discussions/3175), at which point we'll enable `@latest` again.
     </ProcessStep>
     <ProcessStep step="2">
         ### Install Skeleton

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
@@ -31,10 +31,10 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         ### Create a Project
         Create a new Svelte 5 project using `sv` (the [Svelte CLI](https://svelte.dev/docs/cli/overview)). This generates a minimal project with Typescript enabled.
         ```console
-        npx sv create --template minimal --types ts my-skeleton-app
+        npx sv@0.6.16 create --template minimal --types ts my-skeleton-app
 		cd my-skeleton-app
         ```
-		> NOTE: make sure to select `tailwind` when prompted, otherwise use `npx sv add tailwindcss` to add it retroactively.
+		> NOTE: note that we pin `sv@0.6.16` to limit to Tailwind v3. However, [Tailwind v4 support is coming soon](https://github.com/skeletonlabs/skeleton/discussions/3175). If you miss the prompt to install Tailwind, use `npx sv@0.6.16 add tailwindcss` to add it retroactively.
     </ProcessStep>
     <ProcessStep step="2">
         ### Install Skeleton


### PR DESCRIPTION
## Linked Issue

Closes #3179

## Description

Updates SvelteKit and Next.js onboarding to use pinned version that will avoid Tailwind v4 for now.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.