### PR TITLE
fix: avoid dead loop while transforming ts files in v3 migration script

### DIFF
--- a/.changeset/purple-tigers-happen.md
+++ b/.changeset/purple-tigers-happen.md
@@ -1,0 +1,6 @@
+---
+"skeleton": patch
+---
+
+Avoid dead loop while transforming ts files in v3 migration script
+  

--- a/packages/cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-module.ts
+++ b/packages/cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-module.ts
@@ -50,12 +50,18 @@ function transformModule(code: string) {
 			if (Object.hasOwn(EXPORT_MAPPINGS, name) && skeletonImports.includes(name)) {
 				const exportMapping = EXPORT_MAPPINGS[name];
 				if (exportMapping?.identifier.type === 'renamed') {
-					node.replaceWithText(exportMapping.identifier.value);
+					const newName = exportMapping.identifier.value;
+					if (newName !== node.getText()) {
+						node.replaceWithText(newName);
+					}
 				}
 			}
 		}
 		if (!node.wasForgotten() && Node.isStringLiteral(node) && !Node.isImportDeclaration(node.getParent())) {
-			node.replaceWithText(transformClasses(node.getText()).code);
+			const newText = transformClasses(node.getText()).code;
+			if (newText !== node.getText()) {
+				node.replaceWithText(newText);
+			}
 		}
 	});
 


### PR DESCRIPTION
## Linked Issue

None

## Description

When I was migrating my project from skeleton v2 to v3, the migration script gets stuck (hanging for minutes, console not responding) while transforming some ts files. I believe this is due to the fact that nodes inside `forEachDescendant` at https://github.com/skeletonlabs/skeleton/blob/v3/packages/cli/src/commands/migrate/migrations/skeleton-3/transformers/transform-module.ts#L47 could create new AST nodes identical to the original, causing `forEachDescendant` to revisit them indefinitely.

I am targeting main as this template asked, but maybe v3 is more relevant. Let me know if you want me to switch the target branch. 

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [ ] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
