### PR TITLE
Add REPL links to documentation homepage

### DIFF
--- a/sites/skeleton.dev/src/components/homepage/HomePlayground.astro
+++ b/sites/skeleton.dev/src/components/homepage/HomePlayground.astro
@@ -6,61 +6,61 @@ import { Ellipsis as IconEllipsis } from 'lucide-react';
 <div class="card bg-noise preset-filled-surface-100-900 px-10 py-8 grid grid-cols-1 xl:grid-cols-[auto_2fr] gap-10">
 	<!-- Text -->
 	<div class="self-center space-y-1">
-		<h2 class="h2">Frameworks</h2>
-		<p class="xl:text-balance xl:max-w-96">Browse a collection of world Skeleton projects using your favorite web frameworks.</p>
-		<p class="pt-4 text-xs opacity-50">Functional components limited to <u>React</u> and <u>Svelte</u>.</p>
+		<h2 class="h2">Live Demos</h2>
+		<p class="xl:text-balance xl:max-w-96">Test drive Skeleton directly in your browser for supported frameworks.</p>
+		<p class="pt-4 text-xs text-surface-600-400">* Functional components limited to <strong>React</strong> and <strong>Svelte</strong>.</p>
 	</div>
 	<!-- Options -->
 	<div class="self-center grid grid-cols-2 md:grid-cols-6 gap-4">
 		<a
-			href="https://github.com/skeletonlabs/skeleton-repl-nextjs"
+			href="https://stackblitz.com/github/skeletonlabs/skeleton-repl-nextjs?file=README.md"
 			target="_blank"
 			class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal"
 		>
 			<div class="w-16 xl:w-20 aspect-square rounded-full flex justify-center items-center bg-[#00D8FF]">
 				<Icon name="react" class="size-10 text-white" />
 			</div>
-			<span class="font-bold text-xs">React</span>
+			<p class="font-bold text-xs">React</p>
 		</a>
 		<a
-			href="https://github.com/skeletonlabs/skeleton-repl-sveltekit"
+			href="https://stackblitz.com/github/skeletonlabs/skeleton-repl-sveltekit?file=README.md"
 			target="_blank"
 			class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal"
 		>
 			<div class="w-16 xl:w-20 aspect-square rounded-full flex justify-center items-center bg-[#FF3E00]">
 				<Icon name="svelte" class="size-10 text-white" />
 			</div>
-			<span class="font-bold text-xs">Svelte</span>
+			<p class="font-bold text-xs">Svelte</p>
 		</a>
 		<a
-			href="https://github.com/skeletonlabs/skeleton-repl-nuxt"
+			href="https://stackblitz.com/github/skeletonlabs/skeleton-repl-nuxt?file=README.md"
 			target="_blank"
 			class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal"
 		>
 			<div class="w-16 xl:w-20 aspect-square rounded-full flex justify-center items-center bg-[#42B883]">
 				<Icon name="vue" class="size-10 text-white" />
 			</div>
-			<span class="font-bold text-xs">Vue</span>
+			<p class="font-bold text-xs">Vue <span class="text-surface-700-300">*</span></p>
 		</a>
 		<a
-			href="https://github.com/skeletonlabs/skeleton-repl-solidstart"
+			href="https://stackblitz.com/github/skeletonlabs/skeleton-repl-solidstart?file=README.md"
 			target="_blank"
 			class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal"
 		>
 			<div class="w-16 xl:w-20 aspect-square rounded-full flex justify-center items-center bg-[#57A0FF]">
 				<Icon name="solid" class="size-10 text-white" />
 			</div>
-			<span class="font-bold text-xs">Solid</span>
+			<p class="font-bold text-xs">Solid <span class="text-surface-700-300">*</span></p>
 		</a>
 		<a
-			href="https://github.com/skeletonlabs/skeleton-repl-astro"
+			href="https://stackblitz.com/github/skeletonlabs/skeleton-repl-astro?file=README.md"
 			target="_blank"
 			class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal"
 		>
 			<div class="w-16 xl:w-20 aspect-square rounded-full flex justify-center items-center bg-[#761CBA]">
 				<Icon name="astro" class="size-10 text-white" />
 			</div>
-			<span class="font-bold text-xs">Astro</span>
+			<p class="font-bold text-xs">Astro <span class="text-surface-700-300">*</span></p>
 		</a>
 		<a
 			href="/docs/get-started/installation"
@@ -70,7 +70,7 @@ import { Ellipsis as IconEllipsis } from 'lucide-react';
 			<div class="w-16 xl:w-20 aspect-square rounded-full flex justify-center items-center preset-tonal">
 				<IconEllipsis className="size-4" />
 			</div>
-			<span class="font-bold text-xs">More</span>
+			<p class="font-bold text-xs">More</p>
 		</a>
 	</div>
 </div>


### PR DESCRIPTION
## Linked Issue

Closes #3519

## Description

Adds the functional Stackblitz REPL links for each framework on the doc homepage.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
