### PR TITLE
docs: update migration docs to cover input groups

### DIFF
--- a/sites/skeleton.dev/src/content/docs/get-started/migrate-from-v2.mdx
+++ b/sites/skeleton.dev/src/content/docs/get-started/migrate-from-v2.mdx
@@ -279,6 +279,16 @@ Skeleton v3 represents a point of reflection on what features should remain as p
 | Table of Contents | [Link](https://v2.skeleton.dev/utilities/table-of-contents)    | [Link](/docs/[framework]/guides/cookbook/table-of-contents) | Provided via Cookbook guide    |
 | Persisted Store   | [Link](https://v2.skeleton.dev/utilities/local-storage-stores) | --                                                          | Incompatible with Svelte 5     |
 
+### Migrating Classes
+
+Although the automated migration script will handle the majority of class updates, there are some classes that require manual intervention. Review the following classes that may require your attention.
+
+| Old Class             | New Class  |
+| --------------------- | ---------- |
+| `input-group-shim`    | `ig-cell`  |
+| `input-group > input` | `ig-input` |
+| `input-group-divider` | (removed)  |
+
 ### Migration Complete
 
 If you’ve completed all steps above in full, your application should once again be in a function state. Run your application's local dev server to confirm, and remember to merge all changes into your primary branch.


### PR DESCRIPTION
## Linked Issue

Closes #3949 

## Description

Updates the docs to warn users about manually updating their input groups.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
