### PR TITLE
docs: mark toast as beta

### DIFF
--- a/sites/skeleton.dev/src/content.config.ts
+++ b/sites/skeleton.dev/src/content.config.ts
@@ -13,6 +13,7 @@ const docs = defineCollection({
 		srcReact: z.string().optional(),
 		srcAlly: z.string().optional(),
 		srcZag: z.string().optional(),
+		stability: z.enum(['alpha', 'beta', 'stable']).optional().default('stable'),
 		showDocsUrl: z.boolean().optional().default(false),
 		pubDate: z.date().optional(),
 		tags: z.array(z.string()).optional(),

--- a/sites/skeleton.dev/src/content/docs/components/toast/meta.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/toast/meta.mdx
@@ -1,5 +1,5 @@
 ---
-title: Toast
+title: Toast (beta)
 description: Build a toast notification system.
 srcSvelte: '/src/components/Toast'
 srcReact: '/src/components/Toast'


### PR DESCRIPTION
## Linked Issue

Partially closes #3469

We should actually add the tags to the sidebar once #3479 is merged.

## Description

Adds `stability` prop to `content.config` and patches toast title to include `(beta)`

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [ ] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [ ] Contributions should target the `main` branch
- [ ] Documentation should be updated to describe all relevant changes
- [ ] Run `pnpm check` in the root of the monorepo
- [ ] Run `pnpm format` in the root of the monorepo
- [ ] Run `pnpm lint` in the root of the monorepo
- [ ] Run `pnpm test` in the root of the monorepo
- [ ] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
