### PR TITLE
docs: add aria-label and title attributes to btn-icon elements

### DIFF
--- a/playgrounds/skeleton-core/src/pages/components/buttons.astro
+++ b/playgrounds/skeleton-core/src/pages/components/buttons.astro
@@ -9,7 +9,7 @@ import Layout from '@layouts/Layout.astro';
 		</div>
 		<!-- Sizes -->
 		<div class="flex items-center gap-4">
-			<button type="button" class="btn-icon btn-icon-sm preset-filled">
+			<button type="button" class="btn-icon btn-icon-sm preset-filled" title="Small right arrow" aria-label="Small right arrow">
 				<span>&rarr;</span>
 			</button>
 			<button type="button" class="btn btn-sm preset-filled">
@@ -21,7 +21,7 @@ import Layout from '@layouts/Layout.astro';
 			</button>
 		</div>
 		<div class="flex items-center gap-4">
-			<button type="button" class="btn-icon preset-filled">&rarr;</button>
+			<button type="button" class="btn-icon preset-filled" title="Right arrow" aria-label="Right arrow">&rarr;</button>
 			<button type="button" class="btn preset-filled">Base</button>
 			<button type="button" class="btn preset-filled">
 				<span>Base</span>
@@ -29,7 +29,9 @@ import Layout from '@layouts/Layout.astro';
 			</button>
 		</div>
 		<div class="flex items-center gap-4">
-			<button type="button" class="btn-icon btn-icon-lg preset-filled">&rarr;</button>
+			<button type="button" class="btn-icon btn-icon-lg preset-filled" title="Large right arrow" aria-label="Large right arrow"
+				>&rarr;</button
+			>
 			<button type="button" class="btn btn-lg preset-filled">Large</button>
 			<button type="button" class="btn btn-lg preset-filled">
 				<span>Large</span>
@@ -38,9 +40,13 @@ import Layout from '@layouts/Layout.astro';
 		</div>
 		<!-- Icons -->
 		<div class="flex items-center gap-4">
-			<button type="button" class="btn-icon btn-icon-sm preset-filled">&rarr;</button>
-			<button type="button" class="btn-icon preset-filled">&rarr;</button>
-			<button type="button" class="btn-icon btn-icon-lg preset-filled">&rarr;</button>
+			<button type="button" class="btn-icon btn-icon-sm preset-filled" title="Small right arrow" aria-label="Small right arrow"
+				>&rarr;</button
+			>
+			<button type="button" class="btn-icon preset-filled" title="Right arrow" aria-label="Right arrow">&rarr;</button>
+			<button type="button" class="btn-icon btn-icon-lg preset-filled" title="Large right arrow" aria-label="Large right arrow"
+				>&rarr;</button
+			>
 		</div>
 		<!-- Presets -->
 		<div class="space-y-4">
@@ -97,7 +103,12 @@ import Layout from '@layouts/Layout.astro';
 		<!-- Responsive -->
 		<div class="flex items-center gap-4">
 			<button type="button" class="btn btn-sm md:btn-base lg:btn-lg preset-filled">Responsive</button>
-			<button type="button" class="btn-icon btn-icon-sm md:btn-icon-base lg:btn-icon-lg preset-filled">&rarr;</button>
+			<button
+				type="button"
+				class="btn-icon btn-icon-sm md:btn-icon-base lg:btn-icon-lg preset-filled"
+				title="Responsive right arrow"
+				aria-label="Responsive right arrow">&rarr;</button
+			>
 		</div>
 		<!-- Disabled -->
 		<div class="flex items-center gap-4">

