### PR TITLE
docs: simplify test docs

### DIFF
--- a/sites/skeleton.dev/src/content/docs/resources/contribute/components.mdx
+++ b/sites/skeleton.dev/src/content/docs/resources/contribute/components.mdx
@@ -361,12 +361,7 @@ export default function (props: NavigationRootProps) {
 
 ## Testing Components
 
-We recommend you reference existing components to see how we've handled testing. Each framework has slightly different testing conventions, but all utilize [Vitest](https://vitest.dev/) with [Testing Library](https://testing-library.com/).
-
-Test files are located in `packages/skeleton-{framework}/test/components/{component}` and each contain two files:
-
-- `index.test.{tsx|tsx}` - contains the actual test cases.
-- `test.{tsx/svelte}` - contains a wrapper component used to provide `data-testid` attributes to each respective component part.
+We recommend you reference existing components to see how we've handled testing. Each framework has slightly different testing conventions, but all utilize [Vitest](https://vitest.dev/).
 
 ## Additional Resources
 


### PR DESCRIPTION
Since our monorepo performance PR: #4135 flattened the test file structure and removed testing library we can recommend users to reference other component tests, which is now simply vitest, what we already link to.