### PR TITLE
fix: correctly apply text scaling to base body font

### DIFF
--- a/.changeset/thirty-stars-sip.md
+++ b/.changeset/thirty-stars-sip.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+fix: correctly apply text scaling to base body font
+  

--- a/packages/skeleton/src/base/globals.css
+++ b/packages/skeleton/src/base/globals.css
@@ -34,7 +34,7 @@
 		/* Typography */
 		color: var(--base-font-color);
 		font-family: var(--base-font-family);
-		font-size: var(--base-font-size);
+		font-size: var(--base-font-size, var(--text-base));
 		line-height: var(--base-line-height);
 		font-weight: var(--base-font-weight);
 		font-style: var(--base-font-style);

--- a/packages/skeleton/src/base/globals.css
+++ b/packages/skeleton/src/base/globals.css
@@ -35,7 +35,7 @@
 		color: var(--base-font-color);
 		font-family: var(--base-font-family);
 		font-size: var(--base-font-size, var(--text-base));
-		line-height: var(--base-line-height);
+		line-height: var(--base-line-height, var(--text-base--line-height));
 		font-weight: var(--base-font-weight);
 		font-style: var(--base-font-style);
 		letter-spacing: var(--base-letter-spacing);


### PR DESCRIPTION
## Linked Issue

Closes #3495

## Description

Correctly apply the base font size (which includes scaling) when not set by the theme.

I think this is the best fix (see the issue above for more details). It doesn't break anything, still allowing custom themes to override the value as usual, but applying the correct size (with scaling) when the theme does not modify the base font size.

Ditto for line height.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [ ] (N/A) Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
