### PR TITLE
chore: replace v3 next branch mention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@ Closes #{issueNumber}
 Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).
 
 - [ ] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
+- [ ] Contributions should target the `main` branch
 - [ ] Documentation should be updated to describe all relevant changes
 - [ ] Run `pnpm check` in the root of the monorepo
 - [ ] Run `pnpm format` in the root of the monorepo

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,6 @@ Closes #{issueNumber}
 Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).
 
 - [ ] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
-- [ ] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
 - [ ] Documentation should be updated to describe all relevant changes
 - [ ] Run `pnpm check` in the root of the monorepo
 - [ ] Run `pnpm format` in the root of the monorepo


### PR DESCRIPTION
## Description

I don't think this applies anymore

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- **this v**
- [ ] Skeleton v3 contributions must target the `next` branch (NEVER `dev` or `master`)
- **this ^**
- [ ] (N/A) Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
