### PR TITLE
fix(avatar): remove unecessary h-full class in Avatar fallbackBase

### DIFF
--- a/.changeset/curly-jobs-sort.md
+++ b/.changeset/curly-jobs-sort.md
@@ -2,5 +2,5 @@
 "@skeletonlabs/skeleton-svelte": minor
 ---
 
-bugfix(avatar): removed unecessary h-full class from fallbackbase. 
+bugfix: in avaremoved unecessary h-full class from fallbackbase. 
   

--- a/.changeset/curly-jobs-sort.md
+++ b/.changeset/curly-jobs-sort.md
@@ -2,5 +2,5 @@
 "@skeletonlabs/skeleton-svelte": minor
 ---
 
-bugfix: in avaremoved unecessary h-full class from fallbackbase. 
+bugfix: in avatar component, removed unecessary h-full class from fallbackbase. 
   

--- a/.changeset/curly-jobs-sort.md
+++ b/.changeset/curly-jobs-sort.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": minor
+---
+
+bugfix(avatar)Ç removed unecessary h-full class from fallbackbase. 
+  

--- a/.changeset/curly-jobs-sort.md
+++ b/.changeset/curly-jobs-sort.md
@@ -2,5 +2,5 @@
 "@skeletonlabs/skeleton-svelte": minor
 ---
 
-bugfix(avatar)Ç removed unecessary h-full class from fallbackbase. 
+bugfix(avatar): removed unecessary h-full class from fallbackbase. 
   

--- a/.changeset/khaki-shoes-type.md
+++ b/.changeset/khaki-shoes-type.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+bugfix(avatar): removed unecessary h-full class from fallbackbase
+  

--- a/.changeset/khaki-shoes-type.md
+++ b/.changeset/khaki-shoes-type.md
@@ -1,6 +1,0 @@
----
-"@skeletonlabs/skeleton-svelte": patch
----
-
-bugfix(avatar): removed unecessary h-full class from fallbackbase
-  

--- a/packages/skeleton-react/CHANGELOG.md
+++ b/packages/skeleton-react/CHANGELOG.md
@@ -1,8 +1,8 @@
 # @skeletonlabs/skeleton-react
 
 ## 1.0.0-next.15
-### Minor Changes
 
+### Minor Changes
 
 - feat: Navigation - manually handle `selected` state of NavTile ([#3228](https://github.com/skeletonlabs/skeleton/pull/3228))
 

--- a/packages/skeleton-svelte/CHANGELOG.md
+++ b/packages/skeleton-svelte/CHANGELOG.md
@@ -1,17 +1,14 @@
 # @skeletonlabs/skeleton-svelte
 
 ## 1.0.0-next.20
-### Minor Changes
 
+### Minor Changes
 
 - feat: Navigation - manually handle `selected` state of NavTile ([#3228](https://github.com/skeletonlabs/skeleton/pull/3228))
 
-
 ### Patch Changes
 
-
 - chore: Remove redundant null checks for triggers ([#3226](https://github.com/skeletonlabs/skeleton/pull/3226))
-
 
 - bugfix: only render button wrapping around `trigger` if the snippet was provided ([#3223](https://github.com/skeletonlabs/skeleton/pull/3223))
 

--- a/packages/skeleton-svelte/src/lib/components/Avatar/Avatar.svelte
+++ b/packages/skeleton-svelte/src/lib/components/Avatar/Avatar.svelte
@@ -23,7 +23,7 @@
 		imageClasses = '',
 		style = '',
 		// Fallback
-		fallbackBase = 'w-full h-full flex justify-center items-center',
+		fallbackBase = 'w-full flex justify-center items-center',
 		fallbackClasses = '',
 		// Snippets
 		children


### PR DESCRIPTION
## Linked Issue

Closes #2408

## Description

This PR fixes the bug of avatar component with initials only that causes content to load in the center of screen, when used in AppBar. In fact ive just removed unecessary h-full class in fallbackrender
OBS: I didnt manage to replicate the bug, cause i dont have Safari. (I tried BrowserStack but coudnt reproduce as well). @nullpointerexceptionkek tried too and didn't succeed. Since is a trivial fix, i will submit the PR anyway. Tell if we need some other test.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
