### PR TITLE
docs/remove unreferenced `link`

### DIFF
--- a/sites/skeleton.dev/src/examples/components/navigation/ExampleTilesSelectionSvelte.txt
+++ b/sites/skeleton.dev/src/examples/components/navigation/ExampleTilesSelectionSvelte.txt
@@ -14,7 +14,7 @@
 		<Navigation.Tile
 			{label}
 			{href}
-			selected={page.url.pathname  === link.href}
+			selected={page.url.pathname  === href}
 		>
 			{icon}
 		</Navigation.Tile>


### PR DESCRIPTION
## Description

In the example, each `link` in `links` is destructured into `label` and `href` so we can must refer to `href` directly

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [X] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [X] Contributions should target the `main` branch
- [X] Documentation should be updated to describe all relevant changes
- [X] Run `pnpm check` in the root of the monorepo
- [X] Run `pnpm format` in the root of the monorepo
- [X] Run `pnpm lint` in the root of the monorepo
- [X] Run `pnpm test` in the root of the monorepo
- [X] If you modify `/package` projects, please supply a Changeset
