### PR TITLE
Add homepage callout link

### DIFF
--- a/sites/skeleton.dev/src/pages/index.astro
+++ b/sites/skeleton.dev/src/pages/index.astro
@@ -32,7 +32,11 @@ import { resolvePath } from '@/modules/resolve-path';
 						</div>
 					</div>
 					<div class="self-center space-y-4">
-						<a href="/#" target="_blank" class="btn btn-sm preset-filled-primary-500 gap-2 shadow">
+						<a
+							href="https://github.com/skeletonlabs/skeleton/discussions/4076"
+							target="_blank"
+							class="btn btn-sm preset-filled-primary-500 gap-2 shadow"
+						>
 							<div class="bg-surface-950-50 aspect-square size-2 rounded-full"><!-- dot --></div>
 							<span>New documentation updates!</span>
 							<ChevronRightIcon class="size-4" />


### PR DESCRIPTION
## Linked Issue

Closes #4077

## Description

Adds the missing GitHub Announcements link to the homepage hero callout.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
