### PR TITLE
Add MouseEvent types for event handlers

### DIFF
--- a/packages/skeleton-svelte/src/components/Modal/types.ts
+++ b/packages/skeleton-svelte/src/components/Modal/types.ts
@@ -69,5 +69,5 @@ export interface ModalProps extends Omit<dialog.Props, 'id'> {
 
 	// Events ---
 	/** Handle the dialog button click event. */
-	onclick?: () => void;
+	onclick?: (e: MouseEvent) => void;
 }

--- a/packages/skeleton-svelte/src/components/Modal/types.ts
+++ b/packages/skeleton-svelte/src/components/Modal/types.ts
@@ -69,5 +69,5 @@ export interface ModalProps extends Omit<dialog.Props, 'id'> {
 
 	// Events ---
 	/** Handle the dialog button click event. */
-	onclick?: (e: MouseEvent) => void;
+	onclick?: HTMLButtonAttributes['onclick'];
 }

--- a/packages/skeleton-svelte/src/components/Popover/types.ts
+++ b/packages/skeleton-svelte/src/components/Popover/types.ts
@@ -53,5 +53,5 @@ export interface PopoverProps extends Omit<popover.Props, 'id'> {
 
 	// Events ---
 	/** Handle the popover button click event. */
-	onclick?: () => void;
+	onclick?: (e: MouseEvent) => void;
 }

--- a/packages/skeleton-svelte/src/components/Popover/types.ts
+++ b/packages/skeleton-svelte/src/components/Popover/types.ts
@@ -53,5 +53,5 @@ export interface PopoverProps extends Omit<popover.Props, 'id'> {
 
 	// Events ---
 	/** Handle the popover button click event. */
-	onclick?: (e: MouseEvent) => void;
+	onclick?: HTMLButtonAttributes['onclick'];
 }

--- a/packages/skeleton-svelte/src/components/Tooltip/types.ts
+++ b/packages/skeleton-svelte/src/components/Tooltip/types.ts
@@ -53,7 +53,7 @@ export interface TooltipProps extends Omit<tooltip.Props, 'id'> {
 
 	// Events ---
 	/** Handle the tooltip button hover event. */
-	onmouseover?: (e: MouseEvent) => void;
+	onmouseover?: HTMLButtonAttributes['onmouseover'];
 	/** Handle the tooltip button click event. */
 	onclick?: HTMLButtonAttributes['onclick'];
 }

--- a/packages/skeleton-svelte/src/components/Tooltip/types.ts
+++ b/packages/skeleton-svelte/src/components/Tooltip/types.ts
@@ -53,7 +53,7 @@ export interface TooltipProps extends Omit<tooltip.Props, 'id'> {
 
 	// Events ---
 	/** Handle the tooltip button hover event. */
-	onmouseover?: () => void;
+	onmouseover?: (e: MouseEvent) => void;
 	/** Handle the tooltip button click event. */
-	onclick?: () => void;
+	onclick?: (e: MouseEvent) => void;
 }

--- a/packages/skeleton-svelte/src/components/Tooltip/types.ts
+++ b/packages/skeleton-svelte/src/components/Tooltip/types.ts
@@ -55,5 +55,5 @@ export interface TooltipProps extends Omit<tooltip.Props, 'id'> {
 	/** Handle the tooltip button hover event. */
 	onmouseover?: (e: MouseEvent) => void;
 	/** Handle the tooltip button click event. */
-	onclick?: (e: MouseEvent) => void;
+	onclick?: HTMLButtonAttributes['onclick'];
 }


### PR DESCRIPTION
## Linked Issue

eg.

```
<Popover
  onclick={(e: MouseEvent) => {
    // typescript is complaining here 
    // do something with event
    e.stopImmediatePropagation();
  }}
>
```

## Description

Improve typing for onclick function, so that the event can be accessed without ts errors.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [X] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [X] Contributions should target the `main` branch
- [X] Documentation should be updated to describe all relevant changes
- [ ] Run `pnpm check` in the root of the monorepo
- [ ] Run `pnpm format` in the root of the monorepo
- [ ] Run `pnpm lint` in the root of the monorepo
- [ ] Run `pnpm test` in the root of the monorepo
- [ ] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
