### PR TITLE
fix: add missing spacing in table of contents

### DIFF
--- a/.changeset/cool-beers-call.md
+++ b/.changeset/cool-beers-call.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton.dev": patch
+---
+
+fix: add missing spacing in table of contents

--- a/.changeset/cool-beers-call.md
+++ b/.changeset/cool-beers-call.md
@@ -1,5 +1,0 @@
----
-"@skeletonlabs/skeleton.dev": patch
----
-
-fix: add missing spacing in table of contents

--- a/sites/skeleton.dev/src/components/docs/TableOfContents.astro
+++ b/sites/skeleton.dev/src/components/docs/TableOfContents.astro
@@ -23,7 +23,7 @@ function setDepthClass(depth: number) {
 {
 	headings.length > 0 && (
 		<nav class="text-sm space-y-2">
-			<span class="font-bold">On This Page</span>
+			<div class="font-bold">On This Page</div>
 			<ul class="space-y-2">
 				<li>
 					<a href={`#_top`} class="anchor block">

--- a/sites/skeleton.dev/src/examples/guides/cookbook/table-of-contents/Example.astro
+++ b/sites/skeleton.dev/src/examples/guides/cookbook/table-of-contents/Example.astro
@@ -38,7 +38,7 @@ function setIndentationClass(depth: number) {
 	<!-- Table of Contents -->
 	<div class="text-sm space-y-2">
 		<!-- Label -->
-		<span class="font-bold">On This Page</span>
+		<div class="font-bold">On This Page</div>
 		<!-- Links -->
 		<ul class="space-y-2">
 			<!-- Consider a fixed scroll position at the top of your page layouts. -->


### PR DESCRIPTION
## Linked Issue

Closes #3431

## Description

Adds back missing spacing in table of contents components (both on site and cookbook) as it was removed by a Tailwind v4 breaking change (see issue).

If the title should keep being a `<span>`, then `space-y` should be removed and `mt-2` added to the content instead.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] (N/A) Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] (N/A) If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
