### PR TITLE
Firefox Select element style fixes

### DIFF
--- a/packages/skeleton/src/utilities/form-selects.css
+++ b/packages/skeleton/src/utilities/form-selects.css
@@ -105,10 +105,4 @@
 		height: --spacing(9);
 		padding: --spacing(2);
 	}
-
-	/* Firefox */
-
-	& option :: -ms-expand {
-		display: none;
-	}
 }

--- a/packages/skeleton/src/utilities/form-selects.css
+++ b/packages/skeleton/src/utilities/form-selects.css
@@ -105,4 +105,10 @@
 		height: --spacing(9);
 		padding: --spacing(2);
 	}
+
+	/* Firefox */
+
+	& :: -ms-expand {
+		display: none;
+	}
 }

--- a/packages/skeleton/src/utilities/form-selects.css
+++ b/packages/skeleton/src/utilities/form-selects.css
@@ -97,6 +97,7 @@
 
 	& option {
 		background-color: var(--color-surface-50-950);
+		border-radius: 0px;
 		color: var(--color-surface-950-50);
 		border-radius: var(--radius-base);
 		font-size: var(--text-base);

--- a/packages/skeleton/src/utilities/form-selects.css
+++ b/packages/skeleton/src/utilities/form-selects.css
@@ -32,6 +32,13 @@
 	--tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 var(--default-ring-width) var(--tw-ring-color, currentColor);
 	box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
 
+	/* Browser Overrides */
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	-ms-appearance: none;
+	-o-appearance: none;
+	appearance: none;
+
 	@variant active {
 		--tw-ring-color: var(--color-primary-500);
 	}

--- a/packages/skeleton/src/utilities/form-selects.css
+++ b/packages/skeleton/src/utilities/form-selects.css
@@ -108,7 +108,7 @@
 
 	/* Firefox */
 
-	& :: -ms-expand {
+	& option :: -ms-expand {
 		display: none;
 	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #3516

## Description

Removes the thick outline around the native HTML select element dropdown menu in Firefox for Windows.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [ ] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
