### PR TITLE
remove create-skeleton-app from dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "pnpm --recursive build",
-		"dev": "pnpm --parallel dev",
+		"dev": "pnpm --parallel --filter=!create-skeleton-app dev",
 		"test": "pnpm --recursive test",
 		"test:watch": "pnpm --recursive test:watch",
 		"check": "pnpm --recursive check",


### PR DESCRIPTION
Remove `create-skeleton-app` from the `dev` scripts, we don't want to scaffold apps during development 😄 