### PR TITLE
chore: change AppBar's header tag attribute to 'role=group', plus 'aria-labelledby=toolbar'

### DIFF
--- a/.changeset/tall-seals-arrive.md
+++ b/.changeset/tall-seals-arrive.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+"@skeletonlabs/skeleton-react": patch
+---
+
+change role attr of header tag in AppBar to the allowed ARIA following W3C spec
+  

--- a/packages/skeleton-react/src/components/AppBar/AppBar.tsx
+++ b/packages/skeleton-react/src/components/AppBar/AppBar.tsx
@@ -18,7 +18,12 @@ const AppBarRoot: FC<AppBarProps> = ({
 	children
 }) => {
 	return (
-		<div className={`${base} ${background} ${spaceY} ${border} ${padding} ${shadow} ${classes}`} role="toolbar" data-testid="app-bar">
+		<div
+			className={`${base} ${background} ${spaceY} ${border} ${padding} ${shadow} ${classes}`}
+			role="group"
+			aria-labelledby="toolbar"
+			data-testid="app-bar"
+		>
 			{children}
 		</div>
 	);

--- a/packages/skeleton-svelte/src/components/AppBar/AppBar.svelte
+++ b/packages/skeleton-svelte/src/components/AppBar/AppBar.svelte
@@ -43,7 +43,12 @@
 
 <!-- @component A header element for the top of a page layout. -->
 
-<header class="{base} {background} {spaceY} {border} {padding} {shadow} {classes}" role="toolbar" data-testid="app-bar">
+<header
+	class="{base} {background} {spaceY} {border} {padding} {shadow} {classes}"
+	role="group"
+	aria-labelledby="toolbar"
+	data-testid="app-bar"
+>
 	<section class="{toolbarBase} {toolbarGridCols} {toolbarGap} {toolbarClasses}" data-testid="app-bar-toolbar">
 		{#if lead}
 			<div class="{leadBase} {leadSpaceX} {leadPadding} {leadClasses}">


### PR DESCRIPTION
## Linked Issue

Closes [#{3545}](https://github.com/skeletonlabs/skeleton/issues/3545)

## Description

This PR changes the `role=toolbar` attribute of `<header>` tag that is used by `AppBar` component. And it causes Lighthouse - Accessibility score drop (issue marked in Red).

- change to `role="group"` as following the W3C spec, and it is group of toolbar & title ([ref](https://www.w3.org/TR/html-aria/#docconformance))
- add `aria-labelledby="toolbar"` for label the Toolbar section ([ref](https://www.w3.org/TR/wai-aria-1.2/#aria-labelledby))

The other description and details are in Linked Issue.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
