### PR TITLE
fix(FileUpload): conflicting each key

### DIFF
--- a/.changeset/plain-jobs-think.md
+++ b/.changeset/plain-jobs-think.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+fix(FileUpload): Change `#each` key from `file.name` to `file` (Prevents name conflicts).
+  

--- a/packages/skeleton-svelte/src/components/FileUpload/FileUpload.svelte
+++ b/packages/skeleton-svelte/src/components/FileUpload/FileUpload.svelte
@@ -101,7 +101,7 @@
 	{#if !children}
 		<ul {...api.getItemGroupProps()} class="{filesListBase} {filesListClasses}" data-testid="uploader-files-list">
 			<!-- Loop Files -->
-			{#each api.acceptedFiles as file (file.name)}
+			{#each api.acceptedFiles as file (file)}
 				<!-- File -->
 				<li
 					{...api.getItemProps({ file })}


### PR DESCRIPTION
Uses the `file` object instead of `file.name` to prevent the component crashing when passing in duplicate file name's.
Using the object works because every object created is a unique referenced "thing" in memory and thus preventing conflicts to ever happen, even if all the properties have the same value.

See: https://discord.com/channels/1003691521280856084/1356229397929267362