### PR TITLE
chore: unknown at rule ignored

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
 		"css": "css"
 	},
 	"tailwindCSS.classFunctions": ["defineSkeletonClasses"],
+	"css.lint.unknownAtRules": "ignore",
 	"workbench.editor.languageDetection": false
 }


### PR DESCRIPTION
This PR ignores the unknown at rule warnings across various projects in our monorepo due to Tailwind.