### PR TITLE
revert node update

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: pnpm
       - run: npm install -g npm@latest
       - name: Install dependencies

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: pnpm
       - run: pnpm install
       - run: pnpm format:check
@@ -32,7 +32,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: pnpm
       - run: pnpm install
       - run: pnpm lint:check
@@ -44,7 +44,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: pnpm
       - run: pnpm install
       - run: pnpm check
@@ -56,7 +56,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: pnpm
       - run: pnpm install
       - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"prettier-plugin-svelte": "catalog:"
 	},
 	"engines": {
-		"node": "24.11.1",
+		"node": "22.21.1",
 		"pnpm": "10.22.0"
 	},
 	"packageManager": "pnpm@10.22.0"


### PR DESCRIPTION
Reverts updating node to 24 LTS, vercel doesn't support this quite yet: https://community.vercel.com/t/node-24-support-on-vercel/12730/12

We should aim to update immediately following Vercels support