### PR TITLE
Append body selector to CSS example for theme docs - see: Theme background examples should target `<body>` #3464

### DIFF
--- a/sites/skeleton.dev/src/content/docs/design/themes.mdx
+++ b/sites/skeleton.dev/src/content/docs/design/themes.mdx
@@ -131,7 +131,7 @@ If your application supports multiple themes, you may isolate selection using th
 Your app's light and dark mode background color values can be adjusted using the following [theme properties](/docs/get-started/core-api#colors).
 
 ```css title="app.css"
-[data-theme='cerberus'] {
+[data-theme='cerberus'] body {
 	--body-background-color: pink;
 	--body-background-color-dark: green;
 }
@@ -140,7 +140,7 @@ Your app's light and dark mode background color values can be adjusted using the
 Background images are supported, including CSS mesh gradients. The following example adheres to theme colors.
 
 ```css title="app.css"
-[data-theme='cerberus'] {
+[data-theme='cerberus'] body {
 	background-image:
 		radial-gradient(at 24% 25%, color-mix(in oklab, var(--color-primary-500) 30%, transparent) 0px, transparent 30%),
 		radial-gradient(at 35% 13%, color-mix(in oklab, var(--color-success-500) 18%, transparent) 0px, transparent 30%),


### PR DESCRIPTION
## Linked Issue

Closes #3464 

## Description

Just updates docs to use 'body' in selector to demonstrate themeing in CSS examples.

See screencapture below:
![image](https://github.com/user-attachments/assets/4a001d9f-8b69-4c7f-9d4e-595824b27f78)


## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
