### PR TITLE
Input group border-radii for children

### DIFF
--- a/.changeset/ninety-trams-own.md
+++ b/.changeset/ninety-trams-own.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": patch
+---
+
+bugfix: Added missing child border-radii to input group
+  

--- a/packages/skeleton/src/utilities/form-groups.css
+++ b/packages/skeleton/src/utilities/form-groups.css
@@ -14,6 +14,16 @@
 	--tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 var(--default-ring-width) var(--tw-ring-color, currentColor);
 	box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
 
+	/* Child Edges */
+	& > :first-child {
+		border-top-left-radius: var(--radius-base);
+		border-bottom-left-radius: var(--radius-base);
+	}
+	& > :last-child {
+		border-top-right-radius: var(--radius-base);
+		border-bottom-right-radius: var(--radius-base);
+	}
+
 	/* Dividers */
 	& > * + * {
 		border-left-width: 1px !important;


### PR DESCRIPTION
## Linked Issue

Closes #3558

## Description

Automatically apply border-radii to the first and last child of the input group.
They were missing before and leaving a small visual gap when the input was focused
<img width="1096" height="333" alt="image" src="https://github.com/user-attachments/assets/b9448717-ad57-417c-9407-8bac14c8ba10" />

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
