### PR TITLE
Move Login button into nav element

### DIFF
--- a/sites/themes.skeleton.dev/src/lib/components/generator/Preview/PreviewComponents.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/generator/Preview/PreviewComponents.svelte
@@ -155,8 +155,8 @@
 				<button type="button" class="btn hover:preset-tonal">Prices</button>
 				<button type="button" class="btn hover:preset-tonal">Blog</button>
 				<button type="button" class="btn hover:preset-tonal">About</button>
+				<button type="button" class="btn {currentPresets.filled}">Login</button>
 			</nav>
-			<button type="button" class="btn {currentPresets.filled}">Login</button>
 		{/snippet}
 	</AppBar>
 	<!-- Masonry -->


### PR DESCRIPTION
## Description

It's about the Components Preview on <https://themes.skeleton.dev/themes/create>. The code is in `sites/themes.skeleton.dev/src/lib/components/generator/Preview/PreviewComponents.svelte`. There we have this `nav` element with some buttons.

Currently the "Login" button is placed outside the `nav` element (after it). That seems to be a bug. My PR should fix that.