### PR TITLE
docs: remove tailwind v3/v4 warning for NextJS installation

### DIFF
--- a/sites/skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
+++ b/sites/skeleton.dev/src/content/docs/get-started/installation/nextjs.mdx
@@ -32,20 +32,6 @@ import ProcessStep from '@components/docs/ProcessStep.astro';
         cd my-skeleton-app
         ```
 		*/}
-
-        {
-
-        <div className="card preset-outlined-warning-500 p-8 space-y-8">
-            <p>
-                NOTE: The Next.js CLI does not yet install <u>Tailwind v4</u>. Please follow the{' '}
-                <a className="anchor" href="https://tailwindcss.com/docs/installation/framework-guides/nextjs" target="_blank" rel="external">
-                    official Tailwind guide
-                </a> and choose NO when prompted to installed Tailwind by the Next.js CLI.
-            </p>
-        </div>
-
-        }
-
     </ProcessStep>
     <ProcessStep step="2">
         ### Install Skeleton


### PR DESCRIPTION
## Linked Issue

Closes #3480

## Description

Removes the, now not needed, warning about NextJS installing TW3 (Because it install TW4 by default now).

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [ ] Documentation should be updated to describe all relevant changes
- [ ] Run `pnpm check` in the root of the monorepo
- [ ] Run `pnpm format` in the root of the monorepo
- [ ] Run `pnpm lint` in the root of the monorepo
- [ ] Run `pnpm test` in the root of the monorepo
- [ ] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
