### PR TITLE
Implement Component Anatomy doc component

### DIFF
--- a/sites/next.skeleton.dev/astro.config.js
+++ b/sites/next.skeleton.dev/astro.config.js
@@ -38,6 +38,8 @@ export default defineConfig({
 			imports: [
 				// import ApiTable from '@components/docs/ApiTable.astro';
 				'@components/docs/ApiTable.astro',
+				// import CompViz from '@components/docs/CompViz.astro';
+				'@components/docs/CompViz.astro',
 				{
 					// import componentSet from "@components/mdx/index";
 					'@components/mdx/index': [['default', 'componentSet']],

--- a/sites/next.skeleton.dev/src/components/docs/CompViz.astro
+++ b/sites/next.skeleton.dev/src/components/docs/CompViz.astro
@@ -1,0 +1,22 @@
+---
+const { isRoot, label, element } = Astro.props;
+---
+
+<div class="element bg-surface-50-950 preset-outlined-surface-600-400 border-dashed p-3 space-y-3">
+	<!-- Label -->
+	<header class="flex justify-start items-center gap-2 pointer-events-none">
+		{isRoot && <code class="code">{`<${label}>`}</code>}
+		{!isRoot && <code class="code">&bull; {label}</code>}
+		{element && <span class="font-mono text-xs opacity-60">{`<${element}>`}</span>}
+	</header>
+	<!-- Children -->
+	<slot class="space-y-3" />
+</div>
+
+<style lang="postcss">
+	.element:hover:not(:has(*:hover)) {
+		background-color: var(--color-surface-100-900);
+		border-color: var(--color-primary-950-50);
+		border-style: solid;
+	}
+</style>

--- a/sites/next.skeleton.dev/src/content/docs/components/accordion/react.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/accordion/react.mdx
@@ -92,6 +92,20 @@ import { Plus, Minus, Heart } from 'lucide-react';
 <Accordion.Control lead={<Heart size={24} />}>Heart</Accordion.Control>
 ```
 
+## Anatomy
+
+<CompViz label="Accordion" element="div" isRoot>
+	<CompViz label="Accordion.Item" element="div" isRoot>
+		<CompViz label="Accordion.Control" element="button" isRoot>
+			<CompViz label="lead" element="div" />
+			<CompViz label="content" element="div" />
+			<CompViz label="indicator" element="div" />
+		</CompViz>
+		<CompViz label="Accordion.Panel" element="div" />
+	</CompViz>
+	<CompViz label="..." isRoot />
+</CompViz>
+
 ## API Reference
 
 <ApiTable />

--- a/sites/next.skeleton.dev/src/content/docs/components/avatar/react.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/avatar/react.mdx
@@ -31,6 +31,13 @@ When `src` or `srcSet` are missing or fail to load, a fallback will be displayed
 	</Fragment>
 </Preview>
 
+## Anatomy
+
+<CompViz label="<Avatar>" element="figure" isRoot>
+	<CompViz label="image" element="img" />
+	<CompViz label="fallback" element="span" />
+</CompViz>
+
 ## API Reference
 
 <ApiTable />


### PR DESCRIPTION
## Linked Issue

Closes #2587

## Description

Implements a visual preview of the component anatomy to help understand how the component template is structured and how prefixed style props are applied.

