### PR TITLE
bugfix: disable bg-noise for now

### DIFF
--- a/sites/next.skeleton.dev/src/styles/app.css
+++ b/sites/next.skeleton.dev/src/styles/app.css
@@ -48,11 +48,12 @@ html {
 	justify-content: center;
 }
 
-.bg-noise {
+/* TODO: Fix the blend mode on iOS: https://github.com/skeletonlabs/skeleton/issues/3279 */
+/* .bg-noise {
 	background-image: url('../images/noise-light.png');
 	background-repeat: repeat;
 	background-blend-mode: overlay;
-}
+} */
 
 /* Astro Components --- */
 


### PR DESCRIPTION
## Linked Issue

Works around [#safari](https://github.com/skeletonlabs/skeleton/issues/3279)

## Description

Disables the `bg-noise` for now.