### PR TITLE
Update issue template to set type automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: 🐞 Bug
 description: Report an issue or bug
 labels: [bug]
+type: Bug
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,6 +1,7 @@
 name: 📗 Report Docs Issue
 description: Use this to report a typo or incorrect information.
 labels: [documentation]
+type: Task
 body:
   - type: input
     id: link

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: 🛠️ Request New Feature
 description: Let us know what you would like to see added.
 labels: ['feature request']
+type: Feature
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
## Linked Issue

Closes nothing...Chris reported this in Discord

## Description

Use the new GitHub feature

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
