### PR TITLE
Remove support for Select element variants

### DIFF
--- a/sites/skeleton.dev/src/examples/tailwind/forms/ExampleSelection.astro
+++ b/sites/skeleton.dev/src/examples/tailwind/forms/ExampleSelection.astro
@@ -7,20 +7,39 @@
 		<option value="4">Option 4</option>
 		<option value="5">Option 5</option>
 	</select>
-	<!-- Size -->
-	<select class="select rounded-container" size="4" value="1">
+
+	<!--
+		NOTE: the following Select element variants are included purely for legacy support. It is not longer advised you use these variants in production apps. Currently the styles are too limited and the style API vary greatly bewteen browser vendors. Expect these styles to be removed in the next major version of Skeleton (v4.0). In the meantime, consider a replacement using a custom Listbox component if you need this type of interface in your application. We've provided some resources below to guide you in this process.
+
+		ARIA APG Guidelines:
+		https://www.w3.org/WAI/ARIA/apg/patterns/listbox/
+
+		Zag.js Listbox component:
+		(NOTE: this will come to Skeleton in the future)
+		https://zagjs.com/components/react/listbox
+		https://zagjs.com/components/svelte/listbox
+
+		Similar components may also exist or third party libraries such as Bits, Melt, or Radix:
+		https://www.skeleton.dev/docs/headless/bits-ui
+		https://www.skeleton.dev/docs/headless/melt-ui
+		https://www.skeleton.dev/docs/headless/radix-ui
+	-->
+
+	<!-- Size Variant -->
+	<!-- <select class="select rounded-container" size="4" value="1">
 		<option value="1">Option 1</option>
 		<option value="2">Option 2</option>
 		<option value="3">Option 3</option>
 		<option value="4">Option 4</option>
 		<option value="5">Option 5</option>
-	</select>
-	<!-- Multiple -->
-	<select class="select rounded-container" multiple value="['1', '2']">
+	</select> -->
+
+	<!-- Multiple Variant -->
+	<!-- <select class="select rounded-container" multiple value="['1', '2']">
 		<option value="1">Option 1</option>
 		<option value="2">Option 2</option>
 		<option value="3">Option 3</option>
 		<option value="4">Option 4</option>
 		<option value="5">Option 5</option>
-	</select>
+	</select> -->
 </form>


### PR DESCRIPTION
## Linked Issue

Closes #3534

## Description

Update docs to no longer recommend `<select>` element variants like `size` or `multiple`. Note the styles for these will remain in place, nothing is being removed in v3.0. But in Skeleton v4.0 we may properly remove support for these. As such recommendations have been added for moving to a custom component. Additionally, Zag.js has recently introduce a beta Listbox component. We will aim to adopt this asap.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
