### PR TITLE
Remove selected options custom styles

### DIFF
--- a/.changeset/vast-icons-thank.md
+++ b/.changeset/vast-icons-thank.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Remove redundant styling for selected `option` in `select` elements
+  

--- a/packages/skeleton/src/utilities/form-selects.css
+++ b/packages/skeleton/src/utilities/form-selects.css
@@ -92,10 +92,4 @@
 		height: --spacing(9);
 		padding: --spacing(2);
 	}
-
-	& option:checked {
-		/* https://stackoverflow.com/questions/50618602/change-color-of-selected-option-in-select-multiple */
-		background-image: linear-gradient(0deg, var(--color-primary-500) 0%, var(--color-primary-500) 100%) !important;
-		color: var(--color-primary-contrast-950-50) !important;
-	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #3400 

## Description

I don't see why should the style rules deleted in this PR should exist.

(Edit from Hugo, this is the difference on windows, for reference for @endigo9740):

Before (dark):
![image](https://github.com/user-attachments/assets/38685620-08dd-47a9-a657-dee02e0cec7a)
After (dark):
![image](https://github.com/user-attachments/assets/35f66297-c011-4a93-92ef-fed19e1bb785)
Before (light):
![image](https://github.com/user-attachments/assets/0eaa4c6d-4645-497b-8106-83e835a7a4a2)
After (light):
![image](https://github.com/user-attachments/assets/afe0a216-c27d-4812-8143-c7becd648570)


## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
