### PR TITLE
Remove redundant build step, we're already building postinstall

### DIFF
--- a/.github/workflows/release-next.yaml
+++ b/.github/workflows/release-next.yaml
@@ -22,8 +22,6 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install
-      - name: Build packages
-        run: pnpm build
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
Removed a basically duplicate build step in our CI pipeline that also builds playgrounds and other unneccesary packages.