### PR TITLE
fix: apply card hover style correctly

### DIFF
--- a/.changeset/few-vans-doubt.md
+++ b/.changeset/few-vans-doubt.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+fix: apply card hover style correctly
+  

--- a/packages/skeleton/src/utilities/cards.css
+++ b/packages/skeleton/src/utilities/cards.css
@@ -3,7 +3,7 @@
 @utility card {
 	border-radius: var(--radius-container);
 
-	& a {
+	&a {
 		/* Transitions (all) */
 		transition-property: all;
 		transition-timing-function: var(--default-transition-timing-function);


### PR DESCRIPTION
## Linked Issue

Closes #3448 

## Description

Make the hover style apply correctly (to the card, not any links that may be in it).

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] N/A Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
