### PR TITLE
Fix Check in pipeline

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -46,6 +46,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install
+      - run: pnpm build
       - run: pnpm check
   build:
     name: Build


### PR DESCRIPTION
Adds the `build` step before running `check` because `check` includes type checking which will only be present after all monorepo packages are fully built