### PR TITLE
fix(avatar): fix avatar bug, rendering improperly in appbar

### DIFF
--- a/packages/skeleton-svelte/src/lib/components/Avatar/Avatar.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Avatar/Avatar.svelte
@@ -23,7 +23,7 @@
 		imageClasses = '',
 		style = '',
 		// Fallback
-		fallbackBase = 'w-full h-full flex justify-center items-center',
+		fallbackBase = 'w-full flex justify-center items-center',
 		fallbackClasses = '',
 		// Snippets
 		children


### PR DESCRIPTION
## Linked Issue

Closes #2408

## Description

This PR fixes the bug of avatar component with initials only that causes content to load in the center of screen, when used in AppBar. 
OBS: I didnt manage to replicate the bug, cause i dont have Safari. (I tried BrowserStack but coudnt reproduce as well). @nullpointerexceptionkek tried too and didn't succeed. Since is a trivial fix, i will submit the PR anyway. Tell if we need some other test.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
