### PR TITLE
fix peer dep

### DIFF
--- a/.changeset/every-bikes-make.md
+++ b/.changeset/every-bikes-make.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+chore: Update Svelte peer dependency to 5.20.0 or higher because we rely on `$props.id` (which was released in 5.20.0)
+  

--- a/packages/skeleton-svelte/package.json
+++ b/packages/skeleton-svelte/package.json
@@ -47,7 +47,7 @@
 		"@zag-js/tooltip": "catalog:"
 	},
 	"peerDependencies": {
-		"svelte": "^5.0.0"
+		"svelte": "^5.20.0"
 	},
 	"devDependencies": {
 		"@skeletonlabs/skeleton": "workspace:*",


### PR DESCRIPTION
## Linked Issue

Closes #3309 

## Description

Bumps the `peerDependency` `svelte` to `5.20.0` because `$props.id` was released in `5.20.0`.
