### PR TITLE
docs: display version in header

### DIFF
--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -21,7 +21,8 @@
 		"./themes/*": {
 			"style": "./dist/themes/*.css",
 			"default": "./dist/themes/*.css"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"files": [
 		"dist"

--- a/sites/skeleton.dev/src/app.css
+++ b/sites/skeleton.dev/src/app.css
@@ -62,7 +62,6 @@ html {
 /* Homepage Gradients */
 .gradient-homepage-one {
 	background-size: cover;
-	/* prettier-ignore */
 	background-image:
 		radial-gradient(at 24% 25%, color-mix(in oklab, var(--color-primary-500) 30%, transparent) 0px, transparent 30%),
 		radial-gradient(at 35% 13%, color-mix(in oklab, var(--color-success-500) 18%, transparent) 0px, transparent 30%),
@@ -70,7 +69,6 @@ html {
 }
 .gradient-homepage-two {
 	background-size: cover;
-	/* prettier-ignore */
 	background-image:
 		radial-gradient(at 25% 40%, color-mix(in oklab, var(--color-primary-500) 10%, transparent) 0px, transparent 35%),
 		radial-gradient(at 100% 58%, color-mix(in oklab, var(--color-success-500) 5%, transparent) 0px, transparent 35%);
@@ -102,10 +100,9 @@ html {
 [data-theme='wintry'] {
 	& body {
 		background-attachment: fixed;
-		/* prettier-ignore */
 		background-image:
-		radial-gradient(at 0% 25%, color-mix(in oklab, var(--color-primary-500) 10%, transparent) 0px, transparent 30%),
-		radial-gradient(at 15% 06%, color-mix(in oklab, var(--color-success-500) 5%, transparent) 0px, transparent 30%);
+			radial-gradient(at 0% 25%, color-mix(in oklab, var(--color-primary-500) 10%, transparent) 0px, transparent 30%),
+			radial-gradient(at 15% 06%, color-mix(in oklab, var(--color-success-500) 5%, transparent) 0px, transparent 30%);
 	}
 }
 

--- a/sites/skeleton.dev/src/components/ui/header-themes.tsx
+++ b/sites/skeleton.dev/src/components/ui/header-themes.tsx
@@ -14,12 +14,8 @@ export default function HeaderThemes() {
 
 	function selectTheme(theme: string) {
 		setActiveTheme(theme);
-		document.body.classList.add('transition-all', 'duration-200');
 		document.documentElement.setAttribute('data-theme', theme);
 		localStorage.setItem('theme', theme);
-		setTimeout(() => {
-			document.body.classList.remove('transition-all', 'duration-200');
-		}, 200);
 	}
 
 	return (

--- a/sites/skeleton.dev/src/components/ui/header-version.tsx
+++ b/sites/skeleton.dev/src/components/ui/header-version.tsx
@@ -1,11 +1,12 @@
 import { Popover, Portal } from '@skeletonlabs/skeleton-react';
+import packageJson from '@skeletonlabs/skeleton/package.json';
 import { ChevronDownIcon, ArrowUpRightIcon } from 'lucide-react';
 
 export default function HeaderVersion() {
 	return (
 		<Popover positioning={{ placement: 'top-start' }}>
 			<Popover.Trigger className="btn hover:preset-tonal gap-1">
-				<span>v4</span>
+				<span>v{packageJson.version}</span>
 				<ChevronDownIcon className="size-4 opacity-60" />
 			</Popover.Trigger>
 			<Portal>

--- a/sites/skeleton.dev/src/components/ui/header.astro
+++ b/sites/skeleton.dev/src/components/ui/header.astro
@@ -1,13 +1,10 @@
 ---
-// Stores
-// Components
+
 import Drawer from '@/components/ui/drawer';
 import LightSwitch from '@/components/ui/light-switch';
 import Navigation from '@/components/ui/navigation.astro';
-// Icons
 import { Icon } from 'astro-icon/components';
 import { socialLinks } from '@/lib/social-links';
-
 import HeaderSponsors from '@/components/ui/header-sponsors';
 import HeaderThemes from '@/components/ui/header-themes';
 import HeaderVersion from '@/components/ui/header-version';
@@ -30,7 +27,6 @@ const versionLinks = [
 	<div
 		class="container mx-auto grid max-w-screen-2xl grid-cols-[auto_1fr_auto] xl:grid-cols-[1fr_auto_1fr] items-center gap-4 px-4 xl:px-10"
 	>
-		<!-- Left -->
 		<div class="flex items-stretch justify-start gap-4">
 			<Drawer client:load>
 				<Navigation
@@ -38,14 +34,11 @@ const versionLinks = [
 					bottomGroups={[{ title: 'Previous Versions', items: versionLinks }]}
 				/>
 			</Drawer>
-			<!-- Logo -->
 			<a class="hidden xl:inline-block" href="/" title="Skeleton">
 				<Icon name="skeleton" size={32} />
 			</a>
 			<div class="hidden xl:flex items-center">
-				<!-- Version Picker -->
 				<HeaderVersion client:load />
-				<!-- Navigation -->
 				{
 					coreLinks.map((link) => (
 						<a class="btn hover:preset-tonal" href={link.href} target={link.target}>
@@ -55,20 +48,13 @@ const versionLinks = [
 				}
 			</div>
 		</div>
-		<!-- Middle -->
 		<div class="flex items-center gap-2">
-			<!-- Search -->
 			<Search client:load />
 		</div>
-		<!-- Right -->
-		<!-- <div class="hidden xl:flex items-center justify-end gap-2"> -->
 		<div class="flex justify-end items-stretch gap-2">
-			<!-- Mode and Theme -->
 			<LightSwitch client:load />
 			<HeaderThemes client:load />
-			<!-- Divider -->
 			<span class="border-r border-surface-200-800"></span>
-			<!-- Social -->
 			<nav class="flex items-center gap-1">
 				{
 					socialLinks.slice(0, 2).map((link) => (
@@ -78,9 +64,7 @@ const versionLinks = [
 					))
 				}
 			</nav>
-			<!-- Divider -->
 			<span class="hidden xl:inline-block border-r border-surface-200-800"></span>
-			<!-- Sponsors -->
 			<div>
 				<HeaderSponsors client:load />
 			</div>

--- a/sites/skeleton.dev/src/components/ui/header.astro
+++ b/sites/skeleton.dev/src/components/ui/header.astro
@@ -1,5 +1,4 @@
 ---
-
 import Drawer from '@/components/ui/drawer';
 import LightSwitch from '@/components/ui/light-switch';
 import Navigation from '@/components/ui/navigation.astro';


### PR DESCRIPTION
QoL, makes more sense to do now that we have fixed versioning:

<img width="594" height="232" alt="image" src="https://github.com/user-attachments/assets/37fb403b-66e5-41fa-9459-73058220064f" />

