### PR TITLE
Set trigger button type to `button` for Tooltip, Popover and Modal

### DIFF
--- a/.changeset/angry-hats-hear.md
+++ b/.changeset/angry-hats-hear.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+feat: set trigger button type to `button` for **Tooltip**, **Popover** and **Modal**

--- a/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
@@ -70,7 +70,7 @@
 
 <span class="{base} {classes}" data-testid="modal">
 	<!-- Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled}>
+	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
 		{@render trigger?.()}
 	</button>
 

--- a/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
@@ -63,7 +63,7 @@
 
 <span class="{base} {classes}" data-testid="popover">
 	<!-- Snippet: Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled}>
+	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
 		{@render trigger?.()}
 	</button>
 	<!-- Portal -->

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
@@ -64,7 +64,7 @@
 
 <span class="{base} {classes}" data-testid="tooltip">
 	<!-- Snippet: Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled}>
+	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
 		{@render trigger?.()}
 	</button>
 	<!-- Tooltip Content -->


### PR DESCRIPTION
## Linked Issue

Closes #3204

## Description

Set trigger button type to `button` for **Tooltip**, **Popover** and **Modal**

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
