### PR TITLE
chore: update CI for release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
 	"prettier": false,
 	"linked": [],
 	"access": "public",
-	"baseBranch": "dev",
+	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"privatePackages": {
 		"tag": false,

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "@skeletonlabs/skeleton": "2.10.0",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,14 @@
-name: Publish Skeleton (next)
+name: Publish Skeleton
 on:
   push:
     branches:
-      - next
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Build & Publish @next Release
+    name: Build & Publish Release
     if: github.repository == 'skeletonlabs/skeleton'
     runs-on: ubuntu-latest
     steps:
@@ -26,8 +26,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          commit: 'chore(next-release): version package'
-          title: 'chore(next-release): version package'
+          commit: 'chore(release): version package'
+          title: 'chore(release): version package'
           publish: pnpm changeset:publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Publish Skeleton
+name: Publish Skeleton (@latest)
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Build & Publish Release
+    name: Build & Publish Release (@latest)
     if: github.repository == 'skeletonlabs/skeleton'
     runs-on: ubuntu-latest
     steps:
@@ -26,8 +26,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          commit: 'chore(release): version package'
-          title: 'chore(release): version package'
+          commit: 'chore(latest-release): version package'
+          title: 'chore(latest-release): version package'
           publish: pnpm changeset:publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

- replaces the `next` release workflow for our a `main` one to publish `@latest`
- exits prerelease mode

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [ ] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [ ] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [ ] Documentation should be updated to describe all relevant changes
- [ ] Run `pnpm check` in the root of the monorepo
- [ ] Run `pnpm format` in the root of the monorepo
- [ ] Run `pnpm lint` in the root of the monorepo
- [ ] Run `pnpm test` in the root of the monorepo
- [ ] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
