### PR TITLE
Fix Combobox collection not updating on input

### DIFF
--- a/.changeset/tame-jokes-brake.md
+++ b/.changeset/tame-jokes-brake.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+bugfix: Fix Combobox collection not updating on input
+  

--- a/packages/skeleton-svelte/src/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/components/Combobox/Combobox.svelte
@@ -48,7 +48,7 @@
 	let options = $state.raw(data);
 	const collection = $derived(
 		combobox.collection({
-			items: data,
+			items: options,
 			// Map data structure
 			itemToValue: (item) => item.value,
 			itemToString: (item) => item.label
@@ -66,7 +66,6 @@
 		},
 		onInputValueChange(event) {
 			const filtered = data.filter((item) => item.label.toLowerCase().includes(event.inputValue.toLowerCase()));
-			collection.setItems(filtered);
 			options = filtered;
 			zagProps.onInputValueChange?.(event);
 		}


### PR DESCRIPTION
## Linked Issue

Closes #3540 

## Description

Properly updates Combobox's collection when input is provided, preventing issues where options can be submitted even when not visible.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [X] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [X] Contributions should target the `main` branch
- [X] Documentation should be updated to describe all relevant changes
- [X] Run `pnpm check` in the root of the monorepo
- [X] Run `pnpm format` in the root of the monorepo
- [X] Run `pnpm lint` in the root of the monorepo
- [X] Run `pnpm test` in the root of the monorepo
- [X] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
