### PR TITLE
Fix a bunch of typos

### DIFF
--- a/packages/skeleton-react/src/components/Navigation/Navigation.test.tsx
+++ b/packages/skeleton-react/src/components/Navigation/Navigation.test.tsx
@@ -210,7 +210,7 @@ describe('Navigation', () => {
 			expect(getByTestId(testId)).toHaveClass(expandedClasses);
 		});
 
-		it('Correctly applies the `active` prop based on wether the tile is active', async () => {
+		it('Correctly applies the `active` prop based on whether the tile is active', async () => {
 			const active = 'active';
 			const { getByTestId, rerender } = render(
 				<Navigation.Rail>

--- a/playgrounds/skeleton-react/src/app/components/file-upload/page.tsx
+++ b/playgrounds/skeleton-react/src/app/components/file-upload/page.tsx
@@ -41,7 +41,7 @@ export default function Page() {
 			</section>
 			<section className="space-y-4">
 				<h2 className="h2">Disabled</h2>
-				{/* Deafult */}
+				{/* Default */}
 				<FileUpload name="example" disabled />
 				<FileUpload name="example" disabled>
 					<button className="btn preset-filled">Disabled</button>

--- a/playgrounds/skeleton-react/src/app/components/progress/page.tsx
+++ b/playgrounds/skeleton-react/src/app/components/progress/page.tsx
@@ -57,7 +57,7 @@ export default function Page() {
 			<section className="space-y-4">
 				<h2 className="h2">Indeterminate</h2>
 				<Progress value={null}>
-					<span>Deafult Animation</span>
+					<span>Default Animation</span>
 				</Progress>
 				{/* NOTE: `custom-indeterminate` defined in app.pcss */}
 				<Progress value={null} meterAnimate="custom-indeterminate">

--- a/playgrounds/skeleton-svelte/src/routes/components/progress/+page.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/components/progress/+page.svelte
@@ -52,7 +52,7 @@
 	<section class="space-y-4">
 		<h2 class="h2">Indeterminate</h2>
 		<Progress value={null} {max}>
-			<span>Deafult Animation</span>
+			<span>Default Animation</span>
 		</Progress>
 		<!-- NOTE: `custom-indeterminate` defined in app.css -->
 		<Progress value={null} {max} meterAnimate="custom-indeterminate">

--- a/playgrounds/skeleton-svelte/src/routes/components/ratings/+page.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/components/ratings/+page.svelte
@@ -22,7 +22,7 @@
 		</Rating>
 	</section>
 	<section class="space-y-4">
-		<h2 class="h2">With Halfs</h2>
+		<h2 class="h2">With Halves</h2>
 		<Rating {value} onValueChange={(e) => (value = e.value)} allowHalf></Rating>
 	</section>
 	<section class="space-y-4">

--- a/sites/skeleton.dev/src/components/docs/Anatomy.astro
+++ b/sites/skeleton.dev/src/components/docs/Anatomy.astro
@@ -8,7 +8,7 @@ interface Props {
 
 const { isComponent, label, descriptor, tag } = Astro.props;
 
-const labelFallback = '(unlabled)';
+const labelFallback = '(unlabeled)';
 const tagFallback = 'div';
 ---
 

--- a/sites/skeleton.dev/src/content/docs/components/avatar/react.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/avatar/react.mdx
@@ -24,7 +24,7 @@ import ExampleStyleRaw from '@examples/components/avatars/ExampleStyle.tsx?raw';
 
 ## Fallback
 
-When `src` or `srcSet` are missing or fail to load, a fallback will be displayed. By default this will show the user initials, based on the `name`. Optionally you can suppy your own content using the default `children`. This can be used to display icons or even pass a [Next.js image component](https://nextjs.org/docs/pages/api-reference/components/image).
+When `src` or `srcSet` are missing or fail to load, a fallback will be displayed. By default this will show the user initials, based on the `name`. Optionally you can supply your own content using the default `children`. This can be used to display icons or even pass a [Next.js image component](https://nextjs.org/docs/pages/api-reference/components/image).
 
 <Preview client:load>
 	<Fragment slot="preview">

--- a/sites/skeleton.dev/src/content/docs/components/toast/react.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/toast/react.mdx
@@ -48,7 +48,7 @@ toaster.create({
 });
 ```
 
-Additonally, four shorthand methods are available for specific toast types.
+Additionally, four shorthand methods are available for specific toast types.
 
 - `info()`
 - `success()`

--- a/sites/skeleton.dev/src/content/docs/components/toast/svelte.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/toast/svelte.mdx
@@ -48,7 +48,7 @@ toaster.create({
 });
 ```
 
-Additonally, four shorthand methods are available for specific toast types.
+Additionally, four shorthand methods are available for specific toast types.
 
 - `info()`
 - `success()`

--- a/sites/skeleton.dev/src/content/docs/design/colors.mdx
+++ b/sites/skeleton.dev/src/content/docs/design/colors.mdx
@@ -76,7 +76,7 @@ For example:
 
 ### How Pairings Work
 
-Color Pairing are enabled through the use of the CSS [light-dark](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function. For example, the `text-primary-300-700` pairing will be implemnted in your CSS bundle as follows:
+Color Pairing are enabled through the use of the CSS [light-dark](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function. For example, the `text-primary-300-700` pairing will be implemented in your CSS bundle as follows:
 
 ```css
 .text-primary-300-700 {

--- a/sites/skeleton.dev/src/content/docs/design/presets.mdx
+++ b/sites/skeleton.dev/src/content/docs/design/presets.mdx
@@ -109,7 +109,7 @@ preset-outlined-{color}-{shade}-{shade}
 
 ## Custom Presets
 
-For advanced users, we recommend disabing the Skeleton presets in favor of custom-generated presets. This ensures you retain full control over the look and feel of each element. Consider these best practices when creating presets.
+For advanced users, we recommend disabling the Skeleton presets in favor of custom-generated presets. This ensures you retain full control over the look and feel of each element. Consider these best practices when creating presets.
 
 - Custom presets are only limited by your imagination.
 - Use any combination of Skeleton or Tailwind-provided primitive to generate a preset.

--- a/sites/skeleton.dev/src/content/docs/get-started/core-api.mdx
+++ b/sites/skeleton.dev/src/content/docs/get-started/core-api.mdx
@@ -163,7 +163,7 @@ Sets the default width for border, divide, and ring width to match the active th
 
 <figure class="linker bg-noise">
 	<a href="https://github.com/skeletonlabs/skeleton/blob/main/packages/skeleton/src/utilities" target="_blank" class="btn preset-filled">
-		View Utilites
+		View Utilities
 	</a>
 </figure>
 

--- a/sites/skeleton.dev/src/content/docs/get-started/migrate-from-v2.mdx
+++ b/sites/skeleton.dev/src/content/docs/get-started/migrate-from-v2.mdx
@@ -281,7 +281,7 @@ Skeleton v3 represents a point of reflection on what features should remain as p
 | Popovers          | [Link](https://v2.skeleton.dev/utilities/popovers)             | [Link](/docs/integrations/popover/svelte#popover) | Provided via Integration guide |
 | Toasts            | [Link](https://v2.skeleton.dev/utilities/toasts)               | [Link](/docs/integrations/toasts/svelte)          | Provided via Integration guide |
 | Table of Contents | [Link](https://v2.skeleton.dev/utilities/table-of-contents)    | [Link](/docs/guides/cookbook/table-of-contents)   | Provided via Cookbook guide    |
-| Persisted Store   | [Link](https://v2.skeleton.dev/utilities/local-storage-stores) | --                                                | Incompatable with Svelte 5     |
+| Persisted Store   | [Link](https://v2.skeleton.dev/utilities/local-storage-stores) | --                                                | Incompatible with Svelte 5     |
 
 #### Popovers and Modals
 

--- a/sites/skeleton.dev/src/content/docs/guides/cookbook/dialog.mdx
+++ b/sites/skeleton.dev/src/content/docs/guides/cookbook/dialog.mdx
@@ -27,7 +27,7 @@ This is enabled by the native [Dialog](https://developer.mozilla.org/en-US/docs/
 
 ## Animations
 
-Animating `display: none` with CSS alone has limited browser support. However, per the video below, we can use progressive enchancement our dialog to ensure animations degrade gracefully for unsupported browsers.
+Animating `display: none` with CSS alone has limited browser support. However, per the video below, we can use progressive enhancement our dialog to ensure animations degrade gracefully for unsupported browsers.
 
 <iframe
 	class="w-full aspect-video"

--- a/sites/skeleton.dev/src/content/docs/guides/cookbook/dynamic-theming.mdx
+++ b/sites/skeleton.dev/src/content/docs/guides/cookbook/dynamic-theming.mdx
@@ -175,7 +175,7 @@ In this example we will add a default theme that that can be used as a fallback.
 
 </Preview>
 
-> ⚠️ _Important_ make sure you sanitize the CSS before inserting it or you'll be vulernable to CSS injection.
+> ⚠️ _Important_ make sure you sanitize the CSS before inserting it or you'll be vulnerable to CSS injection.
 
 After doing so you should be able to toggle themes on demand by changing the `data-theme` attribute on the `html` tag.
 

--- a/sites/skeleton.dev/src/content/docs/guides/cookbook/svg-filters.mdx
+++ b/sites/skeleton.dev/src/content/docs/guides/cookbook/svg-filters.mdx
@@ -33,7 +33,7 @@ Apply a filter to any element using the Filter style property and passing the un
 <!-- The Target Element -->
 <img ... style="filter: url(#Apollo)" />
 
-<!-- Via aribtrary Tailwind syntax -->
+<!-- Via arbitrary Tailwind syntax -->
 <Avatar classes="[filter:url(#Apollo)]" />
 
 <!-- The SVG Filter with a matching unique ID -->

--- a/sites/skeleton.dev/src/content/docs/headless/bits-ui.mdx
+++ b/sites/skeleton.dev/src/content/docs/headless/bits-ui.mdx
@@ -264,4 +264,4 @@ If you wish to match Skeleton component conventions, view our [contributor compo
 
 ## Attribution
 
-Bits UI is created and maintined by [Huntabyte](https://github.com/huntabyte). Consider [sponsoring him](https://github.com/sponsors/huntabyte) to support this open source project.
+Bits UI is created and maintained by [Huntabyte](https://github.com/huntabyte). Consider [sponsoring him](https://github.com/sponsors/huntabyte) to support this open source project.

--- a/sites/skeleton.dev/src/content/docs/headless/melt-ui.mdx
+++ b/sites/skeleton.dev/src/content/docs/headless/melt-ui.mdx
@@ -224,4 +224,4 @@ If you wish to match Skeleton component conventions, view our [contributor compo
 
 ## Attribution
 
-Melt UI is created and maintined by [TGlide](https://github.com/TGlide). Consider [sponsoring him](https://github.com/sponsors/TGlide) to support this open source project.
+Melt UI is created and maintained by [TGlide](https://github.com/TGlide). Consider [sponsoring him](https://github.com/sponsors/TGlide) to support this open source project.

--- a/sites/skeleton.dev/src/content/docs/headless/radix-ui.mdx
+++ b/sites/skeleton.dev/src/content/docs/headless/radix-ui.mdx
@@ -76,7 +76,7 @@ In this guide we'll implement the following Radix UI `<ToggleGroup>` component. 
     </ProcessStep>
     <ProcessStep step="3">
         ### Component Boilerplate
-    	Create a new component in `/src/components/ToggleGroup/ToggleGroup.tsx` and insert the following markup. This will generate an unstyled version of the component. Note that we have renamed the Radix component to `RadixToggleGroup` to remain semantic and avoid conlict with our own component name.
+    	Create a new component in `/src/components/ToggleGroup/ToggleGroup.tsx` and insert the following markup. This will generate an unstyled version of the component. Note that we have renamed the Radix component to `RadixToggleGroup` to remain semantic and avoid conflict with our own component name.
 
     	```tsx
     	import { type FC } from "react";
@@ -213,4 +213,4 @@ If you wish to match Skeleton component conventions, view our [contributor compo
 
 ## Attribution
 
-Radix UI is created and maintined by [WorkOS](https://workos.com/).
+Radix UI is created and maintained by [WorkOS](https://workos.com/).

--- a/sites/skeleton.dev/src/content/docs/integrations/popover/svelte.mdx
+++ b/sites/skeleton.dev/src/content/docs/integrations/popover/svelte.mdx
@@ -25,7 +25,7 @@ import schemaModal from '@content/schemas/svelte/modal.json';
 
 <div class="card preset-tonal-warning preset-outlined-warning-500 p-8 space-y-8">
 	The following components have been introduced as a temporary solution until either Floating UI provides Svelte bindings, the upcoming
-	native browser APIs become widely avialable, or another alternative is introduced (whichever comes first). Until that time, Skeleton will
+	native browser APIs become widely available, or another alternative is introduced (whichever comes first). Until that time, Skeleton will
 	continue to maintain these components for production use. Maintenance will continue until the next major version of Skeleton if an
 	alternative is introduced.
 </div>

--- a/sites/skeleton.dev/src/content/docs/resources/contribute/components.mdx
+++ b/sites/skeleton.dev/src/content/docs/resources/contribute/components.mdx
@@ -91,7 +91,7 @@ let {
 
 ### Style Prop Conventions
 
-Style props implement sementic naming conventions to enable specificity and avoid naming conflicts. These are organized into three specific categories. Each should be maintained in the following order.
+Style props implement semantic naming conventions to enable specificity and avoid naming conflicts. These are organized into three specific categories. Each should be maintained in the following order.
 
 ```svelte
 <script lang="ts">
@@ -122,7 +122,7 @@ Style props implement sementic naming conventions to enable specificity and avoi
 ```
 
 - `base` - houses any structural utility classes, which can be replaced in a faux-headless manner.
-  - The outter most element is referred to as the Parent in this context. Elements within are children.
+  - The outermost element is referred to as the Parent in this context. Elements within are children.
   - Parent props are not prefixed, which helps maintain parity cross-framework
   - Child props are prefixed: `titleBase`, `panelBase`, `controlBase`.
 - `{property}` - individual style props that house one or more “swappable” utility classes.

--- a/sites/skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
+++ b/sites/skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
@@ -68,7 +68,7 @@ If you wish to prevent a page from showing in the navigation, prefix it with an 
 
 ## Using MDX
 
-View the [Astro MDX Documention](https://docs.astro.build/en/guides/markdown-content/) or refer to `/src/content/docs/resources/_markdown.md` for a "kitchen sink" example page.
+View the [Astro MDX Documentation](https://docs.astro.build/en/guides/markdown-content/) or refer to `/src/content/docs/resources/_markdown.md` for a "kitchen sink" example page.
 
 ### MDX Components
 

--- a/sites/skeleton.dev/src/content/docs/resources/contribute/get-started.mdx
+++ b/sites/skeleton.dev/src/content/docs/resources/contribute/get-started.mdx
@@ -91,7 +91,7 @@ Isolated sandbox environments for developing, testing and experimenting.
 
 ## Branch
 
-Create and target all pull requests agaist the `main` branch unless otherwise instructed.
+Create and target all pull requests against the `main` branch unless otherwise instructed.
 
 | Branch | Description                                        | Pull Requests                                  |
 | ------ | -------------------------------------------------- | ---------------------------------------------- |

--- a/sites/skeleton.dev/src/content/docs/tailwind/forms.mdx
+++ b/sites/skeleton.dev/src/content/docs/tailwind/forms.mdx
@@ -40,7 +40,7 @@ import ExampleGroupsRaw from '@examples/tailwind/forms/ExampleGroups.astro?raw';
 
 ### Tailwind Forms
 
-Skeleton relies on the official [Tailwind Forms](https://github.com/tailwindlabs/tailwindcss-forms) plugin to normalize form styling. Ths plugin is required if you wish to make use of any utility classes provided on this page.
+Skeleton relies on the official [Tailwind Forms](https://github.com/tailwindlabs/tailwindcss-forms) plugin to normalize form styling. This plugin is required if you wish to make use of any utility classes provided on this page.
 
 <figure class="card-filled-enhanced flex justify-center gap-4 p-8">
 	<a class="btn preset-filled" href="https://github.com/tailwindlabs/tailwindcss-forms" target="_blank">

--- a/sites/skeleton.dev/src/examples/tailwind/forms/ExampleSelection.astro
+++ b/sites/skeleton.dev/src/examples/tailwind/forms/ExampleSelection.astro
@@ -9,7 +9,7 @@
 	</select>
 
 	<!--
-		NOTE: the following Select element variants are included purely for legacy support. It is not longer advised you use these variants in production apps. Currently the styles are too limited and the style API vary greatly bewteen browser vendors. Expect these styles to be removed in the next major version of Skeleton (v4.0). In the meantime, consider a replacement using a custom Listbox component if you need this type of interface in your application. We've provided some resources below to guide you in this process.
+		NOTE: the following Select element variants are included purely for legacy support. It is not longer advised you use these variants in production apps. Currently the styles are too limited and the style API vary greatly between browser vendors. Expect these styles to be removed in the next major version of Skeleton (v4.0). In the meantime, consider a replacement using a custom Listbox component if you need this type of interface in your application. We've provided some resources below to guide you in this process.
 
 		ARIA APG Guidelines:
 		https://www.w3.org/WAI/ARIA/apg/patterns/listbox/

--- a/sites/skeleton.dev/src/lib/generate-llm.ts
+++ b/sites/skeleton.dev/src/lib/generate-llm.ts
@@ -87,7 +87,7 @@ async function processPreviewBlocks(content: string, language: string): Promise<
 		// 	    <Code code={ExampleRaw} lang="tsx" />
 		// </Fragment>
 		//</Preview>
-		// We really only care about the code part and detect which path it is refering to
+		// We really only care about the code part and detect which path it is referring to
 		// by using the rawImports Record
 
 		// <Code code={ExampleRaw} lang="tsx" /> -> ExampleRaw

--- a/sites/skeleton.dev/src/styles/app.css
+++ b/sites/skeleton.dev/src/styles/app.css
@@ -121,7 +121,7 @@ html {
 }
 
 /* Linker */
-/* Prominant link elements for MDX pages */
+/* Prominent link elements for MDX pages */
 
 .linker {
 	border-radius: var(--radius-container);

--- a/sites/themes.skeleton.dev/src/lib/utils/importer/import-theme-v2.ts
+++ b/sites/themes.skeleton.dev/src/lib/utils/importer/import-theme-v2.ts
@@ -51,7 +51,7 @@ export async function importThemeV2(fileText: string, fileName: string) {
 		// Update Properties
 		scale.forEach((color, i) => {
 			properties[`--color-${colorName}-${constants.colorShades[i]}`] = color; // hex
-			// TODO: replce with oklch format in the future
+			// TODO: replace with oklch format in the future
 			// // @ts-expect-error oklch param
 			// properties[`--color-${colorName}-${constants.colorShades[i]}`] = chroma(color).css('oklch');
 		});
@@ -67,6 +67,6 @@ export async function importThemeV2(fileText: string, fileName: string) {
 	}
 
 	/* Generate Contrast Colors */
-	/* NOTE: this is a bit redudant, but should get us by for now */
+	/* NOTE: this is a bit redundant, but should get us by for now */
 	constants.colorNames.forEach((name) => genColorRamp(false, name));
 }

--- a/sites/themes.skeleton.dev/src/lib/utils/importer/import-theme-v3.ts
+++ b/sites/themes.skeleton.dev/src/lib/utils/importer/import-theme-v3.ts
@@ -69,6 +69,6 @@ export async function importThemeV3(fileText: string, fileName: string) {
 	}
 
 	/* Generate Contrast Colors */
-	/* NOTE: this is a bit redudant, but should get us by for now */
+	/* NOTE: this is a bit redundant, but should get us by for now */
 	constants.colorNames.forEach((name) => genColorRamp(false, name));
 }

--- a/sites/themes.skeleton.dev/src/routes/(app)/themes/import/+page.svelte
+++ b/sites/themes.skeleton.dev/src/routes/(app)/themes/import/+page.svelte
@@ -6,7 +6,7 @@
 	import { importThemeV2 } from '$lib/utils/importer/import-theme-v2';
 	import { importThemeV3 } from '$lib/utils/importer/import-theme-v3';
 	// import { importThemeV3Rc1 } from '$lib/utils/importer/import-theme-v3-rc1';
-	// Componets (skeleton)
+	// Components (skeleton)
 	import { FileUpload } from '@skeletonlabs/skeleton-svelte';
 	// Icons
 	import IconUpload from '@lucide/svelte/icons/file-up';


### PR DESCRIPTION
## Description

I used [the typos tool](https://github.com/crate-ci/typos#readme) and hand-picked those fixes that don't possibly change the code semantics.

There are some typos in TailwindCSS classes/CSS props that need more a careful review.

I'm not supplying any changesets as these are just typo fixes.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset
