### PR TITLE
fix typos

### DIFF
--- a/sites/skeleton.dev/src/components/layouts/docs.astro
+++ b/sites/skeleton.dev/src/components/layouts/docs.astro
@@ -69,7 +69,7 @@ const urls = {
 						</span>
 						<p>
 							This feature is currently in a {frontmatter.stability} status and not intended for production use. It may receive breaking
-							changes before it's stable release.
+							changes before its stable release.
 						</p>
 					</div>
 				)

--- a/sites/skeleton.dev/src/content/docs/get-started/introduction.mdx
+++ b/sites/skeleton.dev/src/content/docs/get-started/introduction.mdx
@@ -47,7 +47,7 @@ Skeleton provides a uniform design language and structured framework for control
 			<a className="anchor" href="https://tailwindcss.com/" target="_blank" rel="external">
 				Tailwind
 			</a>
-			, while extending it's capabilities in meaningful ways. Providing full support for the encapsulated components of the modern web.
+			, while extending its capabilities in meaningful ways. Providing full support for the encapsulated components of the modern web.
 		</p>
 	</div>
 	<div className="card preset-outlined-surface-200-800 bg-surface-50-950 p-10 space-y-4">

--- a/sites/skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
+++ b/sites/skeleton.dev/src/content/docs/resources/contribute/documentation.mdx
@@ -90,7 +90,7 @@ Code Blocks are provided via [Expressive Code](https://expressive-code.com/) via
 
 ### Preview
 
-Allows you to quickly toggle between an example component and it's source code.
+Allows you to quickly toggle between an example component and its source code.
 
 ```ts
 import Default from '@/components/examples/foo/default';

--- a/sites/skeleton.dev/src/content/docs/tailwind/forms.mdx
+++ b/sites/skeleton.dev/src/content/docs/tailwind/forms.mdx
@@ -61,7 +61,7 @@ Implement the plugin using the `@plugin` directive immediately following the `ta
 
 ### Browser Support
 
-The display of native and semantic HTML form elements can vary between both operating systems and browsers. Skeleton does it's best to adhere to progressive enhancement best practices. However, we advise you validate support for each element per your target audience.
+The display of native and semantic HTML form elements can vary between both operating systems and browsers. Skeleton does its best to adhere to progressive enhancement best practices. However, we advise you validate support for each element per your target audience.
 
 ## Inputs
 


### PR DESCRIPTION
Just a few small typo fixes related to `it's` vs `its` usage.