### PR TITLE
Docs: Add API Reference to Rating Group

### DIFF
--- a/sites/skeleton.dev/src/content/docs/components/rating-group/react.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/rating-group/react.mdx
@@ -67,3 +67,7 @@ import ExampleRtlRaw from '@examples/components/rating-group/react/rtl.tsx?raw';
 		<Code code={ExampleRtlRaw} lang="tsx" />
 	</Fragment>
 </Preview>
+
+## API Reference
+
+<ApiTable />

--- a/sites/skeleton.dev/src/content/docs/components/rating-group/svelte.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/rating-group/svelte.mdx
@@ -67,3 +67,7 @@ import ExampleRtlRaw from '@examples/components/rating-group/svelte/rtl.svelte?r
 		<Code code={ExampleRtlRaw} lang="svelte" />
 	</Fragment>
 </Preview>
+
+## API Reference
+
+<ApiTable />


### PR DESCRIPTION
Rating Group was missing API Reference, now added.