### PR TITLE
fix(skeleton-svelte): SegmentedControl props not reactive

### DIFF
--- a/.changeset/lovely-buttons-know.md
+++ b/.changeset/lovely-buttons-know.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+fix: SegmentedControl props not reactive
+  

--- a/packages/skeleton-svelte/src/components/segmented-control/anatomy/control.svelte
+++ b/packages/skeleton-svelte/src/components/segmented-control/anatomy/control.svelte
@@ -26,5 +26,7 @@
 {#if element}
 	{@render element(attributes)}
 {:else}
-	<div {...attributes}>{@render children?.()}</div>
+	<div {...attributes}>
+		{@render children?.()}
+	</div>
 {/if}

--- a/packages/skeleton-svelte/src/components/segmented-control/modules/provider.svelte.ts
+++ b/packages/skeleton-svelte/src/components/segmented-control/modules/provider.svelte.ts
@@ -3,10 +3,10 @@ import type { Api, Props } from '@zag-js/radio-group';
 import { normalizeProps, useMachine, type PropTypes } from '@zag-js/svelte';
 
 export function useSegmentedControl(props: Props | (() => Props)): () => Api<PropTypes> {
-	const service = useMachine(machine, {
-		orientation: 'horizontal',
+	const service = useMachine(machine, () => ({
+		orientation: 'horizontal' as const,
 		...(typeof props === 'function' ? props() : props),
-	});
-	const segmentedControl = connect(service, normalizeProps);
+	}));
+	const segmentedControl = $derived(connect(service, normalizeProps));
 	return () => segmentedControl;
 }

--- a/sites/skeleton.dev/src/components/examples/components/segmented-control/react/controlled.tsx
+++ b/sites/skeleton.dev/src/components/examples/components/segmented-control/react/controlled.tsx
@@ -1,0 +1,23 @@
+import { SegmentedControl } from '@skeletonlabs/skeleton-react';
+import { useState } from 'react';
+
+export default function Controlled() {
+	const [value, setValue] = useState<string | null>('item-1');
+
+	return (
+		<div className="flex flex-col items-center gap-4">
+			<SegmentedControl value={value} onValueChange={(details) => setValue(details.value)}>
+				<SegmentedControl.Control>
+					<SegmentedControl.Indicator />
+					{['item-1', 'item-2', 'item-3'].map((item) => (
+						<SegmentedControl.Item value={item} key={item}>
+							<SegmentedControl.ItemText>{item}</SegmentedControl.ItemText>
+							<SegmentedControl.ItemHiddenInput />
+						</SegmentedControl.Item>
+					))}
+				</SegmentedControl.Control>
+			</SegmentedControl>
+			<pre className="pre">{value}</pre>
+		</div>
+	);
+}

--- a/sites/skeleton.dev/src/components/examples/components/segmented-control/svelte/controlled.svelte
+++ b/sites/skeleton.dev/src/components/examples/components/segmented-control/svelte/controlled.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { SegmentedControl } from '@skeletonlabs/skeleton-svelte';
+
+	let value = $state<string | null>('item-1');
+</script>
+
+<div class="flex flex-col items-center gap-4">
+	<SegmentedControl {value} onValueChange={(details) => (value = details.value)}>
+		<SegmentedControl.Control>
+			<SegmentedControl.Indicator />
+			{#each ['item-1', 'item-2', 'item-3'] as item (item)}
+				<SegmentedControl.Item value={item}>
+					<SegmentedControl.ItemText>{item}</SegmentedControl.ItemText>
+					<SegmentedControl.ItemHiddenInput />
+				</SegmentedControl.Item>
+			{/each}
+		</SegmentedControl.Control>
+	</SegmentedControl>
+	<pre class="pre">{value}</pre>
+</div>

--- a/sites/skeleton.dev/src/content/docs/components/segmented-control/react.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/segmented-control/react.mdx
@@ -1,6 +1,9 @@
 import Default from '@/components/examples/components/segmented-control/react/default';
 import DefaultRaw from '@/components/examples/components/segmented-control/react/default?raw';
 
+import Controlled from '@/components/examples/components/segmented-control/react/controlled';
+import ControlledRaw from '@/components/examples/components/segmented-control/react/controlled?raw';
+
 import Icons from '@/components/examples/components/segmented-control/react/icons';
 import IconsRaw from '@/components/examples/components/segmented-control/react/icons?raw';
 
@@ -25,6 +28,17 @@ import DirRaw from '@/components/examples/components/segmented-control/react/dir
 	</Fragment>
 	<Fragment slot="code">
 		<Code code={DefaultRaw} lang="tsx" />
+	</Fragment>
+</Preview>
+
+## Controlled
+
+<Preview client:load>
+	<Fragment slot="preview">
+		<Controlled client:visible />
+	</Fragment>
+	<Fragment slot="code">
+		<Code code={ControlledRaw} lang="tsx" />
 	</Fragment>
 </Preview>
 

--- a/sites/skeleton.dev/src/content/docs/components/segmented-control/svelte.mdx
+++ b/sites/skeleton.dev/src/content/docs/components/segmented-control/svelte.mdx
@@ -1,6 +1,9 @@
 import Default from '@/components/examples/components/segmented-control/svelte/default.svelte';
 import DefaultRaw from '@/components/examples/components/segmented-control/svelte/default.svelte?raw';
 
+import Controlled from '@/components/examples/components/segmented-control/svelte/controlled.svelte';
+import ControlledRaw from '@/components/examples/components/segmented-control/svelte/controlled.svelte?raw';
+
 import Icons from '@/components/examples/components/segmented-control/svelte/icons.svelte';
 import IconsRaw from '@/components/examples/components/segmented-control/svelte/icons.svelte?raw';
 
@@ -25,6 +28,17 @@ import DirRaw from '@/components/examples/components/segmented-control/svelte/di
 	</Fragment>
 	<Fragment slot="code">
 		<Code code={DefaultRaw} lang="svelte" />
+	</Fragment>
+</Preview>
+
+## Controlled
+
+<Preview client:load>
+	<Fragment slot="preview">
+		<Controlled client:visible />
+	</Fragment>
+	<Fragment slot="code">
+		<Code code={ControlledRaw} lang="svelte" />
 	</Fragment>
 </Preview>
 


### PR DESCRIPTION
## Linked Issue

Closes #3950 

## Description

Props were not reactively passed, now they are

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
