### PR TITLE
fix: file upload trigger regression

### DIFF
--- a/.changeset/fruity-bottles-tease.md
+++ b/.changeset/fruity-bottles-tease.md
@@ -1,0 +1,7 @@
+---
+"@skeletonlabs/skeleton-react": patch
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+fix: pin versions to keep buggy file upload behaviour we depend on
+  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,58 +7,58 @@ settings:
 catalogs:
   default:
     '@zag-js/accordion':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/avatar':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/combobox':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/dialog':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/file-upload':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/pagination':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/popover':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/progress':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/radio-group':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/rating-group':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/react':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/slider':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/svelte':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/switch':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/tabs':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/tags-input':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/toast':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     '@zag-js/tooltip':
-      specifier: ^1.18.3
+      specifier: 1.18.3
       version: 1.18.3
     svelte:
       specifier: ^5.36.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - sites/*
   - playgrounds/*
 
-define: &zag_version '^1.18.3'
+define: &zag_version '1.18.3'
 
 catalog:
   '@zag-js/svelte': *zag_version


### PR DESCRIPTION
## Linked Issue

Closes #3782

## Description

Pins the Zag version to prevent users from auto installing a newer version of Zag where the bug is removed, as we depend on a zag bug for our file upload trigger to work.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
