### PR TITLE
chore: resolve console bloat

### DIFF
--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -2,6 +2,4 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
 	logLevel: 'error',
-	copy: ['src/index.css'],
-	unbundle: true,
 });

--- a/packages/skeleton-common/tsdown.config.ts
+++ b/packages/skeleton-common/tsdown.config.ts
@@ -3,6 +3,7 @@ import Macros from 'unplugin-macros/rolldown';
 import Raw from 'unplugin-raw/rolldown';
 
 export default defineConfig({
+	logLevel: 'error',
 	unbundle: true,
 	copy: ['src/index.css'],
 	plugins: [Raw(), Macros()],

--- a/packages/skeleton-svelte/vite.config.ts
+++ b/packages/skeleton-svelte/vite.config.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+	logLevel: 'error',
 	plugins: [svelte(), svelteTesting()],
 	resolve: {
 		alias: {

--- a/packages/skeleton/vite.config.ts
+++ b/packages/skeleton/vite.config.ts
@@ -3,6 +3,7 @@ import { glob } from 'tinyglobby';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+	logLevel: 'error',
 	build: {
 		cssCodeSplit: true,
 		cssMinify: false,

--- a/playgrounds/skeleton-react/next.config.ts
+++ b/playgrounds/skeleton-react/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {
-	/* config options here */
-};
-
-export default nextConfig;

--- a/playgrounds/skeleton-react/package.json
+++ b/playgrounds/skeleton-react/package.json
@@ -3,8 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "next dev",
-		"build": "next build"
+		"dev": "next dev --turbopack"
 	},
 	"dependencies": {
 		"@skeletonlabs/skeleton": "workspace:*",

--- a/playgrounds/skeleton-svelte/package.json
+++ b/playgrounds/skeleton-svelte/package.json
@@ -3,8 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"dev": "vite dev",
-		"build": "vite build"
+		"dev": "vite dev"
 	},
 	"devDependencies": {
 		"@lucide/svelte": "catalog:",


### PR DESCRIPTION
This PR sets the `logLevel` to `error` for all packages to reduce console bloat ultimately crashing dev servers after multiple maintainers have complained about this.