### PR TITLE
fix: update theme detection and opening modal on first load

### DIFF
--- a/sites/skeleton.dev/src/components/docs/FigmaBuyNow.astro
+++ b/sites/skeleton.dev/src/components/docs/FigmaBuyNow.astro
@@ -81,18 +81,19 @@ import { Check as IconCheck } from 'lucide-react';
 </div>
 
 <!-- Load the Polar checkout script -->
-<script is:inline src="https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js" defer data-auto-init></script>
+<script is:inline src="https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js" data-auto-init></script>
 
 <script>
 	const htmlElement = document.documentElement;
-
 	const buyButtons = document.querySelectorAll('[data-polar-checkout]');
 
 	/**
-	 * Updates the theme of the buy buttons based on the presence of the 'dark' class on the HTML element
+	 * Updates the theme of the buy buttons based on data-mode attribute or dark class
 	 */
 	function updateTheme() {
-		const theme = htmlElement.classList.contains('dark') ? 'dark' : 'light';
+		// Check both data-mode attribute and dark class
+		const isDarkMode = htmlElement.getAttribute('data-mode') === 'dark' || htmlElement.classList.contains('dark');
+		const theme = isDarkMode ? 'dark' : 'light';
 
 		buyButtons.forEach((button) => {
 			button.setAttribute('data-polar-checkout-theme', theme);
@@ -102,13 +103,13 @@ import { Check as IconCheck } from 'lucide-react';
 	// Initial update of the theme
 	updateTheme();
 
-	// Create a MutationObserver to observe changes to the class attribute of the HTML element
+	// Create a MutationObserver to observe changes to attributes of the HTML element
 	new MutationObserver(() => {
 		updateTheme();
 	}).observe(htmlElement, {
 		// Observe changes to attributes
 		attributes: true,
-		// Only observe changes to the class attribute
-		attributeFilter: ['class']
+		// Observe both class and data-mode attributes
+		attributeFilter: ['class', 'data-mode']
 	});
 </script>


### PR DESCRIPTION
## Description

The checkout modal was not opening on the first click, and the dark theme was not successfully detected.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset
