### PR TITLE
Bugfix for Select arrow and padding

### DIFF
--- a/.changeset/pink-teeth-throw.md
+++ b/.changeset/pink-teeth-throw.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Resolve issue with Select arrows overlapping text
+  

--- a/packages/skeleton/src/utilities/form-selects.css
+++ b/packages/skeleton/src/utilities/form-selects.css
@@ -17,7 +17,12 @@
 	font-size: var(--text-base);
 	line-height: var(--text-base--line-height);
 	padding-block: --spacing(1);
-	padding-inline: --spacing(3);
+
+	/*
+		WARNING
+		Do not set `padding-inline` or it breaks
+		the native drop-down arrow for selects.
+	*/
 
 	/* Edges */
 	outline-color: transparent;


### PR DESCRIPTION
## Linked Issue

Closes #3395

## Description

Removes `padding-inline` - which was unintentionally affecting the native arrow and allowing it to overlap text.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
