### PR TITLE
Add files to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@
 build
 dist
 pagefind
+CHANGELOG.md
+pnpm-lock.yaml


### PR DESCRIPTION
Remove CHANGELOG and lockfiles to prettier ignore, unneccesary formatting. As pointed out by @endigo9740 in #3292.