### PR TITLE
Fix: Tooltip z-index was not working with an arrow

### DIFF
--- a/.changeset/icy-insects-throw.md
+++ b/.changeset/icy-insects-throw.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+Bugfix: z-index of tooltip was not working when an arrow element was present.
+  

--- a/packages/skeleton-svelte/src/components/Tooltip/Tooltip.svelte
+++ b/packages/skeleton-svelte/src/components/Tooltip/Tooltip.svelte
@@ -55,20 +55,23 @@
 		</button>
 	{/if}
 	<!-- Tooltip Content -->
-	{#if api.open}
-		<div {...api.getPositionerProps()} transition:fade={{ duration: 100 }} class="{positionerBase} {positionerClasses}">
-			<!-- Arrow -->
-			{#if arrow}
-				<div {...api.getArrowProps()}>
-					<div {...api.getArrowTipProps()} class="{arrowBase} {arrowBackground} {arrowClasses}"></div>
+	<div {...api.getPositionerProps()} class="{positionerBase} {positionerClasses}">
+		<!-- Popover -->
+		{#if api.open}
+			<div {...api.getContentProps()} transition:fade={{ duration: 100 }} style="z-index: {zIndex};">
+				<!-- Arrow -->
+				{#if arrow}
+					<div {...api.getArrowProps()}>
+						<div {...api.getArrowTipProps()} class="{arrowBase} {arrowBackground} {arrowClasses}"></div>
+					</div>
+				{/if}
+				<!-- Snippet Content -->
+				<div class="{contentBase} {contentBackground} {contentClasses}">
+					{@render content?.()}
 				</div>
-			{/if}
-			<!-- Snippet Content -->
-			<div {...api.getContentProps()} class="{contentBase} {contentBackground} {contentClasses}" style="z-index: {zIndex};">
-				{@render content?.()}
 			</div>
-		</div>
-	{/if}
+		{/if}
+	</div>
 </span>
 
 <style>


### PR DESCRIPTION
## Linked Issue

None

## Description

This PR fixes an issue where the `zIndex` of a tooltip was not correctly applied when an arrow element was present. As a result zIndex was ignored on the tooltip with arrows.


Example code:
```svelte
<section class="border border-surface-200-800 space-y-4 p-20 flex justify-center items-center flex-col">
  <span class="z-10 bg-surface-200">Lorem Ipsum is simply dummy text of the printing and typesetting industry.</span>
  <Tooltip
    open={openState}
    onOpenChange={(e) => (openState = e.open)}
    positioning={{ placement: 'top' }}
    openDelay={0}
    triggerBase="btn preset-tonal"
    contentBase="card preset-filled p-4"
    zIndex="40"
    arrow
  >
    {#snippet trigger()}Hover Me{/snippet}
    {#snippet content()}This is a tooltip.{/snippet}
  </Tooltip>
</section>
```

Previous behavior:
![image](https://github.com/user-attachments/assets/850945fc-f57b-40cb-b469-46810dbf2f73)


Behavior with patch:
![image](https://github.com/user-attachments/assets/c84a164d-e76c-48e7-861a-343c11da89c0)



## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).


- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
