### PR TITLE
feat: add disableAutoFilter prop to Combobox for custom filtering

### DIFF
--- a/.changeset/cyan-brooms-run.md
+++ b/.changeset/cyan-brooms-run.md
@@ -1,5 +1,0 @@
----
-"@skeletonlabs/skeleton-svelte": patch
----
-
-feature: Added disableAutoFilter prop to Combobox for custom filtering control.

--- a/.changeset/cyan-brooms-run.md
+++ b/.changeset/cyan-brooms-run.md
@@ -1,0 +1,5 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+feature: Added disableAutoFilter prop to Combobox for custom filtering control.

--- a/.changeset/sharp-crabs-smash.md
+++ b/.changeset/sharp-crabs-smash.md
@@ -2,5 +2,4 @@
 "@skeletonlabs/skeleton-svelte": patch
 ---
 
-Added customizable `filter` prop to Combobox for flexible filtering, replacing `disableAutoFilter`. Supports custom filter functions, null to disable internal filtering, and maintains default behavior
-  
+chore: Ensure Comboxbox data is reactive, enable custom filtering, and set max content height

--- a/.changeset/sharp-crabs-smash.md
+++ b/.changeset/sharp-crabs-smash.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+Added customizable `filter` prop to Combobox for flexible filtering, replacing `disableAutoFilter`. Supports custom filter functions, null to disable internal filtering, and maintains default behavior
+  

--- a/packages/skeleton-svelte/src/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/components/Combobox/Combobox.svelte
@@ -66,7 +66,9 @@
 		...zagProps,
 		onOpenChange(event) {
 			if (event.open && filter !== null) {
-				internalOptions = data;
+				internalOptions = data.filter((item) => filter(item, api.inputValue));
+			} else if (event.open) {
+				internalOptions = [...data];
 			}
 			zagProps.onOpenChange?.(event);
 		},

--- a/packages/skeleton-svelte/src/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/components/Combobox/Combobox.svelte
@@ -8,6 +8,7 @@
 		data = [],
 		label = '',
 		zIndex = 'auto',
+		disableAutoFilter = false,
 		// Base
 		base = '',
 		width = '',
@@ -65,11 +66,19 @@
 			zagProps.onOpenChange?.(event);
 		},
 		onInputValueChange(event) {
-			const filtered = data.filter((item) => item.label.toLowerCase().includes(event.inputValue.toLowerCase()));
-			options = filtered;
+			if (!disableAutoFilter) {
+				const filtered = data.filter((item) => item.label.toLowerCase().includes(event.inputValue.toLowerCase()));
+				options = filtered;
+			}
 			zagProps.onInputValueChange?.(event);
 		}
 	}));
+
+	if (disableAutoFilter) {
+		$effect(() => {
+			options = data;
+		});
+	}
 	const api = $derived(combobox.connect(service, normalizeProps));
 	const triggerProps = $derived(mergeProps(api.getTriggerProps(), { onclick }));
 </script>

--- a/packages/skeleton-svelte/src/components/Combobox/Combobox.svelte
+++ b/packages/skeleton-svelte/src/components/Combobox/Combobox.svelte
@@ -8,7 +8,6 @@
 		data = [],
 		label = '',
 		zIndex = 'auto',
-		filter = (item: T, value: string) => item.label.toLowerCase().includes(value.toLowerCase()),
 		// Base
 		base = '',
 		width = '',
@@ -27,9 +26,10 @@
 		positionerBase = '',
 		positionerClasses = '',
 		// Content
-		contentBase = 'card p-2',
+		contentBase = 'card p-2 overflow-y-auto',
 		contentBackground = 'preset-outlined-surface-200-800 bg-surface-50-950',
 		contentSpaceY = 'space-y-1',
+		contentMaxHeight = 'max-h-80',
 		contentClasses = '',
 		// Option
 		optionBase = 'btn justify-start w-full',
@@ -46,8 +46,8 @@
 	}: ComboboxProps<T> = $props();
 
 	// Zag
