### PR TITLE
task: boost Pagefind h1 weight for improved search relevance

### DIFF
--- a/sites/skeleton.dev/src/components/ui/header/search.svelte
+++ b/sites/skeleton.dev/src/components/ui/header/search.svelte
@@ -46,8 +46,10 @@
 			// @ts-expect-error pagefind is only present during runtime
 			const pagefind: Pagefind = await import('/pagefind/pagefind.js');
 			await pagefind.options({
-				termFrequency: 0,
 				excerptLength: 3,
+				ranking: {
+					termFrequency: 0,
+				},
 			});
 			await pagefind.init();
 			resolve(pagefind);

--- a/sites/skeleton.dev/src/modules/pagefind.ts
+++ b/sites/skeleton.dev/src/modules/pagefind.ts
@@ -3,7 +3,6 @@ interface PagefindIndexOptions {
 	baseUrl?: string;
 	excerptLength?: number;
 	indexWeight?: number;
-	termFrequency?: number;
 	mergeFilter?: Record<string, unknown>;
 	highlightParam?: string;
 	language?: string;


### PR DESCRIPTION
## Linked Issue

Closes #4130

## Description

This PR increases the Pagefind search weight applied to the main `h1` title
in the docs layout. Pagefind's default weight of 7 can cause direct title
matches to rank below normal content matches.

Setting the weight to 9 ensures titles appear higher in the search results
while still leaving headroom for future priority adjustments. 

**A preview deployment is required to verify the updated Pagefind index, as indexing does not occur during local development. This PR is created to facilitate that preview.**

No functional component changes included, and no changeset is required.