### PR TITLE
feat: add title and aria-label attributes to btn-icon components

### DIFF
--- a/.changeset/shaggy-jokes-start.md
+++ b/.changeset/shaggy-jokes-start.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-svelte": minor
+"@skeletonlabs/skeleton-react": minor
+---
+
+feature: Add accessibility props to btn-icon components
+  

--- a/packages/skeleton-react/src/components/Toast/Toaster.tsx
+++ b/packages/skeleton-react/src/components/Toast/Toaster.tsx
@@ -27,6 +27,9 @@ export function Toaster({
 	// Dismiss Button
 	btnDismissBase = 'btn-icon hover:preset-tonal',
 	btnDismissClasses = '',
+	// Accessibility
+	btnDismissTitle = 'Dismiss',
+	btnDismissAriaLabel = 'Dismiss',
 	// State
 	stateInfo = 'preset-outlined-surface-200-800 preset-filled-surface-50-950',
 	stateSuccess = 'preset-filled-success-500',
@@ -57,6 +60,8 @@ export function Toaster({
 					descriptionClasses={descriptionClasses}
 					btnDismissBase={btnDismissBase}
 					btnDismissClasses={btnDismissClasses}
+					btnDismissTitle={btnDismissTitle}
+					btnDismissAriaLabel={btnDismissAriaLabel}
 					stateInfo={stateInfo}
 					stateError={stateError}
 					stateWarning={stateWarning}

--- a/packages/skeleton-react/src/components/Toast/types.ts
+++ b/packages/skeleton-react/src/components/Toast/types.ts
@@ -39,6 +39,12 @@ export interface ToasterProps {
 	/** Provide arbitrary classes for the dismiss button. */
 	btnDismissClasses?: string;
 
+	// Accessibility ---
+	/** Provide the title attribute for the dismiss button. */
+	btnDismissTitle?: string;
+	/** Provide the aria-label attribute for the dismiss button. */
+	btnDismissAriaLabel?: string;
+
 	// State ---
 	/** Provide base classes for info toasts. */
 	stateInfo?: string;

--- a/packages/skeleton-svelte/src/components/Toast/Toaster.svelte
+++ b/packages/skeleton-svelte/src/components/Toast/Toaster.svelte
@@ -25,6 +25,9 @@
 		// Dismiss Button
 		btnDismissBase = 'btn-icon hover:preset-tonal',
 		btnDismissClasses = '',
+		// Accessibility
+		btnDismissTitle = 'Dismiss',
+		btnDismissAriaLabel = 'Dismiss',
 		// State
 		stateInfo = 'preset-outlined-surface-200-800 preset-filled-surface-50-950',
 		stateSuccess = 'preset-filled-success-500',
@@ -56,6 +59,8 @@
 			{descriptionClasses}
 			{btnDismissBase}
 			{btnDismissClasses}
+			{btnDismissTitle}
+			{btnDismissAriaLabel}
 			{stateInfo}
 			{stateError}
 			{stateWarning}

--- a/packages/skeleton-svelte/src/components/Toast/types.ts
+++ b/packages/skeleton-svelte/src/components/Toast/types.ts
@@ -40,6 +40,12 @@ export interface ToasterProps extends toast.StoreProps {
 	/** Provide arbitrary classes for the dismiss button. */
 	btnDismissClasses?: string;
 
+	// Accessibility ---
+	/** Provide the title attribute for the dismiss button. */
+	btnDismissTitle?: string;
+	/** Provide the aria-label attribute for the dismiss button. */
+	btnDismissAriaLabel?: string;
+
 	// State ---
 	/** Provide base classes for info toasts. */
 	stateInfo?: string;

--- a/playgrounds/skeleton-react/src/app/components/app-bar/page.tsx
+++ b/playgrounds/skeleton-react/src/app/components/app-bar/page.tsx
@@ -137,7 +137,7 @@ export default function Page() {
 			<AppBar>
 				<AppBar.Toolbar>
 					<AppBar.ToolbarLead>
-						<button type="button" className="btn-icon preset-filled-primary-500">
+						<button type="button" className="btn-icon preset-filled-primary-500" title="Menu" aria-label="Menu">
 							<Skull size={22} />
 						</button>
 						<button type="button" className="btn preset-filled">
@@ -149,7 +149,7 @@ export default function Page() {
 						<button type="button" className="btn preset-filled">
 							Skeleton
 						</button>
-						<button type="button" className="btn-icon preset-filled-primary-500">
+						<button type="button" className="btn-icon preset-filled-primary-500" title="Menu" aria-label="Menu">
 							<Skull size={22} />
 						</button>
 					</AppBar.ToolbarTrail>

--- a/playgrounds/skeleton-svelte/src/routes/components/app-bars/+page.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/components/app-bars/+page.svelte
@@ -120,13 +120,13 @@
 <button type="button" class="btn preset-filled">Button before the AppBar</button>
 <AppBar>
 	{#snippet lead()}
-		<button type="button" class="btn-icon preset-filled-primary-500"><Skull size={22} /></button>
+		<button type="button" class="btn-icon preset-filled-primary-500" title="Menu" aria-label="Menu"><Skull size={22} /></button>
 		<button type="button" class="btn preset-filled">Skeleton</button>
 	{/snippet}
 	Skeleton
 	{#snippet trail()}
 		<button type="button" class="btn preset-filled">Skeleton</button>
-		<button type="button" class="btn-icon preset-filled-primary-500"><Skull size={22} /></button>
+		<button type="button" class="btn-icon preset-filled-primary-500" title="Menu" aria-label="Menu"><Skull size={22} /></button>
 	{/snippet}
 </AppBar>
 <button type="button" class="btn preset-filled">Button after the AppBar</button>
@@ -135,13 +135,13 @@
 <div dir="rtl">
 	<AppBar>
 		{#snippet lead()}
-			<button type="button" class="btn-icon preset-filled-primary-500"><Skull size={22} /></button>
+			<button type="button" class="btn-icon preset-filled-primary-500" title="Menu" aria-label="Menu"><Skull size={22} /></button>
 			<button type="button" class="btn preset-filled">lead</button>
 		{/snippet}
 		skeleton
 		{#snippet trail()}
 			<button type="button" class="btn preset-filled">trail</button>
-			<button type="button" class="btn-icon preset-filled-primary-500"><Skull size={22} /></button>
+			<button type="button" class="btn-icon preset-filled-primary-500" title="Menu" aria-label="Menu"><Skull size={22} /></button>
 		{/snippet}
 		{#snippet headline()}
 			<h1 class="h1">مرحبا بك</h1>

--- a/playgrounds/skeleton-svelte/src/routes/components/popover/+page.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/components/popover/+page.svelte
@@ -44,7 +44,7 @@
 			{#snippet content()}
 				<header class="flex justify-between">
 					<p class="font-bold text-xl">Popover</p>
-					<button class="btn-icon" onclick={popoverClose}>
+					<button class="btn-icon" onclick={popoverClose} title="Close" aria-label="Close">
 						<IconX />
 					</button>
 				</header>

--- a/sites/skeleton.dev/src/components/homepage/HomeCompGrid.svelte
+++ b/sites/skeleton.dev/src/components/homepage/HomeCompGrid.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { HomeCompGridProps } from './types';
 	import { Avatar, Slider, Switch, ProgressRing } from '@skeletonlabs/skeleton-svelte';
 	// Icons
 	import IconPlay from '@lucide/svelte/icons/play';
@@ -12,6 +13,14 @@
 	import IconRewind from '@lucide/svelte/icons/rewind';
 	import IconFastForward from '@lucide/svelte/icons/fast-forward';
 	import IconVolume from '@lucide/svelte/icons/volume-2';
+
+	// Accessibility
+	const {
+		revenueExpandTitle = 'Expand revenue details',
+		revenueExpandAriaLabel = 'Expand revenue details',
+		playTitle = 'Play music',
+		playAriaLabel = 'Play music'
+	}: HomeCompGridProps = $props();
 
 	// Classes
 	const cardClasses = 'card preset-outlined-surface-200-800 bg-surface-50-950 p-5 space-y-5';
@@ -239,7 +248,7 @@
 					<h2 class="h3">Revenue</h2>
 					<p class="text-xs opacity-60">Posted April 1-13</p>
 				</div>
-				<button type="button" class="btn-icon rounded-full preset-tonal">
+				<button type="button" class="btn-icon rounded-full preset-tonal" title={revenueExpandTitle} aria-label={revenueExpandAriaLabel}>
 					<IconArrowUpRight class="size-4" />
 				</button>
 			</header>
@@ -378,7 +387,12 @@
 		<!-- 14 -->
 		<div class={`${cardClasses} col-span-2 row-span-2 col-start-3 row-start-7`}>
 			<div class="h-full grid grid-cols-[auto_2fr_0.5fr] items-center gap-2 px-5">
-				<button type="button" class="btn-icon btn-icon-lg rounded-full preset-filled-primary-500 scale-150">
+				<button
+					type="button"
+					class="btn-icon btn-icon-lg rounded-full preset-filled-primary-500 scale-150"
+					title={playTitle}
+					aria-label={playAriaLabel}
+				>
 					<IconPlay class="size-6 fill-current stroke-none" />
 				</button>
 				<div class="grid grid-cols-[auto_1fr_auto] gap-5 items-center px-10">

--- a/sites/skeleton.dev/src/components/homepage/types.ts
+++ b/sites/skeleton.dev/src/components/homepage/types.ts
@@ -1,0 +1,13 @@
+export interface HomeCompGridProps {
+	// Revenue ---
+	/** Provide the title attribute for the revenue expand button. */
+	revenueExpandTitle?: string;
+	/** Provide the aria-label attribute for the revenue expand button. */
+	revenueExpandAriaLabel?: string;
+
+	// Music player ---
+	/** Provide the title attribute for the main play button. */
+	playTitle?: string;
+	/** Provide the aria-label attribute for the main play button. */
+	playAriaLabel?: string;
+}

--- a/sites/skeleton.dev/src/examples/components/popover/ExamplePopover.svelte
+++ b/sites/skeleton.dev/src/examples/components/popover/ExamplePopover.svelte
@@ -22,7 +22,7 @@
 	{#snippet content()}
 		<header class="flex justify-between">
 			<p class="font-bold text-xl">Popover Example</p>
-			<button class="btn-icon hover:preset-tonal" onclick={popoverClose}><IconX /></button>
+			<button class="btn-icon hover:preset-tonal" onclick={popoverClose} title="Close" aria-label="Close"><IconX /></button>
 		</header>
 		<article>
 			<p class="opacity-60">

--- a/sites/skeleton.dev/src/examples/components/popover/ExamplePopover.tsx
+++ b/sites/skeleton.dev/src/examples/components/popover/ExamplePopover.tsx
@@ -61,7 +61,7 @@ export const Page: React.FC = () => {
 						<div className="space-y-4">
 							<header className="flex justify-between">
 								<p className="font-bold text-xl">Popover Example</p>
-								<button className="btn-icon hover:preset-tonal" onClick={() => setIsOpen(false)}>
+								<button className="btn-icon hover:preset-tonal" onClick={() => setIsOpen(false)} title="Close" aria-label="Close">
 									<IconX />
 								</button>
 							</header>

--- a/sites/skeleton.dev/src/examples/guides/cookbook/stepper/Example.svelte
+++ b/sites/skeleton.dev/src/examples/guides/cookbook/stepper/Example.svelte
@@ -49,7 +49,8 @@
 					<button
 						class="btn-icon btn-icon-sm rounded-full {isCurrentStep(i) ? 'preset-filled-primary-500' : 'preset-filled-surface-200-800'}"
 						onclick={() => setStep(i)}
-						title={step.label}
+						title="Go to {step.label}"
+						aria-label="Go to {step.label}"
 					>
 						<span class="font-bold">{i + 1}</span>
 					</button>

--- a/sites/themes.skeleton.dev/src/lib/components/common/Lightswitch/Lightswitch.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/common/Lightswitch/Lightswitch.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import IconSun from '@lucide/svelte/icons/sun';
 	import IconMoon from '@lucide/svelte/icons/moon';
+	import type { LightswitchProps } from './types';
+
+	const { title = 'Toggle dark mode.', ariaLabel = 'Toggle dark mode.' }: LightswitchProps = $props();
 
 	let darkMode = $state(true);
 
@@ -14,7 +17,7 @@
 	}
 </script>
 
-<button class="btn-icon hover:preset-tonal" onclick={toggleDarkMode}>
+<button class="btn-icon hover:preset-tonal" onclick={toggleDarkMode} {title} aria-label={ariaLabel}>
 	{#if darkMode}
 		<IconSun size={20} />
 	{:else}

--- a/sites/themes.skeleton.dev/src/lib/components/common/Lightswitch/types.ts
+++ b/sites/themes.skeleton.dev/src/lib/components/common/Lightswitch/types.ts
@@ -1,0 +1,7 @@
+export interface LightswitchProps {
+	// Accessibility ---
+	/** Provide the title attribute for the theme toggle button. */
+	title?: string;
+	/** Provide the aria-label attribute for the theme toggle button. */
+	ariaLabel?: string;
+}

--- a/sites/themes.skeleton.dev/src/lib/components/generator/Controls/Controls.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/generator/Controls/Controls.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { ControlsProps } from './types';
 	// State
 	import { globals } from '$lib/state/generator.svelte';
 	// Components (Skeleton)
@@ -29,6 +30,20 @@
 
 	// State
 	let settings: string[] = $state([]);
+
+	// Accessibility
+	const {
+		colorTitle = 'Color Palette',
+		colorAriaLabel = 'Color Palette',
+		backgroundsTitle = 'Backgrounds',
+		backgroundsAriaLabel = 'Backgrounds',
+		spacingTitle = 'Spacing',
+		spacingAriaLabel = 'Spacing',
+		edgesTitle = 'Edges',
+		edgesAriaLabel = 'Edges',
+		typographyTitle = 'Typography',
+		typographyAriaLabel = 'Typography'
+	}: ControlsProps = $props();
 </script>
 
 <section class="relative h-screen bg-surface-100-900 pb-96 overflow-y-auto">
@@ -51,35 +66,43 @@
 			<hr class="hr" />
 			<!-- Controls: Colors -->
 			<Accordion.Item value="colors" {...accordionItemProps}>
-				{#snippet lead()}<span class="btn-icon preset-tonal"><IconColors size={20} /></span>{/snippet}
+				{#snippet lead()}<span class="btn-icon preset-tonal" title={colorTitle} aria-label={colorAriaLabel}><IconColors size={20} /></span
+					>{/snippet}
 				{#snippet control()}<span class="h4">Color Palette</span>{/snippet}
 				{#snippet panel()}<ControlsColors />{/snippet}
 			</Accordion.Item>
 			<hr class="hr" />
 			<!-- Controls: Backgrounds -->
 			<Accordion.Item value="backgrounds" {...accordionItemProps}>
-				{#snippet lead()}<span class="btn-icon preset-tonal"><IconBackgrounds size={20} /></span>{/snippet}
+				{#snippet lead()}<span class="btn-icon preset-tonal" title={backgroundsTitle} aria-label={backgroundsAriaLabel}
+						><IconBackgrounds size={20} /></span
+					>{/snippet}
 				{#snippet control()}<span class="h4">Backgrounds</span>{/snippet}
 				{#snippet panel()}<ControlsBackgrounds />{/snippet}
 			</Accordion.Item>
 			<hr class="hr" />
 			<!-- Controls: Spacing -->
 			<Accordion.Item value="spacing" {...accordionItemProps}>
-				{#snippet lead()}<span class="btn-icon preset-tonal"><IconSpacing size={20} /></span>{/snippet}
+				{#snippet lead()}<span class="btn-icon preset-tonal" title={spacingTitle} aria-label={spacingAriaLabel}
+						><IconSpacing size={20} /></span
+					>{/snippet}
 				{#snippet control()}<span class="h4">Spacing</span>{/snippet}
 				{#snippet panel()}<ControlsSpacing />{/snippet}
 			</Accordion.Item>
 			<hr class="hr" />
 			<!-- Controls: Edges -->
 			<Accordion.Item value="edges" {...accordionItemProps}>
-				{#snippet lead()}<span class="btn-icon preset-tonal"><IconEdges size={20} /></span>{/snippet}
+				{#snippet lead()}<span class="btn-icon preset-tonal" title={edgesTitle} aria-label={edgesAriaLabel}><IconEdges size={20} /></span
+					>{/snippet}
 				{#snippet control()}<span class="h4">Edges</span>{/snippet}
 				{#snippet panel()}<ControlsEdges />{/snippet}
 			</Accordion.Item>
 			<hr class="hr" />
 			<!-- Controls: Typography -->
 			<Accordion.Item value="typography" {...accordionItemProps}>
-				{#snippet lead()}<span class="btn-icon preset-tonal"><IconTypography size={20} /></span>{/snippet}
+				{#snippet lead()}<span class="btn-icon preset-tonal" title={typographyTitle} aria-label={typographyAriaLabel}
+						><IconTypography size={20} /></span
+					>{/snippet}
 				{#snippet control()}<span class="h4">Typography</span>{/snippet}
 				{#snippet panel()}<ControlsTypography />{/snippet}
 			</Accordion.Item>

--- a/sites/themes.skeleton.dev/src/lib/components/generator/Controls/types.ts
+++ b/sites/themes.skeleton.dev/src/lib/components/generator/Controls/types.ts
@@ -1,0 +1,31 @@
+export interface ControlsProps {
+	// Color ---
+	/** Provide the title attribute for the color palette icon. */
+	colorTitle?: string;
+	/** Provide the aria-label attribute for the color palette icon. */
+	colorAriaLabel?: string;
+
+	// Background ---
+	/** Provides the title attribute for the backgrounds icon. */
+	backgroundsTitle?: string;
+	/** Provides the aria-label attribute for the backgrounds icon. */
+	backgroundsAriaLabel?: string;
+
+	// Spacing ---
+	/** Provides the title attribute for the spacing icon. */
+	spacingTitle?: string;
+	/** Provides the aria-label attribute for the spacing icon. */
+	spacingAriaLabel?: string;
+
+	// Edges ---
+	/** Provides the title attribute for the edges icon. */
+	edgesTitle?: string;
+	/** Provides the aria-label attribute for the edges icon. */
+	edgesAriaLabel?: string;
+
+	// Typography ---
+	/** Provides the title attribute for the typography icon. */
+	typographyTitle?: string;
+	/** Provides the aria-label attribute for the typography icon. */
+	typographyAriaLabel?: string;
+}


### PR DESCRIPTION
- Add accessibility props with default values to components identified in issue
- Update examples and playgrounds with accessibility attributes

## Linked Issue

Closes #3596

## Description

Adds `title` and `ariaLabel` props to all btn-icon components in codebase.
Provides semantic default values and updates examples with a11y attributes.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
