### PR TITLE
docs: fix datepicker anatomy

### DIFF
--- a/sites/skeleton.dev/src/content/docs/framework-components/date-picker.mdx
+++ b/sites/skeleton.dev/src/content/docs/framework-components/date-picker.mdx
@@ -157,11 +157,12 @@ export default function Anatomy() {
 			<DatePicker.Control>
 				<DatePicker.Input />
 				<DatePicker.Trigger />
-				<DatePicker.ClearTrigger />
 			</DatePicker.Control>
 			<Portal>
 				<DatePicker.Positioner>
 					<DatePicker.Content>
+						<DatePicker.YearSelect />
+						<DatePicker.MonthSelect />
 						<DatePicker.View>
 							<DatePicker.ViewControl>
 								<DatePicker.PrevTrigger />
@@ -206,11 +207,12 @@ export default function Anatomy() {
 	<DatePicker.Control>
 		<DatePicker.Input />
 		<DatePicker.Trigger />
-		<DatePicker.ClearTrigger />
 	</DatePicker.Control>
 	<Portal>
 		<DatePicker.Positioner>
 			<DatePicker.Content>
+				<DatePicker.YearSelect />
+				<DatePicker.MonthSelect />
 				<DatePicker.View>
 					<DatePicker.ViewControl>
 						<DatePicker.PrevTrigger />


### PR DESCRIPTION
fix datepicker anatomy docs

## Linked Issue

Related to #4079 

## Description

remove hallucinated `DatePicker.ClearTrigger`
add missing `DatePicker.YearSelect` and `DatePicker.MonthSelect`

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [X] Your branch should be prefixed with: `docs/`, `feature/`, `chore/`, `bugfix/`
- [X] Contributions should target the `main` branch
- [X] Documentation should be updated to describe all relevant changes
- [X] Run `pnpm check` in the root of the monorepo
- [X] Run `pnpm format` in the root of the monorepo
- [X] Run `pnpm lint` in the root of the monorepo
- [X] Run `pnpm test` in the root of the monorepo
- [X] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR review for review.
