### PR TITLE
Docs: Post RC 2 cleanup

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/components/tabs/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/tabs/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Tabs
 description: Use tabs to quickly switch between different views and pages.
-srcSvelte: '/src/lib/components/Tab'
-srcReact: '/src/lib/components/Tab'
+srcSvelte: '/src/lib/components/Tabs'
+srcReact: '/src/lib/components/Tabs'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/tabs'
 srcZag: 'https://zagjs.com/components/react/tabs'
 showDocsUrl: true

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/astro.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/astro.mdx
@@ -159,10 +159,10 @@ While Astro can support [multiple Frontend frameworks](https://docs.astro.build/
         ### Add Source Path to CSS Config
         Open your global stylesheet in `/src/styles/global.css` and insert each required `@source`. These should come immediately before Skeleton imports.
         ```css
-		@source '../../node_modules/@skeletonlabs/skeleton-react';
+		@source '../../node_modules/@skeletonlabs/skeleton-react/dist';
         ```
         ```css
-		@source '../../node_modules/@skeletonlabs/skeleton-svelte';
+		@source '../../node_modules/@skeletonlabs/skeleton-svelte/dist';
         ```
 		> NOTE: please verify the `@source` path resolves to your `node_modules` directory.
     </ProcessStep>

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
@@ -79,11 +79,11 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         ```css title="globals.css" {3-7}
         @import 'tailwindcss';
 
-    	@source '../../node_modules/@skeletonlabs/skeleton-react/dist';
-
         @import '@skeletonlabs/skeleton';
         @import '@skeletonlabs/skeleton/optional/presets';
         @import '@skeletonlabs/skeleton/themes/cerberus';
+
+        @source '../../node_modules/@skeletonlabs/skeleton-react';
         ```
     	> NOTE: make sure the `@source` path resolves correctly for your application structure.
     </ProcessStep>

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
@@ -79,7 +79,7 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         ```css title="globals.css" {3-7}
         @import 'tailwindcss';
 
-    	@source '../../node_modules/@skeletonlabs/skeleton-react';
+    	@source '../../node_modules/@skeletonlabs/skeleton-react/dist';
 
         @import '@skeletonlabs/skeleton';
         @import '@skeletonlabs/skeleton/optional/presets';

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/sveltekit.mdx
@@ -64,11 +64,11 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         ```css title="app.css" {3-7}
         @import 'tailwindcss';
 
-    	@source '../node_modules/@skeletonlabs/skeleton-svelte';
-
         @import '@skeletonlabs/skeleton';
         @import '@skeletonlabs/skeleton/optional/presets';
         @import '@skeletonlabs/skeleton/themes/cerberus';
+
+        @source '../node_modules/@skeletonlabs/skeleton-svelte/dist';
         ```
     	> NOTE: please verify the `@source` path resolves to your `node_modules` directory.
     </ProcessStep>

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/vite-react.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/vite-react.mdx
@@ -84,11 +84,11 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
          ```css title="index.css"
         @import 'tailwindcss';
 
-    	@source '../node_modules/@skeletonlabs/skeleton-react/dist';
-
         @import '@skeletonlabs/skeleton';
         @import '@skeletonlabs/skeleton/optional/presets';
         @import '@skeletonlabs/skeleton/themes/cerberus';
+
+        @source '../node_modules/@skeletonlabs/skeleton-react/dist';
         ```
     	> NOTE: please verify the `@source` path resolves to your `node_modules` directory.
     </ProcessStep>

--- a/sites/next.skeleton.dev/src/content/docs/get-started/installation/vite-svelte.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/installation/vite-svelte.mdx
@@ -84,11 +84,11 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
          ```css title="app.css"
         @import 'tailwindcss';
 
-    	@source '../node_modules/@skeletonlabs/skeleton-svelte/dist';
-
         @import '@skeletonlabs/skeleton';
         @import '@skeletonlabs/skeleton/optional/presets';
         @import '@skeletonlabs/skeleton/themes/cerberus';
+
+        @source '../node_modules/@skeletonlabs/skeleton-svelte/dist';
         ```
     	> NOTE: please verify the `@source` path resolves to your `node_modules` directory.
     </ProcessStep>

--- a/sites/next.skeleton.dev/src/content/docs/get-started/migrate-from-v2.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/migrate-from-v2.mdx
@@ -140,18 +140,11 @@ With automated migration complete, please follow the remaining manual migration 
 
 #### For Preset Themes
 
-1. [Browse the available preset themes](/docs/design/themes#preset-themes). Tap each preview to copy the name to your clipboard.
-2. You may register or or more theme in your global stylesheet in `/src/app.css`:
-
-```css
-@import '@skeletonlabs/skeleton/themes/{theme-name}';
-```
-
-3. Update the active theme by setting the `data-theme` attribute on the `<body>` tag in `/src/app.html`
+Your preset theme should be automatically migrated by the CLI, you're all set!
 
 #### For Custom Themes
 
-1. Use the [Import feature](https://themes.skeleton.dev/themes/import) provided by the new Theme Generator.
+1. Use the [Import feature](https://themes.skeleton.dev/themes/import) provided by the new Theme Generator.
 2. Drag and Drop your v2 theme into the file upload field.
 3. Your theme will be automatically converted to the newest format.
 4. Update and modify any theme settings in the live preview.

--- a/sites/next.skeleton.dev/src/content/docs/get-started/migrate-from-v2.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/get-started/migrate-from-v2.mdx
@@ -79,12 +79,12 @@ Use the following steps to migrate to from PostCSS to the Vite plugin:
 2. Run `npm uninstall postcss @tailwindcss/postcss`
 3. Run `npm install @tailwindcss/vite`
 4. Open your `vite.config` in the root of your project
-5. Import the following at the top of the file: `import tailwind from '@tailwindcss/vite'`
+5. Import the following at the top of the file: `import tailwindcss from '@tailwindcss/vite'`
 6. Finally, add the Vite plugin ABOVE your specific framework plugin:
 
 ```ts
 plugins: [
-	tailwind(),
+	tailwindcss(),
 	sveltekit() // or svelte()
 ];
 ```

--- a/sites/themes.skeleton.dev/vite.config.ts
+++ b/sites/themes.skeleton.dev/vite.config.ts
@@ -1,7 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
-import tailwindcss from '@tailwindcss/vite';
+import tailwind from '@tailwindcss/vite';
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()]
+	plugins: [sveltekit(), tailwind()]
 });

--- a/sites/themes.skeleton.dev/vite.config.ts
+++ b/sites/themes.skeleton.dev/vite.config.ts
@@ -1,7 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
-import tailwind from '@tailwindcss/vite';
+import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-	plugins: [sveltekit(), tailwind()]
+	plugins: [tailwindcss(), sveltekit()]
 });


### PR DESCRIPTION
- Add `/dist` to `@source` until https://github.com/tailwindlabs/tailwindcss/issues/16038 is fixed.
- Remove unneeded step from v2 -> v3 migration guide.
- Updated `tailwind` to `tailwindcss` default Vite plugin imports.
- Closes #3272