### PR TITLE
docs: remove redundant z-indexes

### DIFF
--- a/playgrounds/skeleton-svelte/src/routes/components/combobox/+page.svelte
+++ b/playgrounds/skeleton-svelte/src/routes/components/combobox/+page.svelte
@@ -62,7 +62,7 @@
 		<Combobox.Trigger />
 	</Combobox.Control>
 	<Portal>
-		<Combobox.Positioner class="z-[1]!">
+		<Combobox.Positioner>
 			<Combobox.Content>
 				{#each collection.group() as [type, items] (type)}
 					<Combobox.ItemGroup>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/auto-highlight.tsx
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/auto-highlight.tsx
@@ -46,7 +46,7 @@ export default function AutoHighlight() {
 				<Combobox.Trigger />
 			</Combobox.Control>
 			<Portal>
-				<Combobox.Positioner className="z-[1]!">
+				<Combobox.Positioner>
 					<Combobox.Content>
 						{items.map((item) => (
 							<Combobox.Item key={item.value} item={item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/custom-filter.tsx
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/custom-filter.tsx
@@ -51,7 +51,7 @@ export default function Default() {
 				<Combobox.Trigger />
 			</Combobox.Control>
 			<Portal>
-				<Combobox.Positioner className="z-[1]!">
+				<Combobox.Positioner>
 					<Combobox.Content>
 						{items.map((item) => (
 							<Combobox.Item key={item.value} item={item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/default.tsx
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/default.tsx
@@ -47,7 +47,7 @@ export default function Default() {
 			</Combobox.Control>
 			<Combobox.ClearTrigger>Clear All</Combobox.ClearTrigger>
 			<Portal>
-				<Combobox.Positioner className="z-[1]!">
+				<Combobox.Positioner>
 					<Combobox.Content>
 						{items.map((item) => (
 							<Combobox.Item key={item.value} item={item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/dir.tsx
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/dir.tsx
@@ -47,7 +47,7 @@ export default function Dir() {
 				<Combobox.Trigger />
 			</Combobox.Control>
 			<Portal>
-				<Combobox.Positioner className="z-[1]!">
+				<Combobox.Positioner>
 					<Combobox.Content>
 						{items.map((item) => (
 							<Combobox.Item key={item.value} item={item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/disabled-item.tsx
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/disabled-item.tsx
@@ -46,7 +46,7 @@ export default function Default() {
 				<Combobox.Trigger />
 			</Combobox.Control>
 			<Portal>
-				<Combobox.Positioner className="z-[1]!">
+				<Combobox.Positioner>
 					<Combobox.Content>
 						{items.map((item) => (
 							<Combobox.Item key={item.value} item={item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/group.tsx
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/group.tsx
@@ -48,7 +48,7 @@ export default function Group() {
 				<Combobox.Trigger />
 			</Combobox.Control>
 			<Portal>
-				<Combobox.Positioner className="z-[1]!">
+				<Combobox.Positioner>
 					<Combobox.Content>
 						{collection.group().map(([type, items]) => (
 							<Combobox.ItemGroup key={type}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/multiple.tsx
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/react/multiple.tsx
@@ -53,7 +53,7 @@ export default function Default() {
 					<Combobox.Trigger />
 				</Combobox.Control>
 				<Portal>
-					<Combobox.Positioner className="z-[1]!">
+					<Combobox.Positioner>
 						<Combobox.Content>
 							{items.map((item) => (
 								<Combobox.Item key={item.value} item={item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/auto-highlight.svelte
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/auto-highlight.svelte
@@ -40,7 +40,7 @@
 		<Combobox.Trigger />
 	</Combobox.Control>
 	<Portal>
-		<Combobox.Positioner class="z-[1]!">
+		<Combobox.Positioner>
 			<Combobox.Content>
 				{#each items as item (item.value)}
 					<Combobox.Item {item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/custom-filter.svelte
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/custom-filter.svelte
@@ -46,7 +46,7 @@
 		<Combobox.Trigger />
 	</Combobox.Control>
 	<Portal>
-		<Combobox.Positioner class="z-[1]!">
+		<Combobox.Positioner>
 			<Combobox.Content>
 				{#each items as item (item.value)}
 					<Combobox.Item {item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/default.svelte
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/default.svelte
@@ -42,7 +42,7 @@
 	</Combobox.Control>
 	<Combobox.ClearTrigger>Clear All</Combobox.ClearTrigger>
 	<Portal>
-		<Combobox.Positioner class="z-[1]!">
+		<Combobox.Positioner>
 			<Combobox.Content>
 				{#each items as item (item.value)}
 					<Combobox.Item {item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/dir.svelte
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/dir.svelte
@@ -41,7 +41,7 @@
 		<Combobox.Trigger />
 	</Combobox.Control>
 	<Portal>
-		<Combobox.Positioner class="z-1!">
+		<Combobox.Positioner>
 			<Combobox.Content>
 				{#each items as item (item.value)}
 					<Combobox.Item {item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/disabled-item.svelte
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/disabled-item.svelte
@@ -41,7 +41,7 @@
 		<Combobox.Trigger />
 	</Combobox.Control>
 	<Portal>
-		<Combobox.Positioner class="z-[1]!">
+		<Combobox.Positioner>
 			<Combobox.Content>
 				{#each items as item (item.value)}
 					<Combobox.Item {item}>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/group.svelte
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/group.svelte
@@ -41,7 +41,7 @@
 		<Combobox.Trigger />
 	</Combobox.Control>
 	<Portal>
-		<Combobox.Positioner class="z-[1]!">
+		<Combobox.Positioner>
 			<Combobox.Content>
 				{#each collection.group() as [type, items] (type)}
 					<Combobox.ItemGroup>

--- a/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/multiple.svelte
+++ b/sites/skeleton.dev/src/components/examples/framework-components/combobox/svelte/multiple.svelte
@@ -46,7 +46,7 @@
 			<Combobox.Trigger />
 		</Combobox.Control>
 		<Portal>
-			<Combobox.Positioner class="z-[1]!">
+			<Combobox.Positioner>
 				<Combobox.Content>
 					{#each items as item (item.value)}
 						<Combobox.Item {item}>

--- a/sites/skeleton.dev/src/content/docs/framework-components/combobox.mdx
+++ b/sites/skeleton.dev/src/content/docs/framework-components/combobox.mdx
@@ -135,11 +135,22 @@ Set the text direction (`ltr` or `rtl`) using the `dir` prop.
 
 ### Z-Index
 
-By default we do not take an opinionated stance regarding z-index stacking. The result is the component can sometimes be occluded beneath other elements with a higher index. The Z-Index can controlled by applying a utility class to the Positioner component part.
+By default we do not take an opinionated stance regarding z-index stacking. The result is the component can sometimes be occluded beneath other elements with a higher index. The Z-Index can controlled by applying a utility class to the Content component part.
 
-```astro
-<Combobox.Positioner class="z-50!" />
+<Framework id="react">
+
+```tsx
+<Combobox.Content className="z-50" />
 ```
+
+</Framework>	
+<Framework id="svelte">
+
+```svelte
+<Combobox.Content class="z-50" />
+```
+
+</Framework>
 
 ### Max Items
 


### PR DESCRIPTION
## Linked Issue

Closes #4148

## Description

Removes redundant z-index classes aswell as adjusting the z-index guideline for combobox to be more accurate.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `task/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR ready for review.
