### PR TITLE
Feat/#3202 svelte slider snippet with argument

### DIFF
--- a/.changeset/bright-rocks-stare.md
+++ b/.changeset/bright-rocks-stare.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+Make Svelte Slider marker snippet take the marker value as argument to enable marker customization

--- a/.changeset/bright-rocks-stare.md
+++ b/.changeset/bright-rocks-stare.md
@@ -1,5 +1,0 @@
----
-'@skeletonlabs/skeleton-svelte': patch
----
-
-Make Svelte Slider marker snippet take the marker value as argument to enable marker customization

--- a/.changeset/proud-toys-exercise.md
+++ b/.changeset/proud-toys-exercise.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+feat: Make Svelte Slider marker snippet take the marker value as argument to enable marker customization

--- a/packages/skeleton-svelte/src/lib/components/Slider/Slider.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Slider/Slider.svelte
@@ -107,7 +107,7 @@
 				<!-- Mark -->
 				<span {...api.getMarkerProps({ value })} class="{markBase} {markText} {markOpacity} {markClasses}" data-testid="slider-mark">
 					{#if mark}
-						{@render mark()}
+						{@render mark(value)}
 					{:else}
 						{value}
 					{/if}

--- a/packages/skeleton-svelte/src/lib/components/Slider/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Slider/types.ts
@@ -2,88 +2,88 @@ import * as slider from '@zag-js/slider';
 import type { Snippet } from 'svelte';
 
 export interface SliderProps extends Omit<slider.Context, 'id' | 'thumbSize'> {
-    /** Provide the value as an array. */
-    value?: number[];
-    /** Provide an array of value markers */
-    markers?: number[];
-    /** Set height classes for the overall slider. */
-    height?: string;
+	/** Provide the value as an array. */
+	value?: number[];
+	/** Provide an array of value markers */
+	markers?: number[];
+	/** Set height classes for the overall slider. */
+	height?: string;
 
-    // Root ---
-    /** Set base classes. */
-    base?: string;
-    /** Set vertical spacing between the control and markers. */
-    spaceY?: string;
-    /** Provide arbitrary classes for the root. */
-    classes?: string;
+	// Root ---
+	/** Set base classes. */
+	base?: string;
+	/** Set vertical spacing between the control and markers. */
+	spaceY?: string;
+	/** Provide arbitrary classes for the root. */
+	classes?: string;
 
-    // Control ---
-    /** Set base classes for the control. */
-    controlBase?: string;
-    /** Provide arbitrary classes for the control. */
-    controlClasses?: string;
+	// Control ---
+	/** Set base classes for the control. */
+	controlBase?: string;
+	/** Provide arbitrary classes for the control. */
+	controlClasses?: string;
 
-    // Track ---
-    /** Set base classes for the track. */
-    trackBase?: string;
-    /** Set background classes for the track. */
-    trackBg?: string;
-    /** Set border radius classes for the track. */
-    trackRounded?: string;
-    /** Provide arbitrary classes for the track. */
-    trackClasses?: string;
+	// Track ---
+	/** Set base classes for the track. */
+	trackBase?: string;
+	/** Set background classes for the track. */
+	trackBg?: string;
+	/** Set border radius classes for the track. */
+	trackRounded?: string;
+	/** Provide arbitrary classes for the track. */
+	trackClasses?: string;
 
-    // Meter ---
-    /** Set base classes for the meter. */
-    meterBase?: string;
-    /** Set background classes for the meter. */
-    meterBg?: string;
-    /** Set border radius classes for the meter. */
-    materRounded?: string;
-    /** Provide arbitrary classes for the meter. */
-    meterClasses?: string;
+	// Meter ---
+	/** Set base classes for the meter. */
+	meterBase?: string;
+	/** Set background classes for the meter. */
+	meterBg?: string;
+	/** Set border radius classes for the meter. */
+	materRounded?: string;
+	/** Provide arbitrary classes for the meter. */
+	meterClasses?: string;
 
-    // Thumb ---
-    /** Set base classes for the thumb. */
-    thumbBase?: string;
-    /** Set size classes for the thumb. */
-    thumbSize?: string;
-    /** Set background classes for the thumb. */
-    thumbBg?: string;
-    /** Set ring size classes for the thumb. */
-    thumbRingSize?: string;
-    /** Set ring color classes for the thumb. */
-    thumbRingColor?: string;
-    /** Set border-radius classes for the thumb. */
-    thumbRounded?: string;
-    /** Set cursor classes for the thumb. */
-    thumbCursor?: string;
-    /** Provide arbitrary classes for the thumb. */
-    thumbClasses?: string;
+	// Thumb ---
+	/** Set base classes for the thumb. */
+	thumbBase?: string;
+	/** Set size classes for the thumb. */
+	thumbSize?: string;
+	/** Set background classes for the thumb. */
+	thumbBg?: string;
+	/** Set ring size classes for the thumb. */
+	thumbRingSize?: string;
+	/** Set ring color classes for the thumb. */
+	thumbRingColor?: string;
+	/** Set border-radius classes for the thumb. */
+	thumbRounded?: string;
+	/** Set cursor classes for the thumb. */
+	thumbCursor?: string;
+	/** Provide arbitrary classes for the thumb. */
+	thumbClasses?: string;
 
-    // Markers ---
-    /** Set base classes for the markers. */
-    markersBase?: string;
-    /** Provide arbitrary classes for the markers. */
-    markerslasses?: string;
+	// Markers ---
+	/** Set base classes for the markers. */
+	markersBase?: string;
+	/** Provide arbitrary classes for the markers. */
+	markerslasses?: string;
 
-    // Mark ---
-    /** Set base classes for each mark. */
-    markBase?: string;
-    /** Set text size classes for each mark. */
-    markText?: string;
-    /** Set opacity classes for each mark. */
-    markOpacity?: string;
-    /** Provide arbitrary classes for each mark. */
-    markClasses?: string;
+	// Mark ---
+	/** Set base classes for each mark. */
+	markBase?: string;
+	/** Set text size classes for each mark. */
+	markText?: string;
+	/** Set opacity classes for each mark. */
+	markOpacity?: string;
+	/** Provide arbitrary classes for each mark. */
+	markClasses?: string;
 
-    // State ---
-    /** Set disabled state classes for the root element. */
-    stateDisabled?: string;
-    /** Set read-only state classes for the root element. */
-    stateReadOnly?: string;
+	// State ---
+	/** Set disabled state classes for the root element. */
+	stateDisabled?: string;
+	/** Set read-only state classes for the root element. */
+	stateReadOnly?: string;
 
-    // Children
-    /** Replace numeric markers with symbol, such as a icon. */
-    mark?: Snippet<[number]>;
+	// Children
+	/** Replace numeric markers with symbol, such as a icon. */
+	mark?: Snippet<[number]>;
 }

--- a/packages/skeleton-svelte/src/lib/components/Slider/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Slider/types.ts
@@ -2,88 +2,88 @@ import * as slider from '@zag-js/slider';
 import type { Snippet } from 'svelte';
 
 export interface SliderProps extends Omit<slider.Context, 'id' | 'thumbSize'> {
-	/** Provide the value as an array. */
-	value?: number[];
-	/** Provide an array of value markers */
-	markers?: number[];
-	/** Set height classes for the overall slider. */
-	height?: string;
+    /** Provide the value as an array. */
+    value?: number[];
+    /** Provide an array of value markers */
+    markers?: number[];
+    /** Set height classes for the overall slider. */
+    height?: string;
 
-	// Root ---
-	/** Set base classes. */
-	base?: string;
-	/** Set vertical spacing between the control and markers. */
-	spaceY?: string;
-	/** Provide arbitrary classes for the root. */
-	classes?: string;
+    // Root ---
+    /** Set base classes. */
+    base?: string;
+    /** Set vertical spacing between the control and markers. */
+    spaceY?: string;
+    /** Provide arbitrary classes for the root. */
+    classes?: string;
 
-	// Control ---
-	/** Set base classes for the control. */
-	controlBase?: string;
-	/** Provide arbitrary classes for the control. */
-	controlClasses?: string;
+    // Control ---
+    /** Set base classes for the control. */
+    controlBase?: string;
+    /** Provide arbitrary classes for the control. */
+    controlClasses?: string;
 
-	// Track ---
-	/** Set base classes for the track. */
-	trackBase?: string;
-	/** Set background classes for the track. */
-	trackBg?: string;
-	/** Set border radius classes for the track. */
-	trackRounded?: string;
-	/** Provide arbitrary classes for the track. */
-	trackClasses?: string;
+    // Track ---
+    /** Set base classes for the track. */
+    trackBase?: string;
+    /** Set background classes for the track. */
+    trackBg?: string;
+    /** Set border radius classes for the track. */
+    trackRounded?: string;
+    /** Provide arbitrary classes for the track. */
+    trackClasses?: string;
 
-	// Meter ---
-	/** Set base classes for the meter. */
-	meterBase?: string;
-	/** Set background classes for the meter. */
-	meterBg?: string;
-	/** Set border radius classes for the meter. */
-	materRounded?: string;
-	/** Provide arbitrary classes for the meter. */
-	meterClasses?: string;
+    // Meter ---
+    /** Set base classes for the meter. */
+    meterBase?: string;
+    /** Set background classes for the meter. */
+    meterBg?: string;
+    /** Set border radius classes for the meter. */
+    materRounded?: string;
+    /** Provide arbitrary classes for the meter. */
+    meterClasses?: string;
 
-	// Thumb ---
-	/** Set base classes for the thumb. */
-	thumbBase?: string;
-	/** Set size classes for the thumb. */
-	thumbSize?: string;
-	/** Set background classes for the thumb. */
-	thumbBg?: string;
-	/** Set ring size classes for the thumb. */
-	thumbRingSize?: string;
-	/** Set ring color classes for the thumb. */
-	thumbRingColor?: string;
-	/** Set border-radius classes for the thumb. */
-	thumbRounded?: string;
-	/** Set cursor classes for the thumb. */
-	thumbCursor?: string;
-	/** Provide arbitrary classes for the thumb. */
-	thumbClasses?: string;
+    // Thumb ---
+    /** Set base classes for the thumb. */
+    thumbBase?: string;
+    /** Set size classes for the thumb. */
+    thumbSize?: string;
+    /** Set background classes for the thumb. */
+    thumbBg?: string;
+    /** Set ring size classes for the thumb. */
+    thumbRingSize?: string;
+    /** Set ring color classes for the thumb. */
+    thumbRingColor?: string;
+    /** Set border-radius classes for the thumb. */
+    thumbRounded?: string;
+    /** Set cursor classes for the thumb. */
+    thumbCursor?: string;
+    /** Provide arbitrary classes for the thumb. */
+    thumbClasses?: string;
 
-	// Markers ---
-	/** Set base classes for the markers. */
-	markersBase?: string;
-	/** Provide arbitrary classes for the markers. */
-	markerslasses?: string;
+    // Markers ---
+    /** Set base classes for the markers. */
+    markersBase?: string;
+    /** Provide arbitrary classes for the markers. */
+    markerslasses?: string;
 
-	// Mark ---
-	/** Set base classes for each mark. */
-	markBase?: string;
-	/** Set text size classes for each mark. */
-	markText?: string;
-	/** Set opacity classes for each mark. */
-	markOpacity?: string;
-	/** Provide arbitrary classes for each mark. */
-	markClasses?: string;
+    // Mark ---
+    /** Set base classes for each mark. */
+    markBase?: string;
+    /** Set text size classes for each mark. */
+    markText?: string;
+    /** Set opacity classes for each mark. */
+    markOpacity?: string;
+    /** Provide arbitrary classes for each mark. */
+    markClasses?: string;
 
-	// State ---
-	/** Set disabled state classes for the root element. */
-	stateDisabled?: string;
-	/** Set read-only state classes for the root element. */
-	stateReadOnly?: string;
+    // State ---
+    /** Set disabled state classes for the root element. */
+    stateDisabled?: string;
+    /** Set read-only state classes for the root element. */
+    stateReadOnly?: string;
 
-	// Children
-	/** Replace numeric markers with symbol, such as a icon. */
-	mark?: Snippet;
+    // Children
+    /** Replace numeric markers with symbol, such as a icon. */
+    mark?: Snippet<[number]>;
 }

--- a/packages/skeleton-svelte/src/lib/components/Slider/types.ts
+++ b/packages/skeleton-svelte/src/lib/components/Slider/types.ts
@@ -84,6 +84,6 @@ export interface SliderProps extends Omit<slider.Context, 'id' | 'thumbSize'> {
 	stateReadOnly?: string;
 
 	// Children
-	/** Replace numeric markers with symbol, such as a icon. */
+	/** Replace numeric markers with symbol, such as a icon. Takes marker value as argument. */
 	mark?: Snippet<[number]>;
 }


### PR DESCRIPTION
## Linked Issue

Closes #3202 

## Description

Make Svelte Slider marker snippet take the marker value as argument to enable marker customization

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
