### PR TITLE
Input-Group style fixes

### DIFF
--- a/.changeset/grumpy-nights-design.md
+++ b/.changeset/grumpy-nights-design.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Resolved a number of small display issues with Input Groups

--- a/packages/skeleton/src/utilities/form-groups.css
+++ b/packages/skeleton/src/utilities/form-groups.css
@@ -20,7 +20,7 @@
 	}
 }
 
-/* Child Elements -- */
+/* Children: Cell --- */
 
 @utility ig-cell {
 	font-size: var(--text-sm);
@@ -30,16 +30,58 @@
 	padding-inline: --spacing(4);
 }
 
+/* Children: Form Elements --- */
+/* We recreate a subset of form element styles here */
+/* These are purpose-built to work in the group */
+
 @utility ig-input {
 	--tw-ring-inset: inset;
 	background-color: transparent;
 	border-width: 0;
+
+	@variant active {
+		--tw-ring-color: var(--color-primary-500);
+	}
+	@variant focus {
+		--tw-ring-color: var(--color-primary-500);
+	}
+	@variant focus-within {
+		--tw-ring-color: var(--color-primary-500);
+	}
 }
 
 @utility ig-select {
 	--tw-ring-inset: inset;
 	background-color: transparent;
 	border-width: 0;
+
+	@variant active {
+		--tw-ring-color: var(--color-primary-500);
+	}
+	@variant focus {
+		--tw-ring-color: var(--color-primary-500);
+	}
+	@variant focus-within {
+		--tw-ring-color: var(--color-primary-500);
+	}
+
+	/* Option --- */
+
+	& option {
+		background-color: var(--color-surface-50-950);
+		color: var(--color-surface-950-50);
+		border-radius: var(--radius-base);
+		font-size: var(--text-base);
+		line-height: --spacing(9);
+		height: --spacing(9);
+		padding: --spacing(2);
+	}
+
+	& option:checked {
+		/* https://stackoverflow.com/questions/50618602/change-color-of-selected-option-in-select-multiple */
+		background-image: linear-gradient(0deg, var(--color-primary-500) 0%, var(--color-primary-500) 100%);
+		color: var(--color-primary-contrast-950-50);
+	}
 }
 
 @utility ig-btn {
@@ -54,4 +96,14 @@
 	gap: --spacing(2);
 	padding-inline: --spacing(4);
 	white-space: nowrap;
+
+	@variant active {
+		--tw-ring-color: var(--color-primary-500);
+	}
+	@variant focus {
+		--tw-ring-color: var(--color-primary-500);
+	}
+	@variant focus-within {
+		--tw-ring-color: var(--color-primary-500);
+	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #3280
Closes #3294

## Description

Resolves a number of small style issues with `input-group` elements.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.