### PR TITLE
chore: bundle again

### DIFF
--- a/packages/skeleton-common/tsdown.config.ts
+++ b/packages/skeleton-common/tsdown.config.ts
@@ -5,7 +5,6 @@ import Raw from 'unplugin-raw/rolldown';
 export default defineConfig({
 	logLevel: 'error',
 	clean: false,
-	unbundle: true,
 	copy: ['src/index.css'],
 	plugins: [Raw(), Macros()],
 });

--- a/packages/skeleton-react/tsdown.config.ts
+++ b/packages/skeleton-react/tsdown.config.ts
@@ -4,5 +4,4 @@ export default defineConfig({
 	logLevel: 'error',
 	clean: false,
 	copy: ['src/index.css'],
-	unbundle: true,
 });

--- a/sites/skeleton.dev/scripts/generate-type-documentation.ts
+++ b/sites/skeleton.dev/scripts/generate-type-documentation.ts
@@ -175,9 +175,7 @@ async function getPartOrderFromAnatomy(framework: string, component: string) {
 
 async function getClassValue(component: string, part: string) {
 	try {
-		const module = await import(
-			/* @vite-ignore */ pathToFileURL(join(PACKAGE_DIRECTORY('skeleton-common'), 'dist', 'classes', `${component}.js`)).href
-		);
+		const module = await import(/* @vite-ignore */ pathToFileURL(join(PACKAGE_DIRECTORY('skeleton-common'), 'dist', 'index.js')).href);
 		const value = module[`classes${kebabToPascal(component)}`][kebabToCamel(part)];
 		if (!value || typeof value !== 'string') {
 			return;


### PR DESCRIPTION
## Description

We were using `unbundle: true` to perserve our file structure in our packages, however, this caused massive logs when using watch mode and another playground consumed it. If we use bundle to bundle into one file that'd be a lot better and healthier for when multiple projects run simultaneously

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
