### PR TITLE
Fixed Grid Overlapping and Extra Padding Issue

### DIFF
--- a/sites/skeleton.dev/src/content/docs/get-started/introduction.mdx
+++ b/sites/skeleton.dev/src/content/docs/get-started/introduction.mdx
@@ -89,7 +89,7 @@ Skeleton provides a uniform design language and structured framework for control
 
 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 
-    <div className="col-span-2 card preset-outlined-surface-200-800 bg-surface-50-950 p-10 space-y-4">
+    <div className="col-span-1 md:col-span-2 card preset-outlined-surface-200-800 bg-surface-50-950 p-10 space-y-4">
     	<h3 className="h3">Functional Components</h3>
     	{/* prettier-ignore */}
     	<p className="text-surface-700-300">

--- a/sites/skeleton.dev/src/layouts/LayoutDoc.astro
+++ b/sites/skeleton.dev/src/layouts/LayoutDoc.astro
@@ -64,14 +64,11 @@ const urls = {
 	<!-- Page -->
 	<div class="container mx-auto grid grid-cols-1 xl:grid-cols-[240px_minmax(0px,_1fr)_280px] px-4 xl:px-10">
 		<!-- Navigation -->
-		<aside
-			class="hidden xl:block self-start sticky top-[70px] h-[calc(100vh-70px)] py-4 xl:py-10 !pb-96 overflow-y-auto pr-10"
-			data-navigation
-		>
+		<aside class="hidden xl:block self-start sticky top-[70px] h-[calc(100vh-70px)] py-4 xl:py-10 overflow-y-auto pr-10" data-navigation>
 			<Navigation />
 		</aside>
 		<!-- Main -->
-		<main class="px-4 xl:px-10 py-10 !pb-96 space-y-8 [&_.scroll-header]:scroll-mt-[calc(70px+40px)]">
+		<main class="px-4 xl:px-10 py-10 space-y-8 [&_.scroll-header]:scroll-mt-[calc(70px+40px)]">
 			<!-- Header -->
 			<header class="scroll-header space-y-4" data-pagefind-body id="_top">
 				<!-- Breadcrumbs -->


### PR DESCRIPTION
## Linked Issue

Closes #3563 

## Description

- Fixed the extra bottom padding appearing appearing in end of all the pages of the docs
- Fixed the "Additional Benefits" Grid overlapping at smaller breakpoints

## Screenshots

- grid is now as it is supposed to be

![image](https://github.com/user-attachments/assets/2f38571e-4ebe-43e0-827d-ab9899007dc3)
- No more extra bottom padding

![image](https://github.com/user-attachments/assets/bf15e946-63c3-48f7-91ff-9a4a5883efd4)


## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset