### PR TITLE
feat: add hidden input for TagsInput

### DIFF
--- a/.changeset/lovely-carrots-enjoy.md
+++ b/.changeset/lovely-carrots-enjoy.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-svelte": minor
+"@skeletonlabs/skeleton-react": minor
+---
+
+feat: add hidden input for TagsInput
+  

--- a/packages/skeleton-react/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/skeleton-react/src/components/TagsInput/TagsInput.test.tsx
@@ -12,10 +12,10 @@ describe('<Switch>', () => {
 		expect(component).toBeInTheDocument();
 	});
 
-	it("should render with a value", () => {
+	it('should render with a value', () => {
 		const { getByTestId } = render(<TagsInput value={flavors} />);
 		const input = getByTestId('tags-input');
-		expect(input).toHaveValue(flavors.join(", "));
+		expect(input).toHaveValue(flavors.join(', '));
 	});
 
 	it('should render the component with an custom delete icon', () => {

--- a/packages/skeleton-react/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/skeleton-react/src/components/TagsInput/TagsInput.test.tsx
@@ -12,6 +12,12 @@ describe('<Switch>', () => {
 		expect(component).toBeInTheDocument();
 	});
 
+	it("should render with a value", () => {
+		const { getByTestId } = render(<TagsInput value={flavors} />);
+		const input = getByTestId('tags-input');
+		expect(input).toHaveValue(flavors.join(", "));
+	});
+
 	it('should render the component with an custom delete icon', () => {
 		const testIcon = 'testIconDelete';
 		const { getAllByTestId } = render(<TagsInput value={flavors} buttonDelete={testIcon} />);

--- a/packages/skeleton-react/src/components/TagsInput/TagsInput.tsx
+++ b/packages/skeleton-react/src/components/TagsInput/TagsInput.tsx
@@ -49,6 +49,8 @@ export const TagsInput: FC<TagsInputProps> = ({
 		<div {...api.getRootProps()} className={`${base} ${padding} ${gap} ${rxDisabled} ${classes}`} data-testid="tags">
 			{/* Input */}
 			<input {...api.getInputProps()} placeholder={placeholder} className={`${inputBase} ${inputClasses}`} data-testid="tags-input-add" />
+			{/* Hidden Input */}
+			<input {...api.getHiddenInputProps()} data-testid="tags-input" />
 			{/* Tag List */}
 			{api.value.length > 0 && (
 				<div className={`${tagListBase} ${tagListClasses}`} data-testid="tags-list">

--- a/packages/skeleton-svelte/src/components/TagsInput/TagsInput.svelte
+++ b/packages/skeleton-svelte/src/components/TagsInput/TagsInput.svelte
@@ -52,6 +52,8 @@
 <div {...api.getRootProps()} class="{base} {padding} {gap} {rxDisabled} {classes}" data-testid="tags">
 	<!-- Input -->
 	<input {...api.getInputProps()} {placeholder} class="{inputBase} {inputClasses}" data-testid="tags-input-add" />
+	<!-- Hidden Input -->
+	<input {...api.getHiddenInputProps()} data-testid="tags-input" />
 	<!-- Tag List -->
 	{#if api.value.length > 0}
 		<div class="{tagListBase} {tagListClasses}" data-testid="tags-list">

--- a/packages/skeleton-svelte/src/components/TagsInput/TagsInput.test.ts
+++ b/packages/skeleton-svelte/src/components/TagsInput/TagsInput.test.ts
@@ -7,6 +7,7 @@ import { TagsInput } from '../../index.js';
 describe('TagsInput', () => {
 	const testIds = {
 		root: 'tags',
+		input: 'tags-input',
 		inputAdd: 'tags-input-add',
 		delete: 'tag-delete'
 	};
@@ -18,6 +19,12 @@ describe('TagsInput', () => {
 		render(TagsInput, { ...commonProps });
 		const component = screen.getByTestId(testIds.root);
 		expect(component).toBeInTheDocument();
+	});
+
+	it("Should render with a value", () => {
+		render(TagsInput, { ...commonProps });
+		const input = screen.getByTestId(testIds.input);
+		expect(input).toHaveValue(commonProps.value.join(", "));
 	});
 
 	it('should render the `buttonDelete` snippet', () => {

--- a/packages/skeleton-svelte/src/components/TagsInput/TagsInput.test.ts
+++ b/packages/skeleton-svelte/src/components/TagsInput/TagsInput.test.ts
@@ -21,10 +21,10 @@ describe('TagsInput', () => {
 		expect(component).toBeInTheDocument();
 	});
 
-	it("Should render with a value", () => {
+	it('Should render with a value', () => {
 		render(TagsInput, { ...commonProps });
 		const input = screen.getByTestId(testIds.input);
-		expect(input).toHaveValue(commonProps.value.join(", "));
+		expect(input).toHaveValue(commonProps.value.join(', '));
 	});
 
 	it('should render the `buttonDelete` snippet', () => {

--- a/packages/skeleton-svelte/src/components/TagsInput/TagsInput.test.ts
+++ b/packages/skeleton-svelte/src/components/TagsInput/TagsInput.test.ts
@@ -21,7 +21,7 @@ describe('TagsInput', () => {
 		expect(component).toBeInTheDocument();
 	});
 
-	it('Should render with a value', () => {
+	it('should render with a value', () => {
 		render(TagsInput, { ...commonProps });
 		const input = screen.getByTestId(testIds.input);
 		expect(input).toHaveValue(commonProps.value.join(', '));


### PR DESCRIPTION
## Linked Issue

Closes #3460 

## Description

Add hidden input to `TagsInput` component, allowing the value to be submitted in a form.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
