### PR TITLE
chore: use vite plugin transform lucide imports

### DIFF
--- a/playgrounds/skeleton-svelte/package.json
+++ b/playgrounds/skeleton-svelte/package.json
@@ -18,7 +18,8 @@
 		"svelte-check": "catalog:",
 		"tailwindcss": "catalog:",
 		"typescript": "catalog:",
-		"vite": "catalog:"
+		"vite": "catalog:",
+		"vite-plugin-transform-lucide-imports": "catalog:"
 	},
 	"type": "module"
 }

--- a/playgrounds/skeleton-svelte/src/routes/components/app-bar/+page.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/components/app-bar/+page.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import CalendarIcon from '@lucide/svelte/icons/calendar';
-	import CircleUserIcon from '@lucide/svelte/icons/circle-user';
-	import MenuIcon from '@lucide/svelte/icons/menu';
-	import SearchIcon from '@lucide/svelte/icons/search';
+	import { CalendarIcon, CircleUserIcon, MenuIcon, SearchIcon } from '@lucide/svelte';
 	import { AppBar } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/playgrounds/skeleton-svelte/src/routes/components/navigation/+page.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/components/navigation/+page.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
-	import ArrowLeftRightIcon from '@lucide/svelte/icons/arrow-left-right';
-	import BedDoubleIcon from '@lucide/svelte/icons/bed-double';
-	import BikeIcon from '@lucide/svelte/icons/bike';
-	import BookIcon from '@lucide/svelte/icons/book';
-	import BubblesIcon from '@lucide/svelte/icons/bubbles';
-	import HouseIcon from '@lucide/svelte/icons/house';
-	import MountainIcon from '@lucide/svelte/icons/mountain';
-	import PopcornIcon from '@lucide/svelte/icons/popcorn';
-	import SailboatIcon from '@lucide/svelte/icons/sailboat';
-	import SettingsIcon from '@lucide/svelte/icons/settings';
-	import SkullIcon from '@lucide/svelte/icons/skull';
-	import TreePalmIcon from '@lucide/svelte/icons/tree-palm';
-	import TvIcon from '@lucide/svelte/icons/tv';
+	import {
+		ArrowLeftRightIcon,
+		BedDoubleIcon,
+		BikeIcon,
+		BookIcon,
+		BubblesIcon,
+		HouseIcon,
+		MountainIcon,
+		PopcornIcon,
+		SailboatIcon,
+		SettingsIcon,
+		SkullIcon,
+		TreePalmIcon,
+		TvIcon,
+	} from '@lucide/svelte';
 	import { Navigation } from '@skeletonlabs/skeleton-svelte';
 
 	const links = [

--- a/playgrounds/skeleton-svelte/src/routes/components/tree-view/+page.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/components/tree-view/+page.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { FileIcon, FolderIcon } from '@lucide/svelte';
+	import { TreeView, createTreeViewCollection } from '@skeletonlabs/skeleton-svelte';
+
+	interface Node {
+		id: string;
+		name: string;
+		children?: Node[];
+	}
+
+	const collection = createTreeViewCollection<Node>({
+		nodeToValue: (node) => node.id,
+		nodeToString: (node) => node.name,
+		rootNode: {
+			id: 'root',
+			name: '',
+			children: [
+				{
+					id: 'node_modules',
+					name: 'node_modules',
+					children: [
+						{
+							id: 'node_modules/@skeletonlabs',
+							name: '@skeletonlabs',
+							children: [
+								{
+									id: 'node_modules/@skeletonlabs/skeleton',
+									name: 'skeleton',
+								},
+							],
+						},
+					],
+				},
+				{
+					id: 'package.json',
+					name: 'package.json',
+				},
+			],
+		},
+	});
+</script>
+
+<TreeView {collection}>
+	<TreeView.Label>File System</TreeView.Label>
+	<TreeView.Tree>
+		{#each collection.rootNode.children || [] as node, index (node)}
+			{@render treeNode(node, [index])}
+		{/each}
+	</TreeView.Tree>
+</TreeView>
+
+{#snippet treeNode(node: Node, indexPath: number[])}
+	<TreeView.NodeProvider value={{ node, indexPath }}>
+		{#if node.children}
+			<TreeView.Branch>
+				<TreeView.BranchControl>
+					<TreeView.BranchIndicator />
+					<TreeView.BranchText>
+						<FolderIcon class="size-4" />
+						{node.name}
+					</TreeView.BranchText>
+				</TreeView.BranchControl>
+				<TreeView.BranchContent>
+					<TreeView.BranchIndentGuide />
+					{#each node.children as childNode, childIndex (childNode)}
+						{@render treeNode(childNode, [...indexPath, childIndex])}
+					{/each}
+				</TreeView.BranchContent>
+			</TreeView.Branch>
+		{:else}
+			<TreeView.Item>
+				<FileIcon class="size-4" />
+				{node.name}
+			</TreeView.Item>
+		{/if}
+	</TreeView.NodeProvider>
+{/snippet}

--- a/playgrounds/skeleton-svelte/src/routes/light-switch.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/light-switch.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import Moon from '@lucide/svelte/icons/moon';
-	import Sun from '@lucide/svelte/icons/sun';
+	import { MoonIcon, SunIcon } from '@lucide/svelte';
 	import { Switch } from '@skeletonlabs/skeleton-svelte';
 
 	let checked = $state(false);
@@ -32,9 +31,9 @@
 			<Switch.Context>
 				{#snippet children(switch_)}
 					{#if switch_().checked}
-						<Sun class="size-4 stroke-surface-50-950" />
+						<SunIcon class="size-4 stroke-surface-50-950" />
 					{:else}
-						<Moon class="size-4 stroke-surface-950-50" />
+						<MoonIcon class="size-4 stroke-surface-950-50" />
 					{/if}
 				{/snippet}
 			</Switch.Context>

--- a/playgrounds/skeleton-svelte/vite.config.ts
+++ b/playgrounds/skeleton-svelte/vite.config.ts
@@ -1,7 +1,8 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
+import transformLucideImports from 'vite-plugin-transform-lucide-imports';
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()],
+	plugins: [tailwindcss(), sveltekit(), transformLucideImports()],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ catalogs:
     vite-plugin-pagefind:
       specifier: 1.0.7
       version: 1.0.7
+    vite-plugin-transform-lucide-imports:
+      specifier: 0.2.0
+      version: 0.2.0
     vitest:
       specifier: 3.2.4
       version: 3.2.4
@@ -756,6 +759,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)
+      vite-plugin-transform-lucide-imports:
+        specifier: 'catalog:'
+        version: 0.2.0(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
 
   sites/skeleton.dev:
     dependencies:
@@ -892,6 +898,9 @@ importers:
       vite-plugin-pagefind:
         specifier: 'catalog:'
         version: 1.0.7(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
+      vite-plugin-transform-lucide-imports:
+        specifier: 'catalog:'
+        version: 0.2.0(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
 
   sites/themes.skeleton.dev:
     devDependencies:
@@ -949,6 +958,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)
+      vite-plugin-transform-lucide-imports:
+        specifier: 'catalog:'
+        version: 0.2.0(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
 
 packages:
   '@adobe/css-tools@4.4.4':
@@ -5629,6 +5641,11 @@ packages:
     peerDependencies:
       vite: '>=4.0.0'
 
+  vite-plugin-transform-lucide-imports@0.2.0:
+    resolution: { integrity: sha512-/pJ+wmjcEgMZ8D3GhD9sYd1Cqwo+YQQn/eq5HIbkkZoDbnK3DSmvYKvNw/I3EOWRpoERJDixfrYp4KHWDaukAQ== }
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+
   vite@6.3.6:
     resolution: { integrity: sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA== }
     engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
@@ -7501,12 +7518,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.39.7)(vite@6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.39.7)(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.39.7)(vite@6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.39.7)(vite@6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.39.7)(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
       debug: 4.4.3
       svelte: 5.39.7
-      vite: 7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7521,14 +7538,14 @@ snapshots:
 
   '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.39.7)(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.39.7)(vite@6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.39.7)(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.39.7)(vite@6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.39.7)(vite@6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.19
       svelte: 5.39.7
       vite: 7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
+      vitefu: 1.1.1(vite@6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11385,6 +11402,14 @@ snapshots:
     dependencies:
       colorette: 2.0.20
       package-manager-detector: 0.2.11
+      vite: 7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)
+
+  vite-plugin-transform-lucide-imports@0.2.0(vite@7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)):
+    dependencies:
+      '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
+      acorn: 8.15.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
       vite: 7.1.7(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1)
 
   vite@6.3.6(@types/node@24.6.1)(jiti@2.6.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(tsx@4.20.6)(yaml@2.8.1):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -107,6 +107,7 @@ catalog:
   unplugin-raw: 0.6.3
   vite: 7.1.7
   vite-plugin-pagefind: 1.0.7
+  vite-plugin-transform-lucide-imports: 0.2.0
   vitest: 3.2.4
   zimmerframe: 1.1.4
 

--- a/sites/skeleton.dev/astro.config.ts
+++ b/sites/skeleton.dev/astro.config.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createIndex } from 'pagefind';
 import { pagefind } from 'vite-plugin-pagefind';
+import transformLucideImports from 'vite-plugin-transform-lucide-imports';
 
 function skeleton(): AstroIntegration {
 	return {
@@ -108,6 +109,8 @@ export default defineConfig({
 			pagefind({
 				outputDirectory: 'dist',
 			}),
+			// @ts-expect-error - vite version mismatch
+			transformLucideImports(),
 		],
 	},
 });

--- a/sites/skeleton.dev/package.json
+++ b/sites/skeleton.dev/package.json
@@ -19,7 +19,8 @@
 		"tinyglobby": "catalog:",
 		"ts-morph": "catalog:",
 		"tsx": "catalog:",
-		"vite-plugin-pagefind": "catalog:"
+		"vite-plugin-pagefind": "catalog:",
+		"vite-plugin-transform-lucide-imports": "catalog:"
 	},
 	"dependencies": {
 		"@astrojs/check": "catalog:",

--- a/sites/skeleton.dev/src/components/examples/components/accordion/svelte/columns.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/accordion/svelte/columns.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import IconClub from '@lucide/svelte/icons/club';
-	import IconDiamond from '@lucide/svelte/icons/diamond';
-	import IconHeart from '@lucide/svelte/icons/heart';
-	import IconSpade from '@lucide/svelte/icons/spade';
+	import { ClubIcon, DiamondIcon, HeartIcon, SpadeIcon } from '@lucide/svelte';
 	import { Accordion } from '@skeletonlabs/skeleton-svelte';
 </script>
 
@@ -11,7 +8,7 @@
 		<h3>
 			<Accordion.ItemTrigger class="grid grid-cols-[1fr_auto]">
 				<span>Club</span>
-				<IconClub />
+				<ClubIcon />
 			</Accordion.ItemTrigger>
 		</h3>
 		<Accordion.ItemContent>Content for Item 1</Accordion.ItemContent>
@@ -21,7 +18,7 @@
 		<h3>
 			<Accordion.ItemTrigger class="grid grid-cols-[1fr_auto]">
 				<span>Diamond</span>
-				<IconDiamond />
+				<DiamondIcon />
 			</Accordion.ItemTrigger>
 		</h3>
 		<Accordion.ItemContent>Content for Item 2</Accordion.ItemContent>
@@ -31,7 +28,7 @@
 		<h3>
 			<Accordion.ItemTrigger class="grid grid-cols-[1fr_auto]">
 				<span>Heart</span>
-				<IconHeart />
+				<HeartIcon />
 			</Accordion.ItemTrigger>
 		</h3>
 		<Accordion.ItemContent>Content for Item 3</Accordion.ItemContent>
@@ -41,7 +38,7 @@
 		<h3>
 			<Accordion.ItemTrigger class="grid grid-cols-[1fr_auto]">
 				<span>Spade</span>
-				<IconSpade />
+				<SpadeIcon />
 			</Accordion.ItemTrigger>
 		</h3>
 		<Accordion.ItemContent>Content for Item 4</Accordion.ItemContent>

--- a/sites/skeleton.dev/src/components/examples/components/accordion/svelte/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/accordion/svelte/default.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import IconClub from '@lucide/svelte/icons/club';
-	import IconDiamond from '@lucide/svelte/icons/diamond';
-	import IconHeart from '@lucide/svelte/icons/heart';
-	import IconSpade from '@lucide/svelte/icons/spade';
+	import { ClubIcon, DiamondIcon, HeartIcon, SpadeIcon } from '@lucide/svelte';
 	import { Accordion } from '@skeletonlabs/skeleton-svelte';
 
 	const lorem =
@@ -13,7 +10,7 @@
 	<Accordion.Item value="item-1">
 		<h3>
 			<Accordion.ItemTrigger class="grid grid-cols-[auto_1fr_auto] gap-2">
-				<IconClub />
+				<ClubIcon />
 				<span>Club</span>
 				<Accordion.ItemIndicator>
 					<Accordion.Context>
@@ -30,7 +27,7 @@
 	<Accordion.Item value="item-2">
 		<h3>
 			<Accordion.ItemTrigger class="grid grid-cols-[auto_1fr_auto] gap-2">
-				<IconDiamond />
+				<DiamondIcon />
 				<span>Diamond</span>
 				<Accordion.ItemIndicator>
 					<Accordion.Context>
@@ -47,7 +44,7 @@
 	<Accordion.Item value="item-3">
 		<h3>
 			<Accordion.ItemTrigger class="grid grid-cols-[auto_1fr_auto] gap-2">
-				<IconHeart />
+				<HeartIcon />
 				<span>Heart</span>
 				<Accordion.ItemIndicator>
 					<Accordion.Context>
@@ -64,7 +61,7 @@
 	<Accordion.Item value="item-4">
 		<h3>
 			<Accordion.ItemTrigger class="grid grid-cols-[auto_1fr_auto] gap-2">
-				<IconSpade />
+				<SpadeIcon />
 				<span>Spade</span>
 				<Accordion.ItemIndicator>
 					<Accordion.Context>

--- a/sites/skeleton.dev/src/components/examples/components/app-bar/svelte/centered.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/app-bar/svelte/centered.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import CalendarIcon from '@lucide/svelte/icons/calendar';
-	import CircleUserIcon from '@lucide/svelte/icons/circle-user';
-	import MenuIcon from '@lucide/svelte/icons/menu';
-	import SearchIcon from '@lucide/svelte/icons/search';
+	import { CalendarIcon, CircleUserIcon, MenuIcon, SearchIcon } from '@lucide/svelte';
 	import { AppBar } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/app-bar/svelte/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/app-bar/svelte/default.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import CalendarIcon from '@lucide/svelte/icons/calendar';
-	import CircleUserIcon from '@lucide/svelte/icons/circle-user';
-	import MenuIcon from '@lucide/svelte/icons/menu';
-	import SearchIcon from '@lucide/svelte/icons/search';
+	import { CalendarIcon, CircleUserIcon, MenuIcon, SearchIcon } from '@lucide/svelte';
 	import { AppBar } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/app-bar/svelte/extended.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/app-bar/svelte/extended.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import CalendarIcon from '@lucide/svelte/icons/calendar';
-	import CircleUserIcon from '@lucide/svelte/icons/circle-user';
-	import MenuIcon from '@lucide/svelte/icons/menu';
-	import SearchIcon from '@lucide/svelte/icons/search';
+	import { CalendarIcon, CircleUserIcon, MenuIcon, SearchIcon } from '@lucide/svelte';
 	import { AppBar } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/app-bar/svelte/responsive.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/app-bar/svelte/responsive.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import CalendarIcon from '@lucide/svelte/icons/calendar';
-	import CircleUserIcon from '@lucide/svelte/icons/circle-user';
-	import MenuIcon from '@lucide/svelte/icons/menu';
-	import SearchIcon from '@lucide/svelte/icons/search';
+	import { CalendarIcon, CircleUserIcon, MenuIcon, SearchIcon } from '@lucide/svelte';
 	import { AppBar } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/dialog/svelte/drawer.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/dialog/svelte/drawer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import XIcon from '@lucide/svelte/icons/x';
+	import { XIcon } from '@lucide/svelte';
 	import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/dialog/svelte/headless.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/dialog/svelte/headless.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import IconSkull from '@lucide/svelte/icons/skull';
+	import { SkullIcon } from '@lucide/svelte';
 	import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
 </script>
 
 <Dialog>
 	<Dialog.Trigger>
-		<IconSkull class="size-12" />
+		<SkullIcon class="size-12" />
 	</Dialog.Trigger>
 	<Portal>
 		<Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50" />

--- a/sites/skeleton.dev/src/components/examples/components/file-upload/svelte/custom-content.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/file-upload/svelte/custom-content.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import FileIcon from '@lucide/svelte/icons/file';
+	import { FileIcon } from '@lucide/svelte';
 	import { FileUpload } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/navigation/svelte/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/navigation/svelte/default.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import BikeIcon from '@lucide/svelte/icons/bike';
-	import BookIcon from '@lucide/svelte/icons/book';
-	import HouseIcon from '@lucide/svelte/icons/house';
-	import TreePalmIcon from '@lucide/svelte/icons/tree-palm';
+	import { BikeIcon, BookIcon, HouseIcon, TreePalmIcon } from '@lucide/svelte';
 	import { Navigation } from '@skeletonlabs/skeleton-svelte';
 
 	const links = [

--- a/sites/skeleton.dev/src/components/examples/components/navigation/svelte/rail.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/navigation/svelte/rail.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-	import BikeIcon from '@lucide/svelte/icons/bike';
-	import BookIcon from '@lucide/svelte/icons/book';
-	import HouseIcon from '@lucide/svelte/icons/house';
-	import SettingsIcon from '@lucide/svelte/icons/settings';
-	import SkullIcon from '@lucide/svelte/icons/skull';
-	import TreePalmIcon from '@lucide/svelte/icons/tree-palm';
+	import { BikeIcon, BookIcon, HouseIcon, SettingsIcon, SkullIcon, TreePalmIcon } from '@lucide/svelte';
 	import { Navigation } from '@skeletonlabs/skeleton-svelte';
 
 	const links = [

--- a/sites/skeleton.dev/src/components/examples/components/navigation/svelte/sidebar.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/navigation/svelte/sidebar.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
-	import BedDoubleIcon from '@lucide/svelte/icons/bed-double';
-	import BikeIcon from '@lucide/svelte/icons/bike';
-	import BookIcon from '@lucide/svelte/icons/book';
-	import BubblesIcon from '@lucide/svelte/icons/bubbles';
-	import HouseIcon from '@lucide/svelte/icons/house';
-	import MountainIcon from '@lucide/svelte/icons/mountain';
-	import PopcornIcon from '@lucide/svelte/icons/popcorn';
-	import SailboatIcon from '@lucide/svelte/icons/sailboat';
-	import SettingsIcon from '@lucide/svelte/icons/settings';
-	import SkullIcon from '@lucide/svelte/icons/skull';
-	import TreePalmIcon from '@lucide/svelte/icons/tree-palm';
-	import TvIcon from '@lucide/svelte/icons/tv';
+	import {
+		BedDoubleIcon,
+		BikeIcon,
+		BookIcon,
+		BubblesIcon,
+		HouseIcon,
+		MountainIcon,
+		PopcornIcon,
+		SailboatIcon,
+		SettingsIcon,
+		SkullIcon,
+		TreePalmIcon,
+		TvIcon,
+	} from '@lucide/svelte';
 	import { Navigation } from '@skeletonlabs/skeleton-svelte';
 
 	const linksSidebar = {

--- a/sites/skeleton.dev/src/components/examples/components/navigation/svelte/toggle.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/navigation/svelte/toggle.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-	import ArrowLeftRightIcon from '@lucide/svelte/icons/arrow-left-right';
-	import BikeIcon from '@lucide/svelte/icons/bike';
-	import BookIcon from '@lucide/svelte/icons/book';
-	import HouseIcon from '@lucide/svelte/icons/house';
-	import TreePalmIcon from '@lucide/svelte/icons/tree-palm';
+	import { ArrowLeftRightIcon, BikeIcon, BookIcon, HouseIcon, TreePalmIcon } from '@lucide/svelte';
 	import { Navigation } from '@skeletonlabs/skeleton-svelte';
 
 	const links = [

--- a/sites/skeleton.dev/src/components/examples/components/pagination/svelte/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/pagination/svelte/default.svelte
@@ -12,8 +12,7 @@
 </script>
 
 <script>
-	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
-	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
+	import { ArrowLeftIcon, ArrowRightIcon } from '@lucide/svelte';
 	import { Pagination } from '@skeletonlabs/skeleton-svelte';
 
 	let page = $state(1);

--- a/sites/skeleton.dev/src/components/examples/components/pagination/svelte/dir.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/pagination/svelte/dir.svelte
@@ -12,8 +12,7 @@
 </script>
 
 <script>
-	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
-	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
+	import { ArrowLeftIcon, ArrowRightIcon } from '@lucide/svelte';
 	import { Pagination } from '@skeletonlabs/skeleton-svelte';
 
 	let page = $state(1);

--- a/sites/skeleton.dev/src/components/examples/components/pagination/svelte/dynamic-page-size.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/pagination/svelte/dynamic-page-size.svelte
@@ -10,8 +10,7 @@
 </script>
 
 <script>
-	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
-	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
+	import { ArrowLeftIcon, ArrowRightIcon } from '@lucide/svelte';
 	import { Pagination } from '@skeletonlabs/skeleton-svelte';
 
 	let page = $state(1);

--- a/sites/skeleton.dev/src/components/examples/components/popover/svelte/headless.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/popover/svelte/headless.svelte
@@ -1,11 +1,11 @@
 <script>
-	import IconSkull from '@lucide/svelte/icons/skull';
+	import { SkullIcon } from '@lucide/svelte';
 	import { Popover, Portal } from '@skeletonlabs/skeleton-svelte';
 </script>
 
 <Popover>
 	<Popover.Trigger>
-		<IconSkull class="size-12" />
+		<SkullIcon class="size-12" />
 	</Popover.Trigger>
 	<Portal>
 		<Popover.Positioner>

--- a/sites/skeleton.dev/src/components/examples/components/portal/svelte/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/portal/svelte/default.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import SkullIcon from '@lucide/svelte/icons/skull';
+	import { SkullIcon } from '@lucide/svelte';
 	import { Portal } from '@skeletonlabs/skeleton-svelte';
 
 	let disabled = $state(true);

--- a/sites/skeleton.dev/src/components/examples/components/rating-group/svelte/custom-icons.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/rating-group/svelte/custom-icons.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import Bone from '@lucide/svelte/icons/bone';
-	import Skull from '@lucide/svelte/icons/skull';
+	import { BoneIcon, SkullIcon } from '@lucide/svelte';
 	import { RatingGroup } from '@skeletonlabs/skeleton-svelte';
 </script>
 
@@ -11,10 +10,10 @@
 				{#each ratingGroup().items as index (index)}
 					<RatingGroup.Item {index}>
 						{#snippet empty()}
-							<Bone />
+							<BoneIcon />
 						{/snippet}
 						{#snippet full()}
-							<Skull />
+							<SkullIcon />
 						{/snippet}
 					</RatingGroup.Item>
 				{/each}

--- a/sites/skeleton.dev/src/components/examples/components/segmented-control/svelte/icons.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/segmented-control/svelte/icons.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import AlignCenterVerticalIcon from '@lucide/svelte/icons/align-center-vertical';
-	import AlignEndVerticalIcon from '@lucide/svelte/icons/align-end-vertical';
-	import AlignStartVerticalIcon from '@lucide/svelte/icons/align-start-vertical';
+	import { AlignCenterVerticalIcon, AlignEndVerticalIcon, AlignStartVerticalIcon } from '@lucide/svelte';
 	import { SegmentedControl } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/switch/svelte/thumb-icons.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/switch/svelte/thumb-icons.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import Moon from '@lucide/svelte/icons/moon';
-	import Sun from '@lucide/svelte/icons/sun';
+	import { MoonIcon, SunIcon } from '@lucide/svelte';
 	import { Switch } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/tags-input/svelte/custom-icon.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/tags-input/svelte/custom-icon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import CircleXIcon from '@lucide/svelte/icons/circle-x';
+	import { CircleXIcon } from '@lucide/svelte';
 	import { TagsInput } from '@skeletonlabs/skeleton-svelte';
 </script>
 

--- a/sites/skeleton.dev/src/components/examples/components/toast/svelte/meta.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/toast/svelte/meta.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Skull from '@lucide/svelte/icons/skull';
+	import { SkullIcon } from '@lucide/svelte';
 	import { Toast, createToaster } from '@skeletonlabs/skeleton-svelte';
 
 	const toaster = createToaster({});

--- a/sites/skeleton.dev/src/components/examples/components/tree-view/svelte/collapse-expand.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/tree-view/svelte/collapse-expand.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { FileIcon, FolderIcon } from '@lucide/svelte';
+	import { TreeView, createTreeViewCollection, useTreeView } from '@skeletonlabs/skeleton-svelte';
+
+	interface Node {
+		id: string;
+		name: string;
+		children?: Node[];
+	}
+
+	const collection = createTreeViewCollection<Node>({
+		nodeToValue: (node) => node.id,
+		nodeToString: (node) => node.name,
+		rootNode: {
+			id: 'root',
+			name: '',
+			children: [
+				{
+					id: 'node_modules',
+					name: 'node_modules',
+					children: [
+						{
+							id: 'node_modules/@skeletonlabs',
+							name: '@skeletonlabs',
+							children: [
+								{
+									id: 'node_modules/@skeletonlabs/skeleton',
+									name: 'skeleton',
+								},
+							],
+						},
+					],
+				},
+				{
+					id: 'package.json',
+					name: 'package.json',
+				},
+			],
+		},
+	});
+
+	const id = $props.id();
+	const treeView = useTreeView({
+		id: id,
+		collection: collection,
+	});
+</script>
+
+<div class="space-y-2">
+	<TreeView.Provider value={treeView}>
+		<TreeView.Label>File System</TreeView.Label>
+		<TreeView.Tree>
+			{#each collection.rootNode.children || [] as node, index (node)}
+				{@render treeNode(node, [index])}
+			{/each}
+		</TreeView.Tree>
+	</TreeView.Provider>
+
+	<div class="flex gap-2">
+		<button class="btn preset-filled" onclick={() => treeView().collapse()}> Collapse </button>
+		<button class="btn preset-filled" onclick={() => treeView().expand()}> Expand </button>
+	</div>
+</div>
+
+{#snippet treeNode(node: Node, indexPath: number[])}
+	<TreeView.NodeProvider value={{ node, indexPath }}>
+		{#if node.children}
+			<TreeView.Branch>
+				<TreeView.BranchControl>
+					<TreeView.BranchIndicator />
+					<TreeView.BranchText>
+						<FolderIcon className="size-4" />
+						{node.name}
+					</TreeView.BranchText>
+				</TreeView.BranchControl>
+				<TreeView.BranchContent>
+					<TreeView.BranchIndentGuide />
+					{#each node.children as childNode, childIndex (childNode)}
+						{@render treeNode(childNode, [...indexPath, childIndex])}
+					{/each}
+				</TreeView.BranchContent>
+			</TreeView.Branch>
+		{:else}
+			<TreeView.Item>
+				<FileIcon className="size-4" />
+				{node.name}
+			</TreeView.Item>
+		{/if}
+	</TreeView.NodeProvider>
+{/snippet}

--- a/sites/skeleton.dev/src/components/examples/components/tree-view/svelte/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/tree-view/svelte/default.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { FileIcon, FolderIcon } from '@lucide/svelte';
+	import { TreeView, createTreeViewCollection } from '@skeletonlabs/skeleton-svelte';
+
+	interface Node {
+		id: string;
+		name: string;
+		children?: Node[];
+	}
+
+	const collection = createTreeViewCollection<Node>({
+		nodeToValue: (node) => node.id,
+		nodeToString: (node) => node.name,
+		rootNode: {
+			id: 'root',
+			name: '',
+			children: [
+				{
+					id: 'node_modules',
+					name: 'node_modules',
+					children: [
+						{
+							id: 'node_modules/@skeletonlabs',
+							name: '@skeletonlabs',
+							children: [
+								{
+									id: 'node_modules/@skeletonlabs/skeleton',
+									name: 'skeleton',
+								},
+							],
+						},
+					],
+				},
+				{
+					id: 'package.json',
+					name: 'package.json',
+				},
+			],
+		},
+	});
+</script>
+
+<TreeView {collection}>
+	<TreeView.Label>File System</TreeView.Label>
+	<TreeView.Tree>
+		{#each collection.rootNode.children || [] as node, index (node)}
+			{@render treeNode(node, [index])}
+		{/each}
+	</TreeView.Tree>
+</TreeView>
+
+{#snippet treeNode(node: Node, indexPath: number[])}
+	<TreeView.NodeProvider value={{ node, indexPath }}>
+		{#if node.children}
+			<TreeView.Branch>
+				<TreeView.BranchControl>
+					<TreeView.BranchIndicator />
+					<TreeView.BranchText>
+						<FolderIcon className="size-4" />
+						{node.name}
+					</TreeView.BranchText>
+				</TreeView.BranchControl>
+				<TreeView.BranchContent>
+					<TreeView.BranchIndentGuide />
+					{#each node.children as childNode, childIndex (childNode)}
+						{@render treeNode(childNode, [...indexPath, childIndex])}
+					{/each}
+				</TreeView.BranchContent>
+			</TreeView.Branch>
+		{:else}
+			<TreeView.Item>
+				<FileIcon className="size-4" />
+				{node.name}
+			</TreeView.Item>
+		{/if}
+	</TreeView.NodeProvider>
+{/snippet}

--- a/sites/skeleton.dev/src/components/examples/design/presets/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/design/presets/default.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import IconBookmark from '@lucide/svelte/icons/bookmark';
+	import { IconBookmark } from '@lucide/svelte';
 
 	const diagramCircle = 'preset-tonal w-8 aspect-square flex justify-center items-center rounded-full';
 </script>

--- a/sites/skeleton.dev/src/components/examples/guides/cookbook/chat/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/guides/cookbook/chat/default.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import IconSend from '@lucide/svelte/icons/send-horizontal';
+	import { IconSend } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 
 	// Types

--- a/sites/skeleton.dev/src/components/examples/guides/cookbook/stepper/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/guides/cookbook/stepper/default.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import IconArrowLeft from '@lucide/svelte/icons/arrow-left';
-	import IconArrowRight from '@lucide/svelte/icons/arrow-right';
+	import { ArrowLeftIcon, ArrowRightIcon } from '@lucide/svelte';
 
 	// Source Data
 	const steps = [
@@ -74,13 +73,13 @@
 		<nav class="flex justify-between items-center gap-4">
 			<!-- Back Button -->
 			<button type="button" class="btn preset-tonal hover:preset-filled" onclick={prevStep} disabled={isFirstStep}>
-				<IconArrowLeft size={18} />
+				<ArrowLeftIcon size={18} />
 				<span>Previous</span>
 			</button>
 			<!-- Next Button -->
 			<button type="button" class="btn preset-tonal hover:preset-filled" onclick={nextStep} disabled={isLastStep}>
 				<span>Next</span>
-				<IconArrowRight size={18} />
+				<ArrowRightIcon size={18} />
 			</button>
 		</nav>
 	</div>

--- a/sites/skeleton.dev/src/components/homepage/component-grid.svelte
+++ b/sites/skeleton.dev/src/components/homepage/component-grid.svelte
@@ -1,22 +1,21 @@
 <script lang="ts">
-	// Icons
-	import IconArrowUpRight from '@lucide/svelte/icons/arrow-up-right';
-	import IconEqualizer from '@lucide/svelte/icons/audio-lines';
-	import IconNormalize from '@lucide/svelte/icons/audio-waveform';
-	import IconCrossfade from '@lucide/svelte/icons/chart-no-axes-column-increasing';
-	import IconCheck from '@lucide/svelte/icons/check';
-	import IconFastForward from '@lucide/svelte/icons/fast-forward';
-	import Icon3dAudio from '@lucide/svelte/icons/move-3d';
-	import IconPlay from '@lucide/svelte/icons/play';
-	import IconRewind from '@lucide/svelte/icons/rewind';
-	import IconUsers from '@lucide/svelte/icons/user';
-	import IconVolume from '@lucide/svelte/icons/volume-2';
+	import {
+		ArrowUpRightIcon,
+		CheckIcon,
+		AudioLinesIcon,
+		FastForwardIcon,
+		AudioWaveform,
+		Headphones,
+		PlayIcon,
+		RewindIcon,
+		UsersIcon,
+		Volume2Icon,
+		ChartNoAxesColumnIncreasingIcon,
+	} from '@lucide/svelte';
 	import { Avatar, Switch, Slider, Progress, SegmentedControl } from '@skeletonlabs/skeleton-svelte';
 
-	// Classes
 	const cardClasses = 'card preset-outlined-surface-200-800 bg-surface-50-950 p-5 space-y-5';
 
-	// State
 	const notifications = $state({
 		doNotDisturb: false,
 		global: false,
@@ -32,13 +31,13 @@
 			.trim();
 	}
 
-	// Seed Data
 	const teamData = [
 		{ name: 'Janet Rosenbell', email: 'jrosenbell@email.com' },
 		{ name: 'Jason Greene', email: 'jgreene@email.com' },
 		{ name: 'Lucas Gamble', email: 'lgamble@email.com' },
 		{ name: 'Murray Henderson', email: 'mhenderson@email.com' },
 	];
+
 	const tableData = [
 		{ position: '0', name: 'Iron', symbol: 'Fe', atomic_no: '26' },
 		{ position: '1', name: 'Rhodium', symbol: 'Rh', atomic_no: '45' },
@@ -136,7 +135,7 @@
 			</header>
 			<img src="https://i.imgur.com/kocJdtN.png" alt="Massive Attack" class="rounded-container border-[1px] border-surface-500/50" />
 			<div class="grid grid-cols-[auto_1fr] gap-2 items-center">
-				<IconPlay class="size-4 opacity-60" />
+				<PlayIcon class="size-4 opacity-60" />
 				<Slider defaultValue={[70]}>
 					<Slider.Control>
 						<Slider.Track>
@@ -151,25 +150,25 @@
 			<div class="grid grid-cols-4 gap-2 items-center">
 				<button type="button" class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal">
 					<div class="w-8 aspect-square rounded-full flex justify-center items-center preset-filled-primary-500">
-						<IconNormalize class="size-4" />
+						<AudioLinesIcon class="size-4" />
 					</div>
 					<span class="text-[10px]">Normalize</span>
 				</button>
 				<button type="button" class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal">
 					<div class="w-8 aspect-square rounded-full flex justify-center items-center preset-filled-primary-500">
-						<IconEqualizer class="size-4" />
+						<AudioWaveform class="size-4" />
 					</div>
 					<span class="text-[10px]">Equalizer</span>
 				</button>
 				<button type="button" class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal">
 					<div class="w-8 aspect-square rounded-full flex justify-center items-center preset-filled-primary-500">
-						<Icon3dAudio class="size-4" />
+						<Headphones class="size-4" />
 					</div>
 					<span class="text-[10px]">3D Audio</span>
 				</button>
 				<button type="button" class="aspect-square flex flex-col justify-center items-center gap-2 rounded-container hover:preset-tonal">
 					<div class="w-8 aspect-square rounded-full flex justify-center items-center preset-filled-primary-500">
-						<IconCrossfade class="size-4" />
+						<ChartNoAxesColumnIncreasingIcon class="size-4" />
 					</div>
 					<span class="text-[10px]">Crossfade</span>
 				</button>
@@ -251,7 +250,7 @@
 					<p class="text-xs opacity-60">Posted April 1-13</p>
 				</div>
 				<button type="button" class="btn-icon rounded-full preset-tonal" title="Expand revenue details" aria-label="Expand revenue details">
-					<IconArrowUpRight class="size-4" />
+					<ArrowUpRightIcon class="size-4" />
 				</button>
 			</header>
 			<hr class="hr" />
@@ -314,7 +313,7 @@
 		<!-- 10 -->
 		<div class={`${cardClasses} row-span-2 row-start-5 text-center`}>
 			<button type="button" class="w-16 aspect-square preset-tonal-success flex justify-center items-center mx-auto rounded-full">
-				<IconCheck class="size-8" />
+				<CheckIcon class="size-8" />
 			</button>
 			<div class="space-y-2 text-center">
 				<h2 class="h2">Invoice Paid</h2>
@@ -390,7 +389,7 @@
 			<div class="space-y-2">
 				<header class="flex justify-between items-center gap-4">
 					<h2 class="h6">Contributions</h2>
-					<IconUsers class="size-4 opacity-60" />
+					<UsersIcon class="size-4 opacity-60" />
 				</header>
 				<h2 class="text-4xl font-bold">+1,248</h2>
 				<p class="text-xs opacity-60"><span class="badge preset-tonal">+150% increase</span></p>
@@ -405,10 +404,10 @@
 					title="Play music"
 					aria-label="Play music"
 				>
-					<IconPlay class="size-6 fill-current stroke-none" />
+					<PlayIcon class="size-6 fill-current stroke-none" />
 				</button>
 				<div class="grid grid-cols-[auto_1fr_auto] gap-5 items-center px-10">
-					<button type="button" class="btn hover:preset-tonal"><IconRewind class="size-4 opacity-60" /></button>
+					<button type="button" class="btn hover:preset-tonal"><RewindIcon class="size-4 opacity-60" /></button>
 					<div class="space-y-1">
 						<p class="font-bold">Pink Floyd</p>
 						<progress class="progress" value={75} max={100}></progress>
@@ -417,10 +416,10 @@
 							<p class="text-xs opacity-60">3:16</p>
 						</div>
 					</div>
-					<button type="button" class="btn hover:preset-tonal"><IconFastForward class="size-4 opacity-60" /></button>
+					<button type="button" class="btn hover:preset-tonal"><FastForwardIcon class="size-4 opacity-60" /></button>
 				</div>
 				<div class="grid grid-cols-[auto_1fr] gap-2 items-center">
-					<IconVolume class="size-4 opacity-60" />
+					<Volume2Icon class="size-4 opacity-60" />
 					<Slider defaultValue={[70]}>
 						<Slider.Control>
 							<Slider.Track>

--- a/sites/skeleton.dev/src/components/homepage/design-system.svelte
+++ b/sites/skeleton.dev/src/components/homepage/design-system.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-	// Icons
-	import IconBookmark from '@lucide/svelte/icons/bookmark';
-	import IconFigma from '@lucide/svelte/icons/figma';
-	import IconHeart from '@lucide/svelte/icons/heart';
-	import IconTriangle from '@lucide/svelte/icons/triangle';
-	import IconUserRound from '@lucide/svelte/icons/user-round';
+	import { BookmarkIcon, FigmaIcon, HeartIcon, TriangleIcon, UserRoundIcon } from '@lucide/svelte';
 
 	let state = $state(0);
+
 	const steps = [
 		{
 			label: 'The Figma UI Kit',
@@ -58,7 +54,7 @@
 		<nav class="grid grid-cols-2 gap-4">
 			{#each steps as step, i (step)}
 				<button type="button" onclick={() => setState(i)} class={`${setStateClass(i)} ${i === 0 ? 'col-span-2' : ''}`}>
-					{#if i === 0}<IconFigma class="size-4" />{/if}
+					{#if i === 0}<FigmaIcon class="size-4" />{/if}
 					<span>{step.label}</span>
 				</button>
 			{/each}
@@ -143,7 +139,7 @@
 				</div>
 				<div class="flex flex-col items-center">
 					<button type="button" class="btn hover:preset-filled hover:brightness-100">
-						<IconBookmark className="size-6" />
+						<BookmarkIcon className="size-6" />
 					</button>
 				</div>
 			</div>
@@ -166,9 +162,9 @@
 		{:else if state == 6}
 			<!-- Step 7: Iconography -->
 			<div class="flex gap-5 md:gap-10">
-				<IconHeart class="size-16 md:size-24" />
-				<IconUserRound class="size-16 md:size-24" />
-				<IconTriangle class="size-16 md:size-24" />
+				<HeartIcon class="size-16 md:size-24" />
+				<UserRoundIcon class="size-16 md:size-24" />
+				<TriangleIcon class="size-16 md:size-24" />
 			</div>
 		{/if}
 	</div>

--- a/sites/skeleton.dev/src/components/homepage/framework-components.svelte
+++ b/sites/skeleton.dev/src/components/homepage/framework-components.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import IconChevron from '@lucide/svelte/icons/chevron-right';
+	import { ChevronRightIcon } from '@lucide/svelte';
 	import { Switch } from '@skeletonlabs/skeleton-svelte';
 
 	let checked = $state(false);
@@ -16,7 +16,7 @@
 		<div class="card bg-noise preset-filled-secondary-500 aspect-video shadow-xl flex justify-center items-center">
 			<a href="/docs/tailwind/buttons" target="_blank" class="btn preset-filled scale-150 shadow-xl">
 				<span>Button</span>
-				<IconChevron className="size-4" />
+				<ChevronRightIcon className="size-4" />
 			</a>
 		</div>
 	</div>

--- a/sites/themes.skeleton.dev/package.json
+++ b/sites/themes.skeleton.dev/package.json
@@ -26,7 +26,8 @@
 		"svelte-check": "catalog:",
 		"tailwindcss": "catalog:",
 		"typescript": "catalog:",
-		"vite": "catalog:"
+		"vite": "catalog:",
+		"vite-plugin-transform-lucide-imports": "catalog:"
 	},
 	"type": "module"
 }

--- a/sites/themes.skeleton.dev/src/lib/components/common/LightSwitch/LightSwitch.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/common/LightSwitch/LightSwitch.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import IconMoon from '@lucide/svelte/icons/moon';
-	import IconSun from '@lucide/svelte/icons/sun';
+	import { MoonIcon, SunIcon } from '@lucide/svelte';
 
 	type Mode = 'dark' | 'light';
 
@@ -48,8 +47,8 @@
 	aria-label="Toggle dark mode."
 >
 	{#if mode === 'dark'}
-		<IconSun class="size-5" />
+		<MoonIcon class="size-5" />
 	{:else}
-		<IconMoon class="size-5" />
+		<SunIcon class="size-5" />
 	{/if}
 </button>

--- a/sites/themes.skeleton.dev/src/lib/components/generator/Controls/Controls.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/generator/Controls/Controls.svelte
@@ -6,13 +6,7 @@
 	import ControlsEdges from './ControlsEdges.svelte';
 	import ControlsSpacing from './ControlsSpacing.svelte';
 	import ControlsTypography from './ControlsTypography.svelte';
-	import ALargeSmallIcon from '@lucide/svelte/icons/a-large-small';
-	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
-	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
-	import LayersIcon from '@lucide/svelte/icons/layers';
-	import PaletteIcon from '@lucide/svelte/icons/palette';
-	import ScalingIcon from '@lucide/svelte/icons/scaling';
-	import SquareDashedIcon from '@lucide/svelte/icons/square-dashed';
+	import { ALargeSmallIcon, ChevronDownIcon, ChevronUpIcon, LayersIcon, PaletteIcon, ScalingIcon, SquareDashedIcon } from '@lucide/svelte';
 	import { Accordion, SegmentedControl } from '@skeletonlabs/skeleton-svelte';
 
 	const items = [

--- a/sites/themes.skeleton.dev/src/lib/components/generator/Controls/ControlsColors.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/generator/Controls/ControlsColors.svelte
@@ -1,18 +1,10 @@
 <script lang="ts">
-	// Constants
-	// Icons
 	import * as constants from '$lib/constants/generator';
 	import { globals, settingsColors } from '$lib/state/generator.svelte';
-	// Utils
 	import { genColorRamp, genRandomSeed, getColorKey, seedColor } from '$lib/utils/generator/colors';
-	import HiddenInput from '../../../../../../../packages/skeleton-svelte/dist/components/file-upload/anatomy/hidden-input.svelte';
-	import DicesIcon from '@lucide/svelte/icons/dices';
-	import ClearIcon from '@lucide/svelte/icons/eraser';
-	import PencilIcon from '@lucide/svelte/icons/pencil';
-	import SproutIcon from '@lucide/svelte/icons/sprout';
+	import { DicesIcon, PencilIcon, SproutIcon, EraserIcon } from '@lucide/svelte';
 	import { Switch, Tabs } from '@skeletonlabs/skeleton-svelte';
 
-	// Types
 	interface ColorSelection {
 		label: string;
 		description: string;
@@ -20,7 +12,6 @@
 		class: string;
 	}
 
-	// Local
 	const colorSelection: ColorSelection[] = [
 		{ label: 'Primary', description: 'The primary brand color.', value: 'primary', class: 'preset-filled-primary-500' },
 		{ label: 'Secondary', description: 'A secondary accent color.', value: 'secondary', class: 'preset-filled-secondary-500' },
@@ -62,7 +53,7 @@
 <div class="space-y-4">
 	<p class="opacity-60">Define a palette per each available theme color.</p>
 	<button type="button" class="btn preset-outlined-surface-200-800 hover:preset-tonal w-full" onclick={onClearPalette}>
-		<ClearIcon size={20} />
+		<EraserIcon size={20} />
 		<span>Clear All Palettes</span>
 	</button>
 	<Tabs value={globals.activeColor} onValueChange={(e) => (globals.activeColor = e.value)}>

--- a/sites/themes.skeleton.dev/src/lib/components/generator/Preview/PreviewComponents.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/generator/Preview/PreviewComponents.svelte
@@ -2,16 +2,18 @@
 	import * as constants from '$lib/constants/generator';
 	import { globals } from '$lib/state/generator.svelte';
 	import ExampleChart from '../ExampleChart/ExampleChart.svelte';
-	import CenterIcon from '@lucide/svelte/icons/align-center';
-	import JustifyIcon from '@lucide/svelte/icons/align-justify';
-	import LeftIcon from '@lucide/svelte/icons/align-left';
-	import RightIcon from '@lucide/svelte/icons/align-right';
-	import ArrowUpRightIcon from '@lucide/svelte/icons/arrow-up-right';
-	import CalendarIcon from '@lucide/svelte/icons/calendar';
-	import CircleUserIcon from '@lucide/svelte/icons/circle-user';
-	import MenuIcon from '@lucide/svelte/icons/menu';
-	import SearchIcon from '@lucide/svelte/icons/search';
-	import SkullIcon from '@lucide/svelte/icons/skull';
+	import {
+		TextAlignCenter,
+		TextAlignJustify,
+		TextAlignStart,
+		TextAlignEnd,
+		ArrowUpRightIcon,
+		CalendarIcon,
+		CircleUserIcon,
+		MenuIcon,
+		SearchIcon,
+		SkullIcon,
+	} from '@lucide/svelte';
 	import { AppBar, Avatar, SegmentedControl, Switch, Tabs } from '@skeletonlabs/skeleton-svelte';
 
 	const currentPresets = $derived(constants.previewPresets[globals.activeColor]);
@@ -136,25 +138,25 @@
 					<SegmentedControl.Indicator />
 					<SegmentedControl.Item value="left" class="flex-1">
 						<SegmentedControl.ItemText>
-							<LeftIcon />
+							<TextAlignStart />
 						</SegmentedControl.ItemText>
 						<SegmentedControl.ItemHiddenInput />
 					</SegmentedControl.Item>
 					<SegmentedControl.Item value="center" class="flex-1">
 						<SegmentedControl.ItemText>
-							<CenterIcon />
+							<TextAlignCenter />
 						</SegmentedControl.ItemText>
 						<SegmentedControl.ItemHiddenInput />
 					</SegmentedControl.Item>
 					<SegmentedControl.Item value="right" class="flex-1">
 						<SegmentedControl.ItemText>
-							<RightIcon />
+							<TextAlignEnd />
 						</SegmentedControl.ItemText>
 						<SegmentedControl.ItemHiddenInput />
 					</SegmentedControl.Item>
 					<SegmentedControl.Item value="justify" class="flex-1">
 						<SegmentedControl.ItemText>
-							<JustifyIcon />
+							<TextAlignJustify />
 						</SegmentedControl.ItemText>
 						<SegmentedControl.ItemHiddenInput />
 					</SegmentedControl.Item>

--- a/sites/themes.skeleton.dev/src/lib/components/generator/Preview/PreviewPalette.svelte
+++ b/sites/themes.skeleton.dev/src/lib/components/generator/Preview/PreviewPalette.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-	// Icons
-	import IconCenter from '@lucide/svelte/icons/swatch-book';
+	import { SwatchBook } from '@lucide/svelte';
 
-	// Data
 	export const palette = [
 		{
 			name: 'Primary',
@@ -143,37 +141,37 @@
 		<h2 class="h4">Filled</h2>
 		<div class="w-full grid grid-cols-11 gap-4">
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-950-50">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-900-100">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-800-200">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-700-300">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-600-400">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-500">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-400-600">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-300-700">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-200-800">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-100-900">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-filled-primary-50-950">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 		</div>
 	</section>
@@ -182,37 +180,37 @@
 		<h2 class="h4">Outlined</h2>
 		<div class="w-full grid grid-cols-11 gap-4">
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-950-50">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-900-100">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-800-200">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-700-300">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-600-400">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-500">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-400-600">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-300-700">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-200-800">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-100-900">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 			<div class="aspect-square rounded-full flex justify-center items-center preset-outlined-primary-50-950">
-				<IconCenter size={32} />
+				<SwatchBook size={32} />
 			</div>
 		</div>
 	</section>
@@ -220,13 +218,13 @@
 	<section class="space-y-5">
 		<h2 class="h4">Tonal</h2>
 		<div class="w-full grid grid-cols-11 gap-4">
-			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-primary"><IconCenter size={32} /></div>
-			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-secondary"><IconCenter size={32} /></div>
-			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-tertiary"><IconCenter size={32} /></div>
-			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-success"><IconCenter size={32} /></div>
-			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-warning"><IconCenter size={32} /></div>
-			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-error"><IconCenter size={32} /></div>
-			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal"><IconCenter size={32} /></div>
+			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-primary"><SwatchBook size={32} /></div>
+			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-secondary"><SwatchBook size={32} /></div>
+			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-tertiary"><SwatchBook size={32} /></div>
+			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-success"><SwatchBook size={32} /></div>
+			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-warning"><SwatchBook size={32} /></div>
+			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal-error"><SwatchBook size={32} /></div>
+			<div class="aspect-square rounded-full flex justify-center items-center preset-tonal"><SwatchBook size={32} /></div>
 		</div>
 	</section>
 </div>

--- a/sites/themes.skeleton.dev/src/routes/(app)/themes/import/+page.svelte
+++ b/sites/themes.skeleton.dev/src/routes/(app)/themes/import/+page.svelte
@@ -5,7 +5,7 @@
 	import { importThemeV2 } from '$lib/utils/importer/import-theme-v2';
 	// Utils
 	import { importThemeV3 } from '$lib/utils/importer/import-theme-v3';
-	import FileUpIcon from '@lucide/svelte/icons/file-up';
+	import { FileUpIcon } from '@lucide/svelte';
 	import { themes } from '@skeletonlabs/skeleton-common';
 	import { FileUpload, type FileUploadRootProps } from '@skeletonlabs/skeleton-svelte';
 

--- a/sites/themes.skeleton.dev/vite.config.ts
+++ b/sites/themes.skeleton.dev/vite.config.ts
@@ -1,7 +1,8 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwind from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
+import transformLucideImports from 'vite-plugin-transform-lucide-imports';
 
 export default defineConfig({
-	plugins: [sveltekit(), tailwind()],
+	plugins: [sveltekit(), tailwind(), transformLucideImports()],
 });


### PR DESCRIPTION
Uses the newly created vite pugin lucide impots from @AdrianGonz97 (Thanks!) that transforms our imports from:
```ts
import { FooIcon } from '@lucide/svelte'
```
to:
```ts
import FooIcon from '@lucide/svelte/icons/foo'
```
Meaning we can do the more conveniently named imports while still benefiting from the performance of default path imports.