### PR TITLE
fix missing color pairings

### DIFF
--- a/playgrounds/skeleton-core/src/pages/design/colors.astro
+++ b/playgrounds/skeleton-core/src/pages/design/colors.astro
@@ -52,8 +52,14 @@ const colorPairings = [
 								const light = pairing[0];
 								const dark = pairing[1];
 								return (
-									<div class="w-full p-2 flex justify-center items-center" style={`background: var(--color-${name}-${light}-${dark})`}>
-										<strong class="text-xs text-center" style={`color: var(--color-${name}-contrast-${light}-${dark})`}>
+									<div
+										class="w-full p-2 flex justify-center items-center"
+										style={`background: light-dark(var(--color-${name}-${light}), var(--color-${name}-${dark})`}
+									>
+										<strong
+											class="text-xs text-center"
+											style={`color: light-dark(var(--color-${name}-contrast-${light}),var(--color-${name}-contrast-${dark}))`}
+										>
 											{light} | {dark}
 										</strong>
 									</div>


### PR DESCRIPTION
## Linked Issue

Closes #3447 

## Description

fixes the color pairings section in the `skeleton-core` playground:
![426045379-9a3748c2-1041-42c5-ba09-ae6b809e0cb2](https://github.com/user-attachments/assets/8a8b8494-2d98-4e27-973d-984a01c2f7e6)
fixed:
![Screenshot 2025-03-24 191615](https://github.com/user-attachments/assets/faaff6ea-e00d-4833-8ef6-1d7025c9b03d)


## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
