### PR TITLE
Fix double hyphens

### DIFF
--- a/sites/next.skeleton.dev/src/content/docs/design/themes.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/design/themes.mdx
@@ -132,8 +132,8 @@ Your app's light and dark mode background color values can be adjusted using the
 
 ```css title="app.css"
 [data-theme='cerberus'] {
-	—body-background-color: 'pink';
-	—body-background-color-dark: 'green';
+	--body-background-color: pink;
+	--body-background-color-dark: green;
 }
 ```
 

--- a/sites/next.skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
@@ -144,6 +144,22 @@ To allow for a common preview to have framework specific code, use the `codeReac
 </Preview>
 ```
 
+For generic code that is not framework specific, such as an Astro component along with JavaScript, use the `code` slot.
+
+```astro
+<Preview client:load>
+  <Fragment slot="preview"><Example /></Fragment>
+  <Preview>
+    <Fragment slot="preview">
+      <Example />
+    </Fragment>
+    <Fragment slot="code">
+      <Code code={ExampleGenericRaw} lang="astro" />
+    </Fragment>
+  </Preview>
+</Preview>
+```
+
 > TIP: For React or Svelte components, make sure to use [Astro's hydration directives](https://docs.astro.build/en/guides/framework-components/#hydrating-interactive-components).
 
 ### Anatomy

--- a/sites/next.skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
@@ -148,15 +148,15 @@ For generic code that is not framework specific, such as an Astro component alon
 
 ```astro
 <Preview client:load>
-  <Fragment slot="preview"><Example /></Fragment>
-  <Preview>
-    <Fragment slot="preview">
-      <Example />
-    </Fragment>
-    <Fragment slot="code">
-      <Code code={ExampleGenericRaw} lang="astro" />
-    </Fragment>
-  </Preview>
+	<Fragment slot="preview"><Example /></Fragment>
+	<Preview>
+		<Fragment slot="preview">
+			<Example />
+		</Fragment>
+		<Fragment slot="code">
+			<Code code={ExampleGenericRaw} lang="astro" />
+		</Fragment>
+	</Preview>
 </Preview>
 ```
 

--- a/sites/next.skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
+++ b/sites/next.skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
@@ -125,26 +125,7 @@ import ExampleRaw from '@examples/foo/Example.astro?raw';
 
 #### Framework Specific Code
 
-To allow for a common preview to have framework specific code, use the `codeReact` and `codeSvelte` slots.
-
-```astro
-<Preview client:load>
-	<Fragment slot="preview"><Example /></Fragment>
-	<Preview>
-		<Fragment slot="preview">
-			<Example />
-		</Fragment>
-		<Fragment slot="codeReact">
-			<Code code={ExampleSvelteRaw} lang="tsx" />
-		</Fragment>
-		<Fragment slot="codeSvelte">
-			<Code code={ExampleReactRaw} lang="svelte" />
-		</Fragment>
-	</Preview>
-</Preview>
-```
-
-For generic code that is not framework specific, such as an Astro component along with JavaScript, use the `code` slot.
+To allow for a common preview to have framework specific code, use the `codeReact` and `codeSvelte` slots. For generic code that is not framework specific, such as an Astro component along with JavaScript, use the `code` slot instead.
 
 ```astro
 <Preview client:load>
@@ -155,6 +136,12 @@ For generic code that is not framework specific, such as an Astro component alon
 		</Fragment>
 		<Fragment slot="code">
 			<Code code={ExampleGenericRaw} lang="astro" />
+		</Fragment>
+		<Fragment slot="codeReact">
+			<Code code={ExampleSvelteRaw} lang="tsx" />
+		</Fragment>
+		<Fragment slot="codeSvelte">
+			<Code code={ExampleReactRaw} lang="svelte" />
 		</Fragment>
 	</Preview>
 </Preview>


### PR DESCRIPTION
## Linked Issue

Closes #3300

## Description

Double hyphens are being rendered into en dash

Need to fix [this](https://github.com/skeletonlabs/skeleton/issues/3300#issuecomment-2702911432)

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [x] This PR targets the `dev` branch (NEVER `master`)
- [x] Documentation reflects all relevant changes
- [x] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [x] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [x] Ensure Prettier linting is current - run `pnpm format`
- [x] All test cases are passing - run `pnpm test`
- [x] Includes a changeset (if relevant; see above)
