### PR TITLE
task: fix build

### DIFF
--- a/sites/skeleton.dev/src/modules/llms/process-preview-components.ts
+++ b/sites/skeleton.dev/src/modules/llms/process-preview-components.ts
@@ -28,6 +28,7 @@ function getDefaultImports(root: Root) {
 }
 
 const resolve = new ResolverFactory({
+	// TODO: Set to `'auto'` when [this issues](https://github.com/oxc-project/oxc-resolver/issues/864) is resolved.
 	tsconfig: {
 		configFile: join(import.meta.dirname, '../../../tsconfig.json'),
 	},


### PR DESCRIPTION
Docs are failing to build because `oxc-resolver` is unable to auto detect our `tsconfig.json` when `baseUrl` is not set. For now we 're manually defining the `tsconfig.json` path, but we should back to `auto` when the issue in the TODO is resolved.