### PR TITLE
feat: skeleton bin path

### DIFF
--- a/.changeset/cruel-months-tap.md
+++ b/.changeset/cruel-months-tap.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-cli": minor
+---
+
+feat: add `skeleton` to bin paths
+  

--- a/packages/skeleton-cli/package.json
+++ b/packages/skeleton-cli/package.json
@@ -14,7 +14,10 @@
 			"import": "./dist/index.mjs"
 		}
 	},
-	"bin": "./dist/index.mjs",
+	"bin": {
+		"skeleton": "./dist/index.mjs",
+		"@skeletonlabs/skeleton-cli": "./dist/index.mjs"
+	},
 	"types": "./dist/index.d.ts",
 	"files": [
 		"dist"


### PR DESCRIPTION
Adds `skeleton` to our bin path so you can do `npx skeleton` instead of `npx @skeletonlabs/skeleton-cli`.