### PR TITLE
Fix Toast typo, move to stable

### DIFF
--- a/sites/skeleton.dev/src/content/docs/components/toast/meta.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/toast/meta.mdx
@@ -4,6 +4,5 @@ description: Build a toast notification system.
 srcSvelte: '/src/components/Toast'
 srcReact: '/src/components/Toast'
 srcZag: 'https://zagjs.com/components/react/toast'
-stability: beta
 showDocsUrl: true
 ---

--- a/sites/skeleton.dev/src/content/docs/components/toast/react.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/toast/react.mdx
@@ -43,7 +43,7 @@ Use the generic `create()` method to trigger toasts of type: `info|success|warni
 ```ts
 toaster.create({
 	type: 'info',
-	message: 'This is a toast',
+	title: 'This is a toast',
 	description: 'This is a toast description.'
 });
 ```

--- a/sites/skeleton.dev/src/content/docs/components/toast/svelte.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/toast/svelte.mdx
@@ -43,7 +43,7 @@ Use the generic `create()` method to trigger toasts of type: `info|success|warni
 ```ts
 toaster.create({
 	type: 'info',
-	message: 'This is a toast',
+	title: 'This is a toast',
 	description: 'This is a toast description.'
 });
 ```


### PR DESCRIPTION
## Linked Issue

Closes #3525

## Description

Fixed an issue where the Toast docs refer to a `message` key in place o `title`. And move the feature from `beta` status to stable.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
