### PR TITLE
Conditional rendering for trigger button

### DIFF
--- a/.changeset/stale-coats-build.md
+++ b/.changeset/stale-coats-build.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton-svelte': patch
+---
+
+bugfix: only render button wrapping around `trigger` if the snippet was provided

--- a/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Modal/Modal.svelte
@@ -70,9 +70,11 @@
 
 <span class="{base} {classes}" data-testid="modal">
 	<!-- Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
-		{@render trigger?.()}
-	</button>
+	{#if trigger}
+		<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
+			{@render trigger?.()}
+		</button>
+	{/if}
 
 	{#if api.open}
 		<!-- Backdrop -->

--- a/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Popover/Popover.svelte
@@ -63,9 +63,11 @@
 
 <span class="{base} {classes}" data-testid="popover">
 	<!-- Snippet: Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
-		{@render trigger?.()}
-	</button>
+	{#if trigger}
+		<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
+			{@render trigger?.()}
+		</button>
+	{/if}
 	<!-- Portal -->
 	<div use:portal={{ disabled: !api.portalled }} {...api.getPositionerProps()} class="{positionerBase} {positionerClasses}">
 		<!-- Popover -->

--- a/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Tooltip/Tooltip.svelte
@@ -64,9 +64,11 @@
 
 <span class="{base} {classes}" data-testid="tooltip">
 	<!-- Snippet: Trigger -->
-	<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
-		{@render trigger?.()}
-	</button>
+	{#if trigger}
+		<button {...triggerProps} class="{triggerBase} {triggerBackground} {triggerClasses}" {disabled} type="button">
+			{@render trigger?.()}
+		</button>
+	{/if}
 	<!-- Tooltip Content -->
 	{#if api.open}
 		<div {...api.getPositionerProps()} transition:fade={{ duration: 100 }} class="{positionerBase} {positionerClasses}">


### PR DESCRIPTION
## Linked Issue

Closes #3206 

## Description

Only render button wrapping around `trigger` if the snippet was provided

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
