### PR TITLE
Docs: fix typo on Get Started page

### DIFF
--- a/sites/skeleton.dev/src/routes/(inner)/docs/get-started/+page.svelte
+++ b/sites/skeleton.dev/src/routes/(inner)/docs/get-started/+page.svelte
@@ -41,7 +41,7 @@
 						</td>
 					</tr>
 					<tr>
-						<td><a href="https://v3.tailwindcss.com/" target="_blank" class="anchor">Taiwlind</a></td>
+						<td><a href="https://v3.tailwindcss.com/" target="_blank" class="anchor">Tailwind</a></td>
 						<td>v3</td>
 						<td>
 							<a href="https://tailwindcss.com/blog/tailwindcss-v4" target="_blank" class="anchor">Tailwind v4</a> is not supported by this version of Skeleton.


### PR DESCRIPTION
## Description

Fixes the typo "Taiwlind" on [Get Started](https://www.skeleton.dev/docs/get-started).

## Changsets

n/a

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format` - _unrelated change in `packages/plugin/src/styles/components/forms.css`_
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
