### PR TITLE
Bugfix for consistent input placeholder text color

### DIFF
--- a/.changeset/witty-files-matter.md
+++ b/.changeset/witty-files-matter.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Set universal input placeholder to ensure consistent coloring
+  

--- a/packages/skeleton/src/base/globals.css
+++ b/packages/skeleton/src/base/globals.css
@@ -52,6 +52,12 @@
 		cursor: pointer;
 	}
 
+	/* Form Placeholders --- */
+
+	*::placeholder {
+		color: var(--color-surface-700-300);
+	}
+
 	/* Selection --- */
 	/* https://developer.mozilla.org/en-US/docs/Web/CSS/::selection */
 

--- a/packages/skeleton/src/utilities/form-inputs.css
+++ b/packages/skeleton/src/utilities/form-inputs.css
@@ -30,12 +30,6 @@
 		--tw-ring-color: var(--color-primary-500);
 	}
 
-	/* Placeholder --- */
-
-	&::placeholder {
-		color: var(--color-surface-700-300);
-	}
-
 	/* File Input --- */
 
 	&[type='file']::file-selector-button {

--- a/packages/skeleton/src/utilities/form-textareas.css
+++ b/packages/skeleton/src/utilities/form-textareas.css
@@ -29,10 +29,4 @@
 	@variant focus-within {
 		--tw-ring-color: var(--color-primary-500);
 	}
-
-	/* Placeholder --- */
-
-	&::placeholder {
-		color: var(--color-surface-800-200);
-	}
 }


### PR DESCRIPTION
## Linked Issue

Closes #3605

## Description

Drop individual utility element placeholder styling for a singular global placeholder color value. This should actually prove easier for users to overwrite if they wish to customize this value on their own, while providing a blanket default for any and all input usage.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
