### PR TITLE
fix: unclearable toasts

### DIFF
--- a/.changeset/brave-bats-bathe.md
+++ b/.changeset/brave-bats-bathe.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": patch
+---
+
+fix: toast overriding the `id` causing unclearable toasts internally
+  

--- a/packages/skeleton-svelte/src/components/toast/anatomy/root.svelte
+++ b/packages/skeleton-svelte/src/components/toast/anatomy/root.svelte
@@ -21,10 +21,8 @@
 
 	const { element, children, toast: toastProps, ...rest } = $derived(props);
 
-	const id = $props.id();
 	const service = useMachine(machine, () => ({
 		...toastProps,
-		id: id,
 		parent: group(),
 	}));
 	const toast = $derived(connect(service, normalizeProps));


### PR DESCRIPTION
## Linked Issue

Closes #3990

## Description

Removes the internal `id` generation and overriding of toasts so that toasts are properly tracked by the internal queue allowing for more than 24 toasts.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
