### PR TITLE
docs: fix broken component links

### DIFF
--- a/packages/skeleton-react/CHANGELOG.md
+++ b/packages/skeleton-react/CHANGELOG.md
@@ -1,8 +1,8 @@
 # @skeletonlabs/skeleton-react
 
 ## 1.0.0-next.16
-### Minor Changes
 
+### Minor Changes
 
 - feat: Zag 1.0 ([#3257](https://github.com/skeletonlabs/skeleton/pull/3257))
 

--- a/packages/skeleton-svelte/CHANGELOG.md
+++ b/packages/skeleton-svelte/CHANGELOG.md
@@ -1,8 +1,8 @@
 # @skeletonlabs/skeleton-svelte
 
 ## 1.0.0-next.21
-### Minor Changes
 
+### Minor Changes
 
 - feat: Zag 1.0 ([#3257](https://github.com/skeletonlabs/skeleton/pull/3257))
 

--- a/packages/skeleton/CHANGELOG.md
+++ b/packages/skeleton/CHANGELOG.md
@@ -1,8 +1,8 @@
 # @skeletonlabs/skeleton
 
 ## 3.0.0-next.12
-### Patch Changes
 
+### Patch Changes
 
 - bugfix: fix css property typo in form-groups classes ([#3283](https://github.com/skeletonlabs/skeleton/pull/3283))
 

--- a/sites/next.skeleton.dev/src/content/docs/components/accordion/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/accordion/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Accordion
 description: Divide content into collapsible sections.
-srcSvelte: '/src/lib/components/Accordion'
-srcReact: '/src/lib/components/Accordion'
+srcSvelte: '/src/components/Accordion'
+srcReact: '/src/components/Accordion'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/accordion/'
 srcZag: 'https://zagjs.com/components/react/accordion'
 showDocsUrl: true

--- a/sites/next.skeleton.dev/src/content/docs/components/app-bar/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/app-bar/meta.mdx
@@ -1,7 +1,7 @@
 ---
 title: App Bar
 description: A header element for the top of your page layout.
-srcReact: '/src/lib/components/AppBar'
-srcSvelte: '/src/lib/components/AppBar'
+srcReact: '/src/components/AppBar'
+srcSvelte: '/src/components/AppBar'
 showDocsUrl: true
 ---

--- a/sites/next.skeleton.dev/src/content/docs/components/avatar/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/avatar/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Avatar
 description: An image with a fallback for representing the user.
-srcSvelte: '/src/lib/components/Avatar'
-srcReact: '/src/lib/components/Avatar'
+srcSvelte: '/src/components/Avatar'
+srcReact: '/src/components/Avatar'
 srcZag: 'https://zagjs.com/components/react/avatar'
 showDocsUrl: true
 ---

--- a/sites/next.skeleton.dev/src/content/docs/components/file-upload/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/file-upload/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: File Upload
 description: Allow upload of files with buttons or drag and drop.
-srcSvelte: '/src/lib/components/FileUpload'
-srcReact: '/src/lib/components/FileUpload'
+srcSvelte: '/src/components/FileUpload'
+srcReact: '/src/components/FileUpload'
 srcZag: 'https://zagjs.com/components/react/file-upload'
 showDocsUrl: true
 ---

--- a/sites/next.skeleton.dev/src/content/docs/components/navigation/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/navigation/meta.mdx
@@ -1,7 +1,7 @@
 ---
 title: Navigation
 description: Provides navigation interfaces for large, medium, and small screens.
-srcSvelte: '/src/lib/components/Navigation'
-srcReact: '/src/lib/components/Navigation'
+srcSvelte: '/src/components/Navigation'
+srcReact: '/src/components/Navigation'
 showDocsUrl: true
 ---

--- a/sites/next.skeleton.dev/src/content/docs/components/pagination/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/pagination/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Pagination
 description: Navigate between multiple pages of content.
-srcSvelte: '/src/lib/components/Pagination'
-srcReact: '/src/lib/components/Pagination'
+srcSvelte: '/src/components/Pagination'
+srcReact: '/src/components/Pagination'
 srcZag: 'https://zagjs.com/components/react/pagination'
 showDocsUrl: true
 ---

--- a/sites/next.skeleton.dev/src/content/docs/components/progress-ring/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/progress-ring/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Progress Ring
 description: A radial indicator showing progress or completion of a task.
-srcSvelte: '/src/lib/components/ProgressRing'
-srcReact: '/src/lib/components/ProgressRing'
+srcSvelte: '/src/components/ProgressRing'
+srcReact: '/src/components/ProgressRing'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/meter/'
 srcZag: 'https://zagjs.com/components/react/circular-progress'
 showDocsUrl: true

--- a/sites/next.skeleton.dev/src/content/docs/components/progress/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/progress/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Progress
 description: An indicator showing the progress or completion of a task.
-srcSvelte: '/src/lib/components/Progress'
-srcReact: '/src/lib/components/Progress'
+srcSvelte: '/src/components/Progress'
+srcReact: '/src/components/Progress'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/meter/'
 srcZag: 'https://zagjs.com/components/react/linear-progress'
 showDocsUrl: true

--- a/sites/next.skeleton.dev/src/content/docs/components/rating/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/rating/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Rating
 description: Create an visual representation of a numeric range.
-srcSvelte: '/src/lib/components/Rating'
-srcReact: '/src/lib/components/Rating'
+srcSvelte: '/src/components/Rating'
+srcReact: '/src/components/Rating'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/rating-group/'
 srcZag: 'https://zagjs.com/components/react/ratings'
 showDocsUrl: true

--- a/sites/next.skeleton.dev/src/content/docs/components/segment/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/segment/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Segment Control
 description: Capture input for a limited set of options.
-srcSvelte: '/src/lib/components/Segment'
-srcReact: '/src/lib/components/Segment'
+srcSvelte: '/src/components/Segment'
+srcReact: '/src/components/Segment'
 srcZag: 'https://zagjs.com/components/react/segmented-control'
 showDocsUrl: true
 ---

--- a/sites/next.skeleton.dev/src/content/docs/components/slider/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/slider/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Slider
 description: Capture input from a range of values.
-srcSvelte: '/src/lib/components/Slider'
-srcReact: '/src/lib/components/Slider'
+srcSvelte: '/src/components/Slider'
+srcReact: '/src/components/Slider'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/slider/'
 srcZag: 'https://zagjs.com/components/react/slider'
 showDocsUrl: true

--- a/sites/next.skeleton.dev/src/content/docs/components/switch/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/switch/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Switch
 description: A control for toggling between checked states.
-srcSvelte: '/src/lib/components/Switch'
-srcReact: '/src/lib/components/Switch'
+srcSvelte: '/src/components/Switch'
+srcReact: '/src/components/Switch'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/switch/'
 srcZag: 'https://zagjs.com/components/react/switch'
 showDocsUrl: true

--- a/sites/next.skeleton.dev/src/content/docs/components/tabs/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/tabs/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Tabs
 description: Use tabs to quickly switch between different views and pages.
-srcSvelte: '/src/lib/components/Tabs'
-srcReact: '/src/lib/components/Tabs'
+srcSvelte: '/src/components/Tabs'
+srcReact: '/src/components/Tabs'
 srcAlly: 'https://www.w3.org/WAI/ARIA/apg/patterns/tabs'
 srcZag: 'https://zagjs.com/components/react/tabs'
 showDocsUrl: true

--- a/sites/next.skeleton.dev/src/content/docs/components/tags-input/meta.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/components/tags-input/meta.mdx
@@ -1,8 +1,8 @@
 ---
 title: Tags Input
 description: Allows input of multiple values.
-srcSvelte: '/src/lib/components/TagsInput'
-srcReact: '/src/lib/components/TagsInput'
+srcSvelte: '/src/components/TagsInput'
+srcReact: '/src/components/TagsInput'
 srcZag: 'https://zagjs.com/components/react/tags-input'
 showDocsUrl: true
 ---


### PR DESCRIPTION
After #3257 got merged the `src/lib` structure was reduced to `src`, the doc links however weren't updated (my bad). This PR fixes that.