### PR TITLE
Restore Headless Components section

### DIFF
--- a/sites/skeleton.dev/src/components/docs/Navigation.astro
+++ b/sites/skeleton.dev/src/components/docs/Navigation.astro
@@ -57,6 +57,7 @@ const sections: [string, string, (prefix: string) => Promise<CollectionEntry<'do
 	['Design System', 'design/', queryCollection],
 	['Tailwind Components', 'tailwind/', queryCollection],
 	['Functional Components', 'components/', queryMetaCollection],
+	['Headless Components', 'headless/', queryMetaCollection],
 	['Integrations', 'integrations/', queryMetaCollection],
 	['Resources', 'resources/', queryCollection]
 ];

--- a/sites/skeleton.dev/src/components/docs/Navigation.astro
+++ b/sites/skeleton.dev/src/components/docs/Navigation.astro
@@ -57,7 +57,7 @@ const sections: [string, string, (prefix: string) => Promise<CollectionEntry<'do
 	['Design System', 'design/', queryCollection],
 	['Tailwind Components', 'tailwind/', queryCollection],
 	['Functional Components', 'components/', queryMetaCollection],
-	['Headless Components', 'headless/', queryMetaCollection],
+	['Headless Components', 'headless/', queryCollection],
 	['Integrations', 'integrations/', queryMetaCollection],
 	['Resources', 'resources/', queryCollection]
 ];


### PR DESCRIPTION
## Linked Issue

Closes #3528

## Description

Aims to restore the missing Headless Components navigation section. This was lost during a recent refactor.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
