### PR TITLE
API Ref Table Improvements

### DIFF
--- a/sites/skeleton.dev/scripts/generate-type-documentation/framework.ts
+++ b/sites/skeleton.dev/scripts/generate-type-documentation/framework.ts
@@ -2,16 +2,12 @@ export const frameworks = [
 	{
 		name: 'svelte',
 		config: {
-			classPropertyName: 'class',
-			declarationExtension: '.svelte.d.ts',
 			extendsBlacklist: [/^HTML.*Attributes(?:<.*>)?$/, /^Omit<\s*HTML.*Attributes.*>$/] as RegExp[]
 		}
 	},
 	{
 		name: 'react',
 		config: {
-			classPropertyName: 'className',
-			declarationExtension: '.d.ts',
 			extendsBlacklist: [/^ComponentProps(?:<.*>)?$/, /^Omit<\s*ComponentProps.*>$/] as RegExp[]
 		}
 	}

--- a/sites/skeleton.dev/scripts/generate-type-documentation/index.ts
+++ b/sites/skeleton.dev/scripts/generate-type-documentation/index.ts
@@ -43,7 +43,11 @@ async function getClassValue(component: string, part: string) {
 	if (!property) {
 		return;
 	}
-	return property.getInitializerOrThrow().getText().replaceAll("'", '"');
+	const text = property.getInitializerOrThrow().getText().trim();
+	if (text === "''") {
+		return;
+	}
+	return text.replaceAll("'", '"');
 }
 
 function getComponentNameFromPath(path: string): string {

--- a/sites/skeleton.dev/scripts/generate-type-documentation/index.ts
+++ b/sites/skeleton.dev/scripts/generate-type-documentation/index.ts
@@ -43,11 +43,7 @@ async function getClassValue(component: string, part: string) {
 	if (!property) {
 		return;
 	}
-	const text = property.getInitializerOrThrow().getText().trim();
-	if (text === "''") {
-		return;
-	}
-	return text.replaceAll("'", '"');
+	return property.getInitializerOrThrow().getText().replaceAll("'", '"');
 }
 
 function getComponentNameFromPath(path: string): string {

--- a/sites/skeleton.dev/scripts/generate-type-documentation/parser.ts
+++ b/sites/skeleton.dev/scripts/generate-type-documentation/parser.ts
@@ -3,9 +3,9 @@ import * as tsMorph from 'ts-morph';
 import { MONOREPO_ROOT } from './constants';
 import type { Framework } from './framework';
 
-type TypeKind = 'function' | 'array' | 'object' | 'primitive';
+export type TypeKind = 'function' | 'array' | 'object' | 'primitive';
 
-interface Property {
+export interface Property {
 	name: string;
 	type: string;
 	typeKind: TypeKind;
@@ -13,22 +13,22 @@ interface Property {
 	JSDoc: JSDoc;
 }
 
-interface JSDoc {
+export interface JSDoc {
 	description: string | null;
 	tags: Tag[];
 }
 
-interface Tag {
+export interface Tag {
 	name: string;
 	value: string | null;
 }
 
-interface Interface {
+export interface Interface {
 	name: string;
-	properties: Property[];
+	props: Property[];
 }
 
-class SourceFile {
+export class SourceFile {
 	constructor(
 		private framework: Framework,
 		private sourceFile: tsMorph.SourceFile
@@ -82,7 +82,9 @@ class SourceFile {
 
 	public getInterface(name: string): Interface {
 		const interface_ = this.sourceFile.getInterface(name);
-		if (!interface_) throw new Error(`Interface not found: ${name}`);
+		if (!interface_) {
+			throw new Error(`Interface not found: ${name}`);
+		}
 
 		interface_.getExtends().forEach((ext) => {
 			if (this.framework.config.extendsBlacklist.some((pattern) => pattern.test(ext.getText()))) {
@@ -92,7 +94,7 @@ class SourceFile {
 
 		return {
 			name: interface_.getName(),
-			properties: interface_
+			props: interface_
 				.getType()
 				.getProperties()
 				.map((symbol) => this.getProperty(symbol))

--- a/sites/skeleton.dev/src/components/docs/ApiTable.astro
+++ b/sites/skeleton.dev/src/components/docs/ApiTable.astro
@@ -51,6 +51,7 @@ function capitalize(str: string) {
 											)}
 										</td>
 										<td class="grid gap-2">
+											{/* This pre tag will otherwise include the line breaks prettier adds */}
 											{/* prettier-ignore */}
 											<pre class="pre text-xs rounded-container !bg-neutral-800 !text-white border border-surface-700/50 !p-1.5">{property.type}</pre>
 											<span>{property.JSDoc.description}</span>

--- a/sites/skeleton.dev/src/components/docs/ApiTable.astro
+++ b/sites/skeleton.dev/src/components/docs/ApiTable.astro
@@ -1,5 +1,5 @@
 ---
-import { getEntry, CollectionEntry } from 'astro:content';
+import { getEntry } from 'astro:content';
 import { Code } from 'astro-expressive-code/components';
 
 interface Props {

--- a/sites/skeleton.dev/src/components/docs/ApiTable.astro
+++ b/sites/skeleton.dev/src/components/docs/ApiTable.astro
@@ -51,9 +51,8 @@ function capitalize(str: string) {
 											)}
 										</td>
 										<td class="grid gap-2">
-											<pre class="pre text-xs rounded-container !bg-neutral-800 !text-white border border-surface-700/50 !p-1.5">
-												{property.type}
-											</pre>
+											{/* prettier-ignore */}
+											<pre class="pre text-xs rounded-container !bg-neutral-800 !text-white border border-surface-700/50 !p-1.5">{property.type}</pre>
 											<span>{property.JSDoc.description}</span>
 										</td>
 									</tr>

--- a/sites/skeleton.dev/src/components/docs/ApiTable.astro
+++ b/sites/skeleton.dev/src/components/docs/ApiTable.astro
@@ -24,52 +24,45 @@ function capitalize(str: string) {
 				Unable to load types for {framework}/{component}
 			</p>
 		) : (
-			Object.entries(types['data']).map(([name, properties]) => {
-				return (
+			<section class="grid gap-4">
+				{types.data.types.map((type) => (
 					<>
-						<section class="grid gap-4">
-							<h3 class="h3">{name.replace(capitalize(component), '').replace('Props', '')}</h3>
-							{properties.find((p) => p.name === 'class')?.JSDoc.tags.find((tag) => tag.name === 'default')?.value ? (
-								<Code code={`${properties.find((p) => p.name === 'class')?.JSDoc.tags.find((tag) => tag.name === 'default')?.value}`} />
-							) : (
-								''
-							)}
-							<table class="table">
-								<thead>
-									<tr>
-										<th>Property</th>
-										<th>Default</th>
-										<th>Type</th>
+						<h3 class="h3">{type.name.replace(capitalize(component), '').replace('Props', '')}</h3>
+						{type.metadata.classValue && <Code code={type.metadata.classValue} />}
+						<table class="table">
+							<thead>
+								<tr>
+									<th>Property</th>
+									<th>Default</th>
+									<th>Type</th>
+								</tr>
+							</thead>
+							<tbody class="[&>tr]:hover:preset-tonal">
+								{type.props.map((property) => (
+									<tr class="align-top">
+										<td>
+											<code class="code">{property.name}</code>
+										</td>
+										<td>
+											{property.JSDoc && property.JSDoc.tags.some((tag) => tag.name === 'default') ? (
+												<span>{property.JSDoc.tags.find((tag) => tag.name === 'default')?.value}</span>
+											) : (
+												<span class="opacity-50">-</span>
+											)}
+										</td>
+										<td class="grid gap-2">
+											<pre class="pre text-xs rounded-container !bg-neutral-800 !text-white border border-surface-700/50 !p-1.5">
+												{property.type}
+											</pre>
+											<span>{property.JSDoc.description}</span>
+										</td>
 									</tr>
-								</thead>
-								<tbody class="[&>tr]:hover:preset-tonal">
-									{properties
-										.filter((property) => property.name !== 'class')
-										.map((property) => (
-											<tr class="align-top">
-												<td>
-													<code class="code">{property.name}</code>
-												</td>
-												<td>
-													{property.JSDoc && property.JSDoc.tags.some((tag) => tag.name === 'default') ? (
-														<span>{property.JSDoc.tags.find((tag) => tag.name === 'default')?.value}</span>
-													) : (
-														<span class="opacity-50">-</span>
-													)}
-												</td>
-												<td class="grid gap-2">
-													{/* prettier-ignore */}
-													<pre class="pre text-xs rounded-container !bg-neutral-800 !text-white border border-surface-700/50 !p-1.5">{property.type}</pre>
-													<span>{property.JSDoc.description}</span>
-												</td>
-											</tr>
-										))}
-								</tbody>
-							</table>
-						</section>
+								))}
+							</tbody>
+						</table>
 					</>
-				);
-			})
+				))}
+			</section>
 		)
 	}
 </div>

--- a/sites/skeleton.dev/src/components/docs/ApiTable.astro
+++ b/sites/skeleton.dev/src/components/docs/ApiTable.astro
@@ -1,5 +1,6 @@
 ---
 import { getEntry } from 'astro:content';
+import { Code } from 'astro-expressive-code/components';
 
 interface Props {
 	component: string;
@@ -25,38 +26,48 @@ function capitalize(str: string) {
 		) : (
 			Object.entries(types['data']).map(([name, properties]) => {
 				return (
-					<section class="grid gap-4">
-						<h3 class="h3">{name.replace(capitalize(component), '').replace('Props', '')}</h3>
-						<table class="table">
-							<thead>
-								<tr>
-									<th>Property</th>
-									<th>Default</th>
-									<th>Type</th>
-								</tr>
-							</thead>
-							<tbody class="[&>tr]:hover:preset-tonal">
-								{properties.map((property) => (
-									<tr class="align-top">
-										<td>
-											<code class="code">{property.name}</code>
-										</td>
-										<td>
-											{property.JSDoc && property.JSDoc.tags.some((tag) => tag.name === 'default') ? (
-												<span>{property.JSDoc.tags.find((tag) => tag.name === 'default')?.value}</span>
-											) : (
-												<span class="opacity-50">-</span>
-											)}
-										</td>
-										<td class="grid gap-2">
-											<pre class="pre !p-2">{property.type}</pre>
-											<span>{property.JSDoc.description}</span>
-										</td>
+					<>
+						<section class="grid gap-4">
+							<h3 class="h3">{name.replace(capitalize(component), '').replace('Props', '')}</h3>
+							{properties.find((p) => p.name === 'class')?.JSDoc.tags.find((tag) => tag.name === 'default')?.value ? (
+								<Code code={`${properties.find((p) => p.name === 'class')?.JSDoc.tags.find((tag) => tag.name === 'default')?.value}`} />
+							) : (
+								''
+							)}
+							<table class="table">
+								<thead>
+									<tr>
+										<th>Property</th>
+										<th>Default</th>
+										<th>Type</th>
 									</tr>
-								))}
-							</tbody>
-						</table>
-					</section>
+								</thead>
+								<tbody class="[&>tr]:hover:preset-tonal">
+									{properties
+										.filter((property) => property.name !== 'class')
+										.map((property) => (
+											<tr class="align-top">
+												<td>
+													<code class="code">{property.name}</code>
+												</td>
+												<td>
+													{property.JSDoc && property.JSDoc.tags.some((tag) => tag.name === 'default') ? (
+														<span>{property.JSDoc.tags.find((tag) => tag.name === 'default')?.value}</span>
+													) : (
+														<span class="opacity-50">-</span>
+													)}
+												</td>
+												<td class="grid gap-2">
+													{/* prettier-ignore */}
+													<pre class="pre text-xs rounded-container !bg-neutral-800 !text-white border border-surface-700/50 !p-1.5">{property.type}</pre>
+													<span>{property.JSDoc.description}</span>
+												</td>
+											</tr>
+										))}
+								</tbody>
+							</table>
+						</section>
+					</>
 				);
 			})
 		)

--- a/sites/skeleton.dev/src/components/docs/ApiTable.astro
+++ b/sites/skeleton.dev/src/components/docs/ApiTable.astro
@@ -53,7 +53,7 @@ function capitalize(str: string) {
 										<td class="grid gap-2">
 											{/* This pre tag will otherwise include the line breaks prettier adds */}
 											{/* prettier-ignore */}
-											<pre class="pre text-xs rounded-container !bg-neutral-800 !text-white border border-surface-700/50 !p-1.5">{property.type}</pre>
+											<pre class="pre max-w-[400px] !bg-surface-950 border border-surface-800 !p-1.5">{property.type}</pre>
 											<span>{property.JSDoc.description}</span>
 										</td>
 									</tr>

--- a/sites/skeleton.dev/src/components/docs/ApiTable.astro
+++ b/sites/skeleton.dev/src/components/docs/ApiTable.astro
@@ -1,5 +1,5 @@
 ---
-import { getEntry } from 'astro:content';
+import { getEntry, CollectionEntry } from 'astro:content';
 import { Code } from 'astro-expressive-code/components';
 
 interface Props {

--- a/sites/skeleton.dev/src/components/docs/ApiTable.astro
+++ b/sites/skeleton.dev/src/components/docs/ApiTable.astro
@@ -28,7 +28,7 @@ function capitalize(str: string) {
 				{types.data.types.map((type) => (
 					<>
 						<h3 class="h3">{type.name.replace(capitalize(component), '').replace('Props', '')}</h3>
-						{type.metadata.classValue && <Code code={type.metadata.classValue} />}
+						{type.metadata.classValue && type.metadata.classValue !== "''" && <Code code={type.metadata.classValue} />}
 						<table class="table">
 							<thead>
 								<tr>

--- a/sites/skeleton.dev/src/content.config.ts
+++ b/sites/skeleton.dev/src/content.config.ts
@@ -26,26 +26,34 @@ const types = defineCollection({
 		base: './src/content/types',
 		pattern: '**/*.json'
 	}),
-	schema: z.record(
-		z.string(),
-		z.array(
+	schema: z.object({
+		name: z.string(),
+		types: z.array(
 			z.object({
 				name: z.string(),
-				type: z.string(),
-				typeKind: z.string(),
-				optional: z.boolean(),
-				JSDoc: z.object({
-					description: z.string().nullable(),
-					tags: z.array(
-						z.object({
-							name: z.string(),
-							value: z.string().nullable()
+				props: z.array(
+					z.object({
+						name: z.string(),
+						type: z.string(),
+						typeKind: z.string(),
+						optional: z.boolean(),
+						JSDoc: z.object({
+							description: z.string().nullable(),
+							tags: z.array(
+								z.object({
+									name: z.string(),
+									value: z.string().nullable()
+								})
+							)
 						})
-					)
+					})
+				),
+				metadata: z.object({
+					classValue: z.string().optional()
 				})
 			})
 		)
-	)
+	})
 });
 
 export const collections = { docs, types };


### PR DESCRIPTION
## Linked Issue

Closes #3689

## Description

Pulls the class list to a code block above the props table. Filters the class attribute out of the props table.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
