### PR TITLE
fix(progress-ring): Fix progress ring being 100% on Safari

### DIFF
--- a/.changeset/metal-ravens-tell.md
+++ b/.changeset/metal-ravens-tell.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+"@skeletonlabs/skeleton-react": patch
+---
+
+bugfix: progress ring safari 100%
+  

--- a/packages/skeleton-react/src/components/ProgressRing/ProgressRing.tsx
+++ b/packages/skeleton-react/src/components/ProgressRing/ProgressRing.tsx
@@ -63,8 +63,9 @@ export const ProgressRing: FC<ProgressRingProps> = ({
 			{/* SVG */}
 			<svg
 				{...api.getCircleProps()}
+				viewBox="0 0 100 100"
 				className={`${svgBase} ${svgClasses} ${rxAnimCircle}`}
-				style={{ '--size': '100%', '--thickness': strokeWidth } as React.CSSProperties}
+				style={{ '--size': '100px', '--thickness': strokeWidth } as React.CSSProperties}
 				data-testid="progress-ring-svg"
 			>
 				{/* Track */}

--- a/packages/skeleton-svelte/src/components/ProgressRing/ProgressRing.svelte
+++ b/packages/skeleton-svelte/src/components/ProgressRing/ProgressRing.svelte
@@ -65,8 +65,9 @@
 	<!-- SVG -->
 	<svg
 		{...api.getCircleProps()}
+		viewBox="0 0 100 100"
 		class="{svgBase} {svgClasses} {rxAnimCircle}"
-		style="--size:100%;--thickness:{strokeWidth};"
+		style="--size:100px;--thickness:{strokeWidth};"
 		data-testid="progress-ring-svg"
 	>
 		<!-- Track -->


### PR DESCRIPTION
## Linked Issue

Closes #3222
Partially improves #2991

## Description

Fixes the progress by adding @nullpointerexceptionkek's suggestion of applying the `viewBox` prop.