--- a/sites/skeleton.dev/src/components/docs/Drawer.astro
+++ b/sites/skeleton.dev/src/components/docs/Drawer.astro
@@ -24,7 +24,7 @@ const {
 		class="flex justify-between items-center p-6 from-surface-100-900 from-75% to-surface-100-900/0 bg-linear-to-b start sticky top-0"
 	>
 		<h2 class="h3">Skeleton</h2>
-		<button class="btn-icon" data-drawer-trigger>
+		<button class="btn-icon" title="Close drawer" aria-label="Close drawer" data-drawer-trigger>
 			<IconClose />
 		</button>
 	</header>
@@ -35,7 +35,7 @@ const {
 </dialog>
 
 {/* Drawer Trigger */}
-<button class="xl:hidden btn-icon translate-x" data-drawer-trigger>
+<button class="xl:hidden btn-icon translate-x" title="Open drawer" aria-label="Open drawer" data-drawer-trigger>
 	<IconMenu />
 </button>
 

--- a/sites/skeleton.dev/src/components/docs/Footer.astro
+++ b/sites/skeleton.dev/src/components/docs/Footer.astro
@@ -18,7 +18,7 @@ const { classList = 'p-4' } = Astro.props;
 		<nav class="flex items-center">
 			{
 				socialLinks.get().map((l) => (
-					<a class="btn-icon hover:preset-tonal" href={l.href} target="_blank" title={l.label}>
+					<a class="btn-icon hover:preset-tonal" href={l.href} target="_blank" title={l.label} aria-label={l.label}>
 						<Icon name={l.icon} size={24} />
 					</a>
 				))

--- a/sites/skeleton.dev/src/components/docs/Header.astro
+++ b/sites/skeleton.dev/src/components/docs/Header.astro
@@ -74,7 +74,7 @@ const versionLinks = [
 						.get()
 						.slice(0, 2)
 						.map((l) => (
-							<a class="btn-icon hover:preset-tonal" href={l.href} target="_blank" title={l.label}>
+							<a class="btn-icon hover:preset-tonal" href={l.href} target="_blank" title={l.label} aria-label={l.label}>
 								<Icon name={l.icon} size={20} />
 							</a>
 						))

--- a/sites/skeleton.dev/src/components/docs/Lightswitch.astro
+++ b/sites/skeleton.dev/src/components/docs/Lightswitch.astro
@@ -6,7 +6,7 @@ import { SunMoon } from 'lucide-react';
 ---
 
 <nav>
-	<button class="btn-icon hover:preset-tonal" title="Toggle dark mode." data-lightswitch>
+	<button class="btn-icon hover:preset-tonal" title="Toggle dark mode." aria-label="Toggle dark mode." data-lightswitch>
 		<SunMoon size={20} />
 	</button>
 </nav>

--- a/sites/skeleton.dev/src/content/docs/headless/bits-ui.mdx
+++ b/sites/skeleton.dev/src/content/docs/headless/bits-ui.mdx
@@ -169,7 +169,7 @@ Styling the `<Calendar.Root>` parent component.
 Styling the `<Calendar.PrevButton>` sub-component. You can clone these to `<Calendar.NextButton>` too.
 
 ```svelte
-<Calendar.PrevButton class="btn-icon preset-filled-primary-500">
+<Calendar.PrevButton class="btn-icon preset-filled-primary-500" title="Previous month" aria-label="Previous month">
 	<span>&larr;</span>
 </Calendar.PrevButton>
 ```
@@ -213,11 +213,11 @@ Below is a complete example showing the entire component with all styles and bas
 >
 	{#snippet children({ months, weekdays })}
 		<Calendar.Header class="flex items-center justify-between">
-			<Calendar.PrevButton class="btn-icon preset-filled-primary-500">
+			<Calendar.PrevButton class="btn-icon preset-filled-primary-500" title="Previous month" aria-label="Previous month">
 				<span>&larr;</span>
 			</Calendar.PrevButton>
 			<Calendar.Heading class="text-lg font-bold" />
-			<Calendar.NextButton class="btn-icon preset-filled-primary-500">
+			<Calendar.NextButton class="btn-icon preset-filled-primary-500" title="Next month" aria-label="Next month">
 				<span>&rarr;</span>
 			</Calendar.NextButton>
 		</Calendar.Header>

--- a/sites/skeleton.dev/src/examples/guides/cookbook/scroll-containers/ExampleCarousel.astro
+++ b/sites/skeleton.dev/src/examples/guides/cookbook/scroll-containers/ExampleCarousel.astro
@@ -8,7 +8,7 @@ const generatedArray = Array.from({ length: 6 });
 	<!-- Carousel -->
 	<div class="card p-4 grid grid-cols-[auto_1fr_auto] gap-4 items-center">
 		<!-- Button: Left -->
-		<button type="button" class="btn-icon preset-filled" data-carousel-left>
+		<button type="button" class="btn-icon preset-filled" data-carousel-left title="Previous slide" aria-label="Previous slide">
 			<ArrowLeft size={16} />
 		</button>
 		<!-- Full Images -->
@@ -26,7 +26,7 @@ const generatedArray = Array.from({ length: 6 });
 			}
 		</div>
 		<!-- Button: Right -->
-		<button type="button" class="btn-icon preset-filled" data-carousel-right>
+		<button type="button" class="btn-icon preset-filled" data-carousel-right title="Next slide" aria-label="Next slide">
 			<ArrowRight size={16} />
 		</button>
 	</div>

--- a/sites/skeleton.dev/src/examples/guides/cookbook/scroll-containers/ExampleMultiColumn.astro
+++ b/sites/skeleton.dev/src/examples/guides/cookbook/scroll-containers/ExampleMultiColumn.astro
@@ -60,7 +60,7 @@ export const movies: Movie[] = [
 <div class="w-ful">
 	<div class="grid grid-cols-[auto_1fr_auto] gap-4 items-center">
 		<!-- Button: Left -->
-		<button type="button" class="btn-icon preset-filled" data-multi-column-left>
+		<button type="button" class="btn-icon preset-filled" data-multi-column-left title="Scroll left" aria-label="Scroll left">
 			<ArrowLeft size={16} />
 		</button>
 		<!-- Carousel -->
@@ -81,7 +81,7 @@ export const movies: Movie[] = [
 			}
 		</div>
 		<!-- Button-Right -->
-		<button type="button" class="btn-icon preset-filled" data-multi-column-right>
+		<button type="button" class="btn-icon preset-filled" data-multi-column-right title="Scroll right" aria-label="Scroll right">
 			<ArrowRight size={16} />
 		</button>
 	</div>

--- a/sites/skeleton.dev/src/examples/tailwind/buttons/Example.astro
+++ b/sites/skeleton.dev/src/examples/tailwind/buttons/Example.astro
@@ -4,7 +4,7 @@ import { ArrowRight as IconArrowRight } from 'lucide-react';
 
 <div class="flex items-center gap-4">
 	<!-- A simple icon button -->
-	<button type="button" class="btn-icon preset-filled"><IconArrowRight size={18} /></button>
+	<button type="button" class="btn-icon preset-filled" title="Go" aria-label="Go"><IconArrowRight size={18} /></button>
 	<!-- A standard button -->
 	<button type="button" class="btn preset-filled">Button</button>
 	<!-- A button + icon -->


### PR DESCRIPTION
## Linked Issue

Closes #3588 

## Description

Added title and aria-label fields to all btn-icon elements in documentation and static files.

- Add accessibility attributes to documentation examples and static files
- Update playgrounds/skeleton-core/src/pages/components/buttons.astro
- Update sites/skeleton.dev/src/components/docs/Header.astro
- Update sites/skeleton.dev/src/components/docs/Lightswitch.astro
- Update sites/skeleton.dev/src/components/docs/Drawer.astro
- Update sites/skeleton.dev/src/content/docs/headless/bits-ui.mdx
- Update sites/skeleton.dev/src/examples/guides/cookbook/scroll-containers/ExampleCarousel.astro
- Update sites/skeleton.dev/src/examples/guides/cookbook/scroll-containers/ExampleMultiColumn.astro
- Update sites/skeleton.dev/src/examples/tailwind/buttons/Example.astro

Also tracked component files that contained btn-icon for review per the issue requirements.

Moved this this issue: https://github.com/skeletonlabs/skeleton/issues/3596

#### Notes

- **Playground scope**: Wasn't sure if playground files should be included since they're dev tools rather than public facing docs, but included them since they demonstrate best practices
- **Component vs. examples**: Left component files (.svelte/.tsx) untouched and tracked above for review

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset
