### PR TITLE
chore: workflow prep for upcoming `v3` branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
 	"prettier": false,
 	"linked": [],
 	"access": "public",
-	"baseBranch": "main",
+	"baseBranch": "v3",
 	"updateInternalDependencies": "patch",
 	"privatePackages": {
 		"tag": false,

--- a/.github/workflows/build-publish-next.yml
+++ b/.github/workflows/build-publish-next.yml
@@ -1,15 +1,15 @@
-name: Publish Skeleton (@latest)
+name: Publish Skeleton (@next)
 
 on:
   push:
     branches:
-      - v3
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Build & Publish Release (@latest)
+    name: Build & Publish Release (@next)
     if: github.repository == 'skeletonlabs/skeleton'
     runs-on: ubuntu-latest
     steps:
@@ -27,8 +27,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          commit: 'chore(latest-release): version package'
-          title: 'chore(latest-release): version package'
+          commit: 'chore(next-release): version package'
+          title: 'chore(next-release): version package'
           publish: pnpm changeset:publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v3
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Description

- sets the `v3` branch to publish with the `@latest` tag
- temporarily changed the base branch for changesets to `v3`

## Changsets

Instructions: Changesets automate our changelog. If you modify files in `/packages`, run `pnpm changeset` in the root of the monorepo, follow the prompts, then commit the markdown file. Changes that add features should be `minor` while chores and bugfixes should be `patch`. Please prefix the changeset message with `feat:`, `bugfix:` or `chore:`.

## Checklist

Please read and apply all [contribution requirements](https://www.skeleton.dev/docs/contributing).

- [ ] This PR targets the `dev` branch (NEVER `master`)
- [ ] Documentation reflects all relevant changes
- [ ] Branch is prefixed with: `docs/`, `feat/`, `chore/`, `bugfix/`
- [ ] Ensure Svelte and Typescript linting is current - run `pnpm ci:check`
- [ ] Ensure Prettier linting is current - run `pnpm format`
- [ ] All test cases are passing - run `pnpm test`
- [ ] Includes a changeset (if relevant; see above)
