### PR TITLE
fix: select option checked styling

### DIFF
--- a/packages/skeleton/src/utilities/form-selects.css
+++ b/packages/skeleton/src/utilities/form-selects.css
@@ -96,5 +96,9 @@
 		line-height: --spacing(9);
 		height: --spacing(9);
 		padding: --spacing(2);
+
+		&:checked {
+			background-color: var(--color-primary-500);
+		}
 	}
 }


### PR DESCRIPTION
## Description

A styling for checked options is missing. It only shows the checked option(s) when the select is focused.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset
