### PR TITLE
chore: fix astro svelte warning in dev server

### DIFF
--- a/sites/skeleton.dev/astro.config.js
+++ b/sites/skeleton.dev/astro.config.js
@@ -2,7 +2,7 @@ import mdx from '@astrojs/mdx';
 // Integrations
 import partytown from '@astrojs/partytown';
 import react from '@astrojs/react';
-import svelte from '@astrojs/svelte';
+import svelte, { vitePreprocess } from '@astrojs/svelte';
 // Vite Plugins
 import tailwindcss from '@tailwindcss/vite';
 import AutoImport from 'astro-auto-import';
@@ -17,7 +17,14 @@ export default defineConfig({
 		// https://docs.astro.build/en/guides/integrations-guide/partytown/
 		partytown(),
 		// https://docs.astro.build/en/guides/integrations-guide/svelte/
-		svelte(),
+		svelte({
+			preprocess: vitePreprocess(),
+			compilerOptions: {
+				experimental: {
+					async: true,
+				},
+			},
+		}),
 		// https://docs.astro.build/en/guides/integrations-guide/react/
 		react({
 			experimentalReactChildren: true,

--- a/sites/skeleton.dev/svelte.config.js
+++ b/sites/skeleton.dev/svelte.config.js
@@ -1,5 +1,0 @@
-import { vitePreprocess } from '@astrojs/svelte';
-
-export default {
-	preprocess: vitePreprocess(),
-};


### PR DESCRIPTION
Removes those `async` warnings by enabling the experimental flag, this is probably a mistake on Astro's end but it doesn't really matter.