### PR TITLE
Disabled prop implementation

### DIFF
--- a/.changeset/hip-bikes-doubt.md
+++ b/.changeset/hip-bikes-doubt.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+feat: Implement `disabled` for Modal, Tooltip, Popover and Combobox

--- a/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/Combobox.svelte
@@ -10,6 +10,7 @@
 		data = $bindable([]),
 		value = $bindable([]),
 		label = '',
+		disabled = false,
 		// Base
 		base = '',
 		width = '',
@@ -99,9 +100,9 @@
 		<!-- Input Group -->
 		<div {...api.getControlProps()} class="{inputGroupBase} {inputGroupClasses}">
 			<!-- Input -->
-			<input {...api.getInputProps()} class={inputGroupInput} />
+			<input {...api.getInputProps()} class={inputGroupInput} {disabled} />
 			<!-- Arrow -->
-			<button {...triggerProps} class={inputGroupButton}>
+			<button {...triggerProps} class={inputGroupButton} {disabled}>
 				{#if arrow}
 					{@render arrow()}
 				{:else}

--- a/packages/skeleton-svelte/src/lib/components/Combobox/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Combobox/types.ts
@@ -8,6 +8,8 @@ export interface ComboboxProps extends Omit<combobox.Context, 'id' | 'collection
 	value?: string[] | undefined;
 	/** Set the label to display. */
 	label?: string;
+	/** Disable the trigger element of the combobox */
+	disabled?: boolean;
 
 	// Base ---
 	/** Set base classes for the root element. */

--- a/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
@@ -7,6 +7,7 @@
 
 	let {
 		open = $bindable(false),
+		disabled = false,
 		// Base
 		base = '',
 		classes = '',
@@ -69,7 +70,7 @@
 
 <span class="{base} {classes}" data-testid="modal">
 	<!-- Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}">
+	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled}>
 		{@render trigger?.()}
 	</button>
 

--- a/packages/skeleton-svelte/src/lib/components/Modal/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Modal/types.ts
@@ -5,6 +5,8 @@ import type { FlyParams, FadeParams } from 'svelte/transition';
 export interface ModalProps extends Omit<dialog.Context, 'id' | 'open'> {
 	/** Set the open state of the dialog. */
 	open?: boolean;
+	/** Disable trigger element of the dialog */
+	disabled?: boolean;
 
 	// Base ---
 	/** Set base classes for the root element. */

--- a/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
@@ -9,6 +9,7 @@
 	let {
 		open = $bindable(false),
 		arrow = false,
+		disabled = false,
 		// Base
 		base = '',
 		classes = '',
@@ -62,7 +63,7 @@
 
 <span class="{base} {classes}" data-testid="popover">
 	<!-- Snippet: Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}">
+	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled}>
 		{@render trigger?.()}
 	</button>
 	<!-- Portal -->

--- a/packages/skeleton-svelte/src/lib/components/Popover/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Popover/types.ts
@@ -6,6 +6,8 @@ export interface PopoverProps extends Omit<popover.Context, 'id' | 'open'> {
 	open?: boolean;
 	/** Enable display of the popover arrow. */
 	arrow?: boolean;
+	/** Disable the trigger element of the popover */
+	disabled?: boolean;
 
 	// Base ---
 	/** Set base classes for the root element. */

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
@@ -8,6 +8,7 @@
 
 	let {
 		open = $bindable(false),
+		disabled = false,
 		// Base
 		base = '',
 		classes = '',
@@ -58,7 +59,7 @@
 
 <span class="{base} {classes}" data-testid="tooltip">
 	<!-- Snippet: Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}">
+	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled}>
 		{@render trigger?.()}
 	</button>
 	<!-- Tooltip Content -->

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/types.ts
@@ -4,6 +4,8 @@ import * as tooltip from '@zag-js/tooltip';
 export interface TooltipProps extends Omit<tooltip.Context, 'id' | 'open'> {
 	/** Set the open state of the tooltip. */
 	open?: boolean;
+	/** Disable the trigger element of the tooltip */
+	disabled?: boolean;
 
 	// Base ---
 	/** Set base classes for the root element. */


### PR DESCRIPTION
## Linked Issue

Closes #3120 

## Description

Implemented `disabled` prop for:
- Combobox
- Modal
- Popover
- Tooltip

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
