### PR TITLE
fix: respect closable toast option

### DIFF
--- a/.changeset/open-trams-stop.md
+++ b/.changeset/open-trams-stop.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+"@skeletonlabs/skeleton-react": patch
+---
+
+fix: respect closable toast option
+  

--- a/packages/skeleton-react/src/components/Toast/Toast.test.tsx
+++ b/packages/skeleton-react/src/components/Toast/Toast.test.tsx
@@ -26,9 +26,20 @@ describe('Toaster', () => {
 		const toaster = createToaster();
 		render(<Toaster toaster={toaster} />);
 		toaster.create({
-			duration: Infinity
+			duration: Infinity,
+			closable: true,
 		});
 		expect(screen.getByTestId('toast-root')).toBeInTheDocument();
+		expect(screen.getByTestId('toast-dismiss')).toBeInTheDocument();
+	});
+	it.skip("does not render the close button if the toast is not closable", async () => {
+		const toaster = createToaster();
+		render(<Toaster toaster={toaster} />);
+		toaster.create({
+			duration: Infinity,
+			closable: false,
+		});
+		expect(screen.queryByTestId('toast-dismiss')).not.toBeInTheDocument();
 	});
 	const rootProps = ['base', 'width', 'padding', 'rounded', 'classes'];
 	for (const prop of rootProps) {

--- a/packages/skeleton-react/src/components/Toast/Toast.tsx
+++ b/packages/skeleton-react/src/components/Toast/Toast.tsx
@@ -44,10 +44,12 @@ export function Toast(props: ToastProps) {
 						{api.description}
 					</span>
 				</div>
-				{/*  Dismiss Button */}
-				<button className={`${props.btnDismissBase} ${props.btnDismissClasses}`} onClick={api.dismiss} data-testid="toast-dismiss">
-					&times;
-				</button>
+				{api.closable && (
+					// Dismiss Button
+					<button className={`${props.btnDismissBase} ${props.btnDismissClasses}`} onClick={api.dismiss} data-testid="toast-dismiss">
+						&times;
+					</button>
+				)}
 			</div>
 			<style>{`
                 [data-part='root'] {

--- a/packages/skeleton-svelte/src/components/Toast/Toast.svelte
+++ b/packages/skeleton-svelte/src/components/Toast/Toast.svelte
@@ -38,8 +38,10 @@
 			>{api.description}</span
 		>
 	</div>
-	<!-- Dismiss Button -->
-	<button class="{props.btnDismissBase} {props.btnDismissClasses}" onclick={api.dismiss} data-testid="toast-dismiss">&times;</button>
+	{#if api.closable}
+		<!-- Dismiss Button -->
+		<button class="{props.btnDismissBase} {props.btnDismissClasses}" {...api.getCloseTriggerProps()} data-testid="toast-dismiss">&times;</button>
+	{/if}
 </div>
 
 <style>

--- a/packages/skeleton-svelte/src/components/Toast/Toast.test.ts
+++ b/packages/skeleton-svelte/src/components/Toast/Toast.test.ts
@@ -27,7 +27,8 @@ describe('Toaster', () => {
 		render(Toaster, { toaster });
 		await act(() => {
 			toaster.create({
-				duration: Infinity
+				duration: Infinity,
+				closable: true,
 			});
 		});
 		expect(screen.getByTestId('toast-root')).toBeInTheDocument();
@@ -35,6 +36,17 @@ describe('Toaster', () => {
 		expect(screen.getByTestId('toast-title')).toBeInTheDocument();
 		expect(screen.getByTestId('toast-description')).toBeInTheDocument();
 		expect(screen.getByTestId('toast-dismiss')).toBeInTheDocument();
+	});
+	it("does not render the close button if the toast is not closable", async () => {
+		const toaster = createToaster();
+		render(Toaster, { toaster });
+		await act(() => {
+			toaster.create({
+				duration: Infinity
+				closable: false,
+			});
+		});
+		expect(screen.queryByTestId('toast-dismiss')).not.toBeInTheDocument();
 	});
 	const rootProps = ['base', 'width', 'padding', 'rounded', 'classes'];
 	for (const prop of rootProps) {


### PR DESCRIPTION
## Linked Issue

Closes #3506

## Description

Conditionally show the dismiss button for toasts, respecting the Zag `closable` property.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [ ] (N/A) Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
