### PR TITLE
Restore button hover states

### DIFF
--- a/.changeset/calm-adults-lay.md
+++ b/.changeset/calm-adults-lay.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+chore: Restore Button and Chip default hover states
+  

--- a/packages/skeleton/src/utilities/buttons.css
+++ b/packages/skeleton/src/utilities/buttons.css
@@ -23,6 +23,13 @@
 	height: --spacing(9);
 	padding-inline: --spacing(4);
 	padding-block: --spacing(2);
+
+	@variant hover {
+		filter: brightness(125%);
+		@variant dark {
+			filter: brightness(75%);
+		}
+	}
 }
 
 @utility btn-icon {
@@ -47,6 +54,13 @@
 	line-height: --spacing(9);
 	width: --spacing(9);
 	height: --spacing(9);
+
+	@variant hover {
+		filter: brightness(125%);
+		@variant dark {
+			filter: brightness(75%);
+		}
+	}
 }
 
 @utility btn-group {

--- a/packages/skeleton/src/utilities/chips.css
+++ b/packages/skeleton/src/utilities/chips.css
@@ -25,7 +25,7 @@
 	padding-block: --spacing(2);
 
 	@variant hover {
-		filter: brightness(105%);
+		filter: brightness(125%);
 		@variant dark {
 			filter: brightness(75%);
 		}
@@ -56,7 +56,7 @@
 	transition-duration: var(--default-transition-duration);
 
 	@variant hover {
-		filter: brightness(105%);
+		filter: brightness(125%);
 		@variant dark {
 			filter: brightness(75%);
 		}


### PR DESCRIPTION
## Linked Issue

#3316

## Description

Restores and ensure matching styles for default `.btn` and `.chip` hover states.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.