### PR TITLE
fix: resolve conflicting hover styles for tabs control

### DIFF
--- a/.changeset/giant-cycles-care.md
+++ b/.changeset/giant-cycles-care.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-react": patch
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+fix: resolve conflicting hover styles for tabs control
+  

--- a/packages/skeleton-react/src/components/Tabs/Tabs.tsx
+++ b/packages/skeleton-react/src/components/Tabs/Tabs.tsx
@@ -59,13 +59,13 @@ const TabsControl: FC<TabsControlProps> = ({
 	translateX = 'translate-y-[1px]',
 	classes = '',
 	// Label
-	labelBase = 'btn hover:preset-tonal-primary',
+	labelBase = 'btn hover:preset-tonal-primary !filter-none',
 	labelClasses = '',
 	// State
-	stateInactive = '[&:not(:hover)]:opacity-50',
-	stateActive = 'border-b-surface-950-50 opacity-100',
-	stateLabelInactive = '',
-	stateLabelActive = '',
+	stateInactive = '',
+	stateActive = 'border-b-surface-950-50',
+	stateLabelInactive = '[&:not(:hover)]:opacity-50',
+	stateLabelActive = 'opacity-100',
 	// Nodes
 	lead,
 	// Children

--- a/packages/skeleton-react/src/components/Tabs/Tabs.tsx
+++ b/packages/skeleton-react/src/components/Tabs/Tabs.tsx
@@ -59,7 +59,7 @@ const TabsControl: FC<TabsControlProps> = ({
 	translateX = 'translate-y-[1px]',
 	classes = '',
 	// Label
-	labelBase = 'btn hover:preset-tonal-primary !filter-none',
+	labelBase = 'flex items-center justify-center gap-2 py-1 px-4 transition-all rounded-base hover:preset-tonal-primary',
 	labelClasses = '',
 	// State
 	stateInactive = '',

--- a/packages/skeleton-svelte/src/components/Tabs/TabsControl.svelte
+++ b/packages/skeleton-svelte/src/components/Tabs/TabsControl.svelte
@@ -9,13 +9,13 @@
 		translateX = 'translate-y-[1px]',
 		classes = '',
 		// Label
-		labelBase = 'btn hover:preset-tonal-primary',
+		labelBase = 'btn hover:preset-tonal-primary !filter-none',
 		labelClasses = '',
 		// State
-		stateInactive = '[&:not(:hover)]:opacity-50',
-		stateActive = 'border-b-surface-950-50 opacity-100',
-		stateLabelInactive = '',
-		stateLabelActive = '',
+		stateInactive = '',
+		stateActive = 'border-b-surface-950-50',
+		stateLabelInactive = '[&:not(:hover)]:opacity-50',
+		stateLabelActive = 'opacity-100',
 		// Snippets
 		lead,
 		children,

--- a/packages/skeleton-svelte/src/components/Tabs/TabsControl.svelte
+++ b/packages/skeleton-svelte/src/components/Tabs/TabsControl.svelte
@@ -9,7 +9,7 @@
 		translateX = 'translate-y-[1px]',
 		classes = '',
 		// Label
-		labelBase = 'btn hover:preset-tonal-primary !filter-none',
+		labelBase = 'flex items-center justify-center gap-2 py-1 px-4 transition-all rounded-base hover:preset-tonal-primary',
 		labelClasses = '',
 		// State
 		stateInactive = '',


### PR DESCRIPTION
## Linked Issue

Closes #3429

## Description

There were two issues with the tab controls hover styles:
1. There was a hover style on the outer element, and one for the label, causing only one to trigger when the cursor was placed inside the outer element, but not the inner. Additionally, one hover style had a transition and the other not, so it flickered regardless. This PR moves the outer hover style to the inner element.
2. The `btn` sets receives `filter: brightness(125%)` on hover, which conflicts with `hover:preset-tonal-primary`, causing it to become white instead of the intended color. This PR removes this additional filter.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [ ] (N/A) Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
3. Run `pnpm changeset` and follow the prompts
4. Commit and push the changeset before flagging your PR review for review.
