### PR TITLE
chore: cleanup skeleton-cli rename junk

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @skeletonlabs/skeleton-cli
+# skeleton
 
 ## 1.0.0
 ### Major Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/skeletonlabs/skeleton",
-		"directory": "packages/skeleton-cli"
+		"directory": "packages/cli"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/sites/skeleton.dev/src/content/docs/resources/contribute/get-started.mdx
+++ b/sites/skeleton.dev/src/content/docs/resources/contribute/get-started.mdx
@@ -75,7 +75,7 @@ Modular Skeleton packages distributed via NPM.
 | `/packages/skeleton`        | The Skeleton core package, contains Skeleton's Tailwind-specific features. |
 | `/packages/skeleton-react`  | The Skeleton React package, contains Skeleton React components.            |
 | `/packages/skeleton-svelte` | The Skeleton Svelte package, contains Skeleton Svelte components.          |
-| `/packages/skeleton-cli`    | The Skeleton CLI, currently focused on migrations.                         |
+| `/packages/cli`             | The Skeleton CLI, contains Skeleton's migrations.                          |
 | `/packages/skeleton-common` | The Skeleton common package, contains shared internal only utilities.      |
 | `/packages/necroparser`     | An internal tool for generating component type schema for API references.  |
 


### PR DESCRIPTION
Just removes some old references to the old CLI name.