### PR TITLE
bugfix: simplify script parsing.

### DIFF
--- a/.changeset/slick-waves-throw.md
+++ b/.changeset/slick-waves-throw.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-cli": patch
+---
+
+fix: Simplify `script` parsing in Svelte modules
+  


### PR DESCRIPTION
This thread on our Discrd: https://discord.com/channels/1003691521280856084/1352848490656432188 shows our migration CLI choking on `script` tag stuff which was manually parsed. Turns out Svelte provides these anyways, so we swap out our manually (janky) way of parsing it.