### PR TITLE
Remove aria role tooltip from AppBar component

### DIFF
--- a/.changeset/major-parents-serve.md
+++ b/.changeset/major-parents-serve.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+"@skeletonlabs/skeleton-react": patch
+---
+
+chore: Remove aria role tooltip from AppBar component
+  

--- a/packages/skeleton-react/src/components/AppBar/AppBar.tsx
+++ b/packages/skeleton-react/src/components/AppBar/AppBar.tsx
@@ -18,7 +18,7 @@ const AppBarRoot: FC<AppBarProps> = ({
 	children
 }) => {
 	return (
-		<div className={`${base} ${background} ${spaceY} ${border} ${padding} ${shadow} ${classes}`} role="toolbar" data-testid="app-bar">
+		<div className={`${base} ${background} ${spaceY} ${border} ${padding} ${shadow} ${classes}`} data-testid="app-bar">
 			{children}
 		</div>
 	);

--- a/packages/skeleton-svelte/src/components/AppBar/AppBar.svelte
+++ b/packages/skeleton-svelte/src/components/AppBar/AppBar.svelte
@@ -43,7 +43,7 @@
 
 <!-- @component A header element for the top of a page layout. -->
 
-<header class="{base} {background} {spaceY} {border} {padding} {shadow} {classes}" role="toolbar" data-testid="app-bar">
+<header class="{base} {background} {spaceY} {border} {padding} {shadow} {classes}" data-testid="app-bar">
 	<section class="{toolbarBase} {toolbarGridCols} {toolbarGap} {toolbarClasses}" data-testid="app-bar-toolbar">
 		{#if lead}
 			<div class="{leadBase} {leadSpaceX} {leadPadding} {leadClasses}">


### PR DESCRIPTION
## Linked Issue

Closes #3545

## Description

Removes the `tooltip` aria role from the AppBar component. General rule of thumb with aria is no aria is better than bad aria, so we're taking that approach for now. In the future we should revisit to determine if there's a better way to designate this feature.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changsets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
