### PR TITLE
Resolve small errors tripping up our CI process

### DIFF
--- a/.changeset/rare-dodos-swim.md
+++ b/.changeset/rare-dodos-swim.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+bugfix: Resolve issue in Popover, Tooltip, and Modal types for missing import.

--- a/packages/skeleton-svelte/src/components/Modal/types.ts
+++ b/packages/skeleton-svelte/src/components/Modal/types.ts
@@ -1,6 +1,7 @@
 import type { Snippet } from 'svelte';
 import * as dialog from '@zag-js/dialog';
 import type { FlyParams, FadeParams } from 'svelte/transition';
+import type { HTMLButtonAttributes } from 'svelte/elements';
 
 export interface ModalProps extends Omit<dialog.Props, 'id'> {
 	// Base ---

--- a/packages/skeleton-svelte/src/components/Popover/types.ts
+++ b/packages/skeleton-svelte/src/components/Popover/types.ts
@@ -1,5 +1,6 @@
 import type { Snippet } from 'svelte';
 import * as popover from '@zag-js/popover';
+import type { HTMLButtonAttributes } from 'svelte/elements';
 
 export interface PopoverProps extends Omit<popover.Props, 'id'> {
 	/** Enable display of the popover arrow. */

--- a/packages/skeleton-svelte/src/components/Tooltip/types.ts
+++ b/packages/skeleton-svelte/src/components/Tooltip/types.ts
@@ -1,5 +1,6 @@
 import type { Snippet } from 'svelte';
 import * as tooltip from '@zag-js/tooltip';
+import type { HTMLButtonAttributes } from 'svelte/elements';
 
 export interface TooltipProps extends Omit<tooltip.Props, 'id'> {
 	/** Enable display of the popover arrow. */

--- a/sites/skeleton.dev/scripts/generate-schemas.ts
+++ b/sites/skeleton.dev/scripts/generate-schemas.ts
@@ -1,60 +1,60 @@
-// import { glob } from 'tinyglobby';
-// import { Project } from '@skeletonlabs/necroparser';
-// import { mkdir, rm, writeFile } from 'fs/promises';
-// import { join, resolve } from 'path';
-// import { performance } from 'perf_hooks';
-// import { blue, bold, gray } from 'colorette';
+import { glob } from 'tinyglobby';
+import { Project } from '@skeletonlabs/necroparser';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { join, resolve } from 'path';
+import { performance } from 'perf_hooks';
+import { blue, bold, gray } from 'colorette';
 
-// function log(message: string) {
-// 	console.log(`${gray(new Date().toLocaleTimeString())} ${blue('[generate-schemas]')} ${message}`);
-// }
+function log(message: string) {
+	console.log(`${gray(new Date().toLocaleTimeString())} ${blue('[generate-schemas]')} ${message}`);
+}
 
-// function toKebabCase(str: string) {
-// 	str = str.charAt(0).toLowerCase() + str.slice(1);
-// 	return str.replace(/([A-Z])/g, '-$1').toLowerCase();
-// }
+function toKebabCase(str: string) {
+	str = str.charAt(0).toLowerCase() + str.slice(1);
+	return str.replace(/([A-Z])/g, '-$1').toLowerCase();
+}
 
-// async function generateSchemas() {
-// 	log('Preparing to generate schemas');
-// 	const start = performance.now();
-// 	const inputPaths = await glob('./node_modules/@skeletonlabs/skeleton-**/src/components/**/types.ts');
-// 	const outputPath = resolve(import.meta.dirname, '../src/content/schemas');
-// 	const project = new Project(inputPaths);
-// 	await rm(outputPath, {
-// 		recursive: true,
-// 		force: true
-// 	});
-// 	await Promise.allSettled(
-// 		inputPaths.map(async (path) => {
-// 			const framework = path.match(/@skeletonlabs\/skeleton-(\w+)/)?.[1];
-// 			const component = toKebabCase(path.match(/\/components\/(\w+)/)?.[1] ?? '');
-// 			if (!(framework && component)) {
-// 				return;
-// 			}
-// 			log(`Generating ${bold(framework)}/${bold(component)}`);
-// 			const interfaces = project.getInterfaces(path, {
-// 				filter(node) {
-// 					return /\w+Props/.test(node.name.getText());
-// 				},
-// 				transformProperty(property) {
-// 					if (property.type.startsWith('Snippet')) {
-// 						return {
-// 							...property,
-// 							typeKind: 'primitive'
-// 						};
-// 					}
-// 					return property;
-// 				}
-// 			});
-// 			const frameworkPath = join(outputPath, framework);
-// 			await mkdir(frameworkPath, {
-// 				recursive: true
-// 			});
-// 			await writeFile(join(frameworkPath, `${component}.json`), JSON.stringify(interfaces, null, 4));
-// 		})
-// 	);
-// 	const end = performance.now();
-// 	log(`Generated ${inputPaths.length} schemas in ${((end - start) / 1000).toFixed(2)}s`);
-// }
+async function generateSchemas() {
+	log('Preparing to generate schemas');
+	const start = performance.now();
+	const inputPaths = await glob('./node_modules/@skeletonlabs/skeleton-**/src/components/**/types.ts');
+	const outputPath = resolve(import.meta.dirname, '../src/content/schemas');
+	const project = new Project(inputPaths);
+	await rm(outputPath, {
+		recursive: true,
+		force: true
+	});
+	await Promise.allSettled(
+		inputPaths.map(async (path) => {
+			const framework = path.match(/@skeletonlabs\/skeleton-(\w+)/)?.[1];
+			const component = toKebabCase(path.match(/\/components\/(\w+)/)?.[1] ?? '');
+			if (!(framework && component)) {
+				return;
+			}
+			log(`Generating ${bold(framework)}/${bold(component)}`);
+			const interfaces = project.getInterfaces(path, {
+				filter(node) {
+					return /\w+Props/.test(node.name.getText());
+				},
+				transformProperty(property) {
+					if (property.type.startsWith('Snippet')) {
+						return {
+							...property,
+							typeKind: 'primitive'
+						};
+					}
+					return property;
+				}
+			});
+			const frameworkPath = join(outputPath, framework);
+			await mkdir(frameworkPath, {
+				recursive: true
+			});
+			await writeFile(join(frameworkPath, `${component}.json`), JSON.stringify(interfaces, null, 4));
+		})
+	);
+	const end = performance.now();
+	log(`Generated ${inputPaths.length} schemas in ${((end - start) / 1000).toFixed(2)}s`);
+}
 
-// await generateSchemas();
+await generateSchemas();

--- a/sites/skeleton.dev/scripts/generate-schemas.ts
+++ b/sites/skeleton.dev/scripts/generate-schemas.ts
@@ -33,9 +33,11 @@ async function generateSchemas() {
 			}
 			log(`Generating ${bold(framework)}/${bold(component)}`);
 			const interfaces = project.getInterfaces(path, {
+				// @ts-expect-error type error
 				filter(node) {
 					return /\w+Props/.test(node.name.getText());
 				},
+				// @ts-expect-error type error
 				transformProperty(property) {
 					if (property.type.startsWith('Snippet')) {
 						return {

--- a/sites/skeleton.dev/scripts/generate-schemas.ts
+++ b/sites/skeleton.dev/scripts/generate-schemas.ts
@@ -1,62 +1,60 @@
-import { glob } from 'tinyglobby';
-import { Project } from '@skeletonlabs/necroparser';
-import { mkdir, rm, writeFile } from 'fs/promises';
-import { join, resolve } from 'path';
-import { performance } from 'perf_hooks';
-import { blue, bold, gray } from 'colorette';
+// import { glob } from 'tinyglobby';
+// import { Project } from '@skeletonlabs/necroparser';
+// import { mkdir, rm, writeFile } from 'fs/promises';
+// import { join, resolve } from 'path';
+// import { performance } from 'perf_hooks';
+// import { blue, bold, gray } from 'colorette';
 
-function log(message: string) {
-	console.log(`${gray(new Date().toLocaleTimeString())} ${blue('[generate-schemas]')} ${message}`);
-}
+// function log(message: string) {
+// 	console.log(`${gray(new Date().toLocaleTimeString())} ${blue('[generate-schemas]')} ${message}`);
+// }
 
-function toKebabCase(str: string) {
-	str = str.charAt(0).toLowerCase() + str.slice(1);
-	return str.replace(/([A-Z])/g, '-$1').toLowerCase();
-}
+// function toKebabCase(str: string) {
+// 	str = str.charAt(0).toLowerCase() + str.slice(1);
+// 	return str.replace(/([A-Z])/g, '-$1').toLowerCase();
+// }
 
-async function generateSchemas() {
-	log('Preparing to generate schemas');
-	const start = performance.now();
-	const inputPaths = await glob('./node_modules/@skeletonlabs/skeleton-**/src/components/**/types.ts');
-	const outputPath = resolve(import.meta.dirname, '../src/content/schemas');
-	const project = new Project(inputPaths);
-	await rm(outputPath, {
-		recursive: true,
-		force: true
-	});
-	await Promise.allSettled(
-		inputPaths.map(async (path) => {
-			const framework = path.match(/@skeletonlabs\/skeleton-(\w+)/)?.[1];
-			const component = toKebabCase(path.match(/\/components\/(\w+)/)?.[1] ?? '');
-			if (!(framework && component)) {
-				return;
-			}
-			log(`Generating ${bold(framework)}/${bold(component)}`);
-			const interfaces = project.getInterfaces(path, {
-				// @ts-expect-error type error
-				filter(node) {
-					return /\w+Props/.test(node.name.getText());
-				},
-				// @ts-expect-error type error
-				transformProperty(property) {
-					if (property.type.startsWith('Snippet')) {
-						return {
-							...property,
-							typeKind: 'primitive'
-						};
-					}
-					return property;
-				}
-			});
-			const frameworkPath = join(outputPath, framework);
-			await mkdir(frameworkPath, {
-				recursive: true
-			});
-			await writeFile(join(frameworkPath, `${component}.json`), JSON.stringify(interfaces, null, 4));
-		})
-	);
-	const end = performance.now();
-	log(`Generated ${inputPaths.length} schemas in ${((end - start) / 1000).toFixed(2)}s`);
-}
+// async function generateSchemas() {
+// 	log('Preparing to generate schemas');
+// 	const start = performance.now();
+// 	const inputPaths = await glob('./node_modules/@skeletonlabs/skeleton-**/src/components/**/types.ts');
+// 	const outputPath = resolve(import.meta.dirname, '../src/content/schemas');
+// 	const project = new Project(inputPaths);
+// 	await rm(outputPath, {
+// 		recursive: true,
+// 		force: true
+// 	});
+// 	await Promise.allSettled(
+// 		inputPaths.map(async (path) => {
+// 			const framework = path.match(/@skeletonlabs\/skeleton-(\w+)/)?.[1];
+// 			const component = toKebabCase(path.match(/\/components\/(\w+)/)?.[1] ?? '');
+// 			if (!(framework && component)) {
+// 				return;
+// 			}
+// 			log(`Generating ${bold(framework)}/${bold(component)}`);
+// 			const interfaces = project.getInterfaces(path, {
+// 				filter(node) {
+// 					return /\w+Props/.test(node.name.getText());
+// 				},
+// 				transformProperty(property) {
+// 					if (property.type.startsWith('Snippet')) {
+// 						return {
+// 							...property,
+// 							typeKind: 'primitive'
+// 						};
+// 					}
+// 					return property;
+// 				}
+// 			});
+// 			const frameworkPath = join(outputPath, framework);
+// 			await mkdir(frameworkPath, {
+// 				recursive: true
+// 			});
+// 			await writeFile(join(frameworkPath, `${component}.json`), JSON.stringify(interfaces, null, 4));
+// 		})
+// 	);
+// 	const end = performance.now();
+// 	log(`Generated ${inputPaths.length} schemas in ${((end - start) / 1000).toFixed(2)}s`);
+// }
 
-await generateSchemas();
+// await generateSchemas();

--- a/sites/skeleton.dev/tsconfig.json
+++ b/sites/skeleton.dev/tsconfig.json
@@ -14,5 +14,5 @@
 			"@images/*": ["src/images/*"]
 		}
 	},
-	"exclude": ["node_modules", "dist", "public/pagefind"]
+	"exclude": ["node_modules", "dist", "public/pagefind", "./scripts/generate-schemas.ts"]
 }

--- a/sites/themes.skeleton.dev/src/lib/components/generator/Controls/ControlsColors.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/generator/Controls/ControlsColors.svelte
@@ -127,7 +127,7 @@
 											<input
 												type="text"
 												class="input"
-												bind:value={settingsColors[getColorKey(color.value, shade)]}
+												bind:value={settingsColors[getColorKey(color.value, shade.toString())]}
 												onblur={() => genColorRamp(showAllShades, color.value)}
 											/>
 										</td>
@@ -137,7 +137,7 @@
 											<input
 												class="input"
 												type="color"
-												bind:value={settingsColors[getColorKey(color.value, shade)]}
+												bind:value={settingsColors[getColorKey(color.value, shade.toString())]}
 												oninput={() => genColorRamp(showAllShades, color.value)}
 											/>
 										</td>


### PR DESCRIPTION
## Linked Issue

Closes #3583

## Description

Resolves a number of small issues tripping up our CI checks:

- [x] Resolved onclick type bug for Popover components. This was missing a required import to function.
- [x] Additionally, this also resolves a type error in the Theme Generator app
- [x] Exclude `generate-scheme.ts` from `tsconfig.ts` in the Docs app

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
4. Run `pnpm changeset` and follow the prompts
5. Commit and push the changeset before flagging your PR review for review.