-	let internalOptions = $state(data);
-	const options = $derived(filter === null ? data : internalOptions);
+	let options = $derived(data);
+
 	const collection = $derived(
 		combobox.collection({
 			items: options,
@@ -64,19 +64,20 @@
 			return collection;
 		},
 		...zagProps,
-		onOpenChange(event) {
-			if (event.open && filter !== null) {
-				internalOptions = data.filter((item) => filter(item, api.inputValue));
-			} else if (event.open) {
-				internalOptions = [...data];
+		async onOpenChange(event) {
+			if (zagProps.onOpenChange) {
+				zagProps.onOpenChange(event);
+				return;
 			}
-			zagProps.onOpenChange?.(event);
+			options = data;
 		},
-		onInputValueChange(event) {
-			if (filter !== null) {
-				internalOptions = data.filter((item) => filter(item, event.inputValue));
+		async onInputValueChange(event) {
+			if (zagProps.onInputValueChange) {
+				zagProps.onInputValueChange(event);
+				return;
 			}
-			zagProps.onInputValueChange?.(event);
+			const filtered = data.filter((item) => item.label.toLowerCase().includes(event.inputValue.toLowerCase()));
+			options = filtered;
 		}
 	}));
 
@@ -123,7 +124,7 @@
 				<!-- Content (list) -->
 				<nav
 					{...api.getContentProps()}
-					class="{contentBase} {contentBackground} {contentSpaceY} {contentClasses}"
+					class="{contentBase} {contentBackground} {contentSpaceY} {contentClasses} {contentMaxHeight}"
 					style="z-index: {zIndex}"
 				>
 					{#each options as option (option.label)}

--- a/packages/skeleton-svelte/src/components/Combobox/types.ts
+++ b/packages/skeleton-svelte/src/components/Combobox/types.ts
@@ -8,9 +8,8 @@ export interface ComboboxProps<T extends ComboboxItem> extends Omit<combobox.Pro
 	label?: string;
 	/** Set a positioner style for z-index, ex: "10" */
 	zIndex?: string;
-
-	/** Set to true to disable the automatic internal filtering, allowing full custom control over data updates via onInputValueChange. Defaults to false. */
-	disableAutoFilter?: boolean;
+	/** Custom filter function for items based on input value. Defaults to case-insensitive label includes. Set to `null` to disable internal filtering and manage data updates manually via `onInputValueChange`. */
+	filter?: ((item: T, value: string) => boolean) | null;
 
 	// Base ---
 	/** Set base classes for the root element. */

--- a/packages/skeleton-svelte/src/components/Combobox/types.ts
+++ b/packages/skeleton-svelte/src/components/Combobox/types.ts
@@ -50,8 +50,7 @@ export interface ComboboxProps<T extends ComboboxItem> extends Omit<combobox.Pro
 	contentBackground?: string;
 	/** Set space-y classes for the content. */
 	contentSpaceY?: string;
-	/** Maximum height of the combobox options list container. Controls vertical scrolling when there are many options. Default: 'max-h-80'.
-	 * Use Tailwind CSS classes (e.g., 'max-h-64') or a valid CSS value (e.g., '300px'). */
+	/** Set max-h classes for the content. */
 	contentMaxHeight?: string;
 	/** Provide arbitrary classes for the content. */
 	contentClasses?: string;

--- a/packages/skeleton-svelte/src/components/Combobox/types.ts
+++ b/packages/skeleton-svelte/src/components/Combobox/types.ts
@@ -9,6 +9,9 @@ export interface ComboboxProps<T extends ComboboxItem> extends Omit<combobox.Pro
 	/** Set a positioner style for z-index, ex: "10" */
 	zIndex?: string;
 
+	/** Set to true to disable the automatic internal filtering, allowing full custom control over data updates via onInputValueChange. Defaults to false. */
+	disableAutoFilter?: boolean;
+
 	// Base ---
 	/** Set base classes for the root element. */
 	base?: string;

--- a/packages/skeleton-svelte/src/components/Combobox/types.ts
+++ b/packages/skeleton-svelte/src/components/Combobox/types.ts
@@ -8,8 +8,6 @@ export interface ComboboxProps<T extends ComboboxItem> extends Omit<combobox.Pro
 	label?: string;
 	/** Set a positioner style for z-index, ex: "10" */
 	zIndex?: string;
-	/** Custom filter function for items based on input value. Defaults to case-insensitive label includes. Set to `null` to disable internal filtering and manage data updates manually via `onInputValueChange`. */
-	filter?: ((item: T, value: string) => boolean) | null;
 
 	// Base ---
 	/** Set base classes for the root element. */
@@ -52,6 +50,9 @@ export interface ComboboxProps<T extends ComboboxItem> extends Omit<combobox.Pro
 	contentBackground?: string;
 	/** Set space-y classes for the content. */
 	contentSpaceY?: string;
+	/** Maximum height of the combobox options list container. Controls vertical scrolling when there are many options. Default: 'max-h-80'.
+	 * Use Tailwind CSS classes (e.g., 'max-h-64') or a valid CSS value (e.g., '300px'). */
+	contentMaxHeight?: string;
 	/** Provide arbitrary classes for the content. */
 	contentClasses?: string;
 

--- a/sites/skeleton.dev/src/content/docs/integrations/popover/svelte.mdx
+++ b/sites/skeleton.dev/src/content/docs/integrations/popover/svelte.mdx
@@ -145,6 +145,21 @@ Triggers an anchored popover list when you tap the arrow. Includes auto-suggesti
 	</Fragment>
 </Preview>
 
+Supplying a custom filter:
+
+```ts
+let selectedValue = $state(['']);
+function customSearchFn(e) { ... }
+```
+
+{/* prettier-ignore */}
+```svelte
+<Combobox
+	onValueChange={(e) => (selectedValue = e.value)}
+	onInputValueChange={(e) => customSearchFn(e.inputValue)}
+>...</Combobox>
+```
+
 ### Anatomy
 
 <Anatomy label="Combobox" element="span" isComponent>


### PR DESCRIPTION
## Linked Issue

Closes #3600
Closes #3328

## Description

This PR addresses the issues reported in #3600, where the Combobox component experiences desynchronization between the provided data and the filtered options. The root cause is the internal "contains" filter logic, which always executes before any external handlers (e.g., onInputValueChange). This results in the data being one step behind, causing lag in scenarios involving dynamic filtering, such as minimum length checks or asynchronous API fetches.

To resolve this, I've introduced an optional boolean prop disableAutoFilter (default: false). When set to true, the internal filtering is skipped, allowing users full control over data updates via their own onInputValueChange handler. This ensures seamless handling of custom filtering logic without interference from the component's built-in behavior.

Additionally, a reactive $effect has been added to synchronize the options with the data prop when auto-filtering is disabled, maintaining reactivity.

This approach preserves backward compatibility, as the default behavior remains unchanged.

**Alternatives Considered**
I evaluated a more flexible option, such as introducing a filterFn prop to allow custom filter callbacks. However, the disableAutoFilter prop provides a simpler and more accessible solution for users, especially beginners, while still enabling advanced customization.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [X] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [X] Contributions should target the `main` branch
- [X] Documentation should be updated to describe all relevant changes
- [X] Run `pnpm check` in the root of the monorepo
- [X] Run `pnpm format` in the root of the monorepo
- [X] Run `pnpm lint` in the root of the monorepo
- [X] Run `pnpm test` in the root of the monorepo
- [X] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
