### PR TITLE
docs: redirect v3 Figma page to new etesie.dev location

### DIFF
--- a/sites/skeleton.dev/src/components/docs/Header.astro
+++ b/sites/skeleton.dev/src/components/docs/Header.astro
@@ -16,7 +16,7 @@ const coreLinks = [
 	{ href: '/docs/get-started/introduction', title: 'Docs' },
 	{ href: '/news', title: 'News' },
 	{ href: 'https://themes.skeleton.dev/', title: 'Themes', target: '_blank' },
-	{ href: '/figma', title: 'Figma' }
+	{ href: 'https://etesie.dev/figma', title: 'Figma', target: '_blank' }
 ];
 const versionLinks = [
 	{ href: 'https://v1.skeleton.dev/', title: 'Version 1', target: '_blank' },

--- a/sites/skeleton.dev/src/pages/figma/index.astro
+++ b/sites/skeleton.dev/src/pages/figma/index.astro
@@ -4,181 +4,34 @@ import LayoutRoot from '@layouts/LayoutRoot.astro';
 // Components
 import Header from '@components/docs/Header.astro';
 import Footer from '@components/docs/Footer.astro';
-import FigmaBuyNow from '@components/docs/FigmaBuyNow.astro';
-import NavGrid from '@components/docs/NavGrid.astro';
-// Images
-import { Image } from 'astro:assets';
-import ImgHeroDark from '@images/get-started/figma/hero-dark.webp';
-import ImgHeroLight from '@images/get-started/figma/hero-light.webp';
-import ImgPlugin from '@images/get-started/figma/plugin.webp';
-import ImgTutorial from '@images/get-started/figma/tutorials.webp';
-import ImgKit from '@images/get-started/figma/ui-kit.webp';
 // Icons
-import {
-	ChevronRight as IconChevron,
-	Clock3 as IconClock,
-	Shapes as IconShapes,
-	SwatchBook as IconSwatches,
-	MessageCircle as IconMessage
-} from 'lucide-react';
+import { ChevronRight as IconChevron } from 'lucide-react';
 
 const layoutProps = {
 	title: 'Figma UI Kit',
-	description: 'Learn more about the Figma UI Kit for Skeleton.'
+	description: 'The Figma UI Kit page has moved to a new location.'
 };
 ---
 
-<!-- Floating Button -->
-<a
-	href="https://www.etesie.dev/support"
-	target="_blank"
-	class="fixed bottom-8 right-8 preset-filled p-4 rounded-full shadow-xl flex items-center justify-center"
-	aria-label="Contact Support"
-	title="Contact Support"
->
-	<IconMessage size={24} />
-</a>
+<script is:inline>
+	window.location.replace('https://etesie.dev/figma');
+</script>
 
 <LayoutRoot {...layoutProps}>
 	<!-- Header -->
 	<Header />
 	<!-- Main -->
-	<main class="container mx-auto space-y-10 xl:space-y-20 py-10 xl:py-20 px-4">
-		<!-- Hero -->
-		<header class="w-full max-w-6xl mx-auto flex flex-col items-center gap-5 text-center">
-			<h1 class="h1">Design faster.<br />Align better.<br />Deliver consistently.</h1>
-			<p class="text-xl text-balance opacity-60 w-full max-w-6xl">
-				Turn Figma into your superpower for creating apps that look stunning, align with clients and developers, and stay on-brand with
-				ease.
+	<main class="container mx-auto py-20 px-4 min-h-[60vh] flex items-center justify-center">
+		<header class="w-full max-w-2xl mx-auto flex flex-col items-center gap-6 text-center">
+			<h1 class="h1">This page has moved</h1>
+			<p class="text-xl text-balance opacity-60">
+				The Figma UI Kit documentation is now available at a new location. You should be redirected automatically.
 			</p>
-			<!-- CTA -->
-			<a href="#get-access" class="btn btn-lg preset-filled shadow-lg" href="#get-access">
-				<span>Get Access</span>
+			<a href="https://etesie.dev/figma" target="_blank" rel="noopener noreferrer" class="btn btn-lg preset-filled shadow-lg">
+				<span>Go to Figma UI Kit</span>
 				<IconChevron className="size-4" />
 			</a>
-			<!-- Banner -->
-			<div class="relative">
-				<Image src={ImgHeroDark} class="w-full max-w-6xl hidden dark:block" alt="hero" />
-				<Image src={ImgHeroLight} class="w-full max-w-6xl dark:hidden" alt="hero" />
-			</div>
 		</header>
-
-		<!-- Three Blocks -->
-		<section class="space-y-10">
-			<header class="space-y-2 text-center">
-				<h2 class="h2">Struggling to create consistent designs?</h2>
-				<p class="opacity-60 max-w-6xl mx-auto text-balance">
-					You’re not alone. We know these frustrations. We’re here to help by streamlining your workflow and bringing your design,
-					development, and customers into perfect harmony.
-				</p>
-			</header>
-			<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-				<!-- 1 -->
-				<div class="card preset-outlined-surface-200-800 bg-surface-50-950 p-10 space-y-10">
-					<IconClock size="32" className="opacity-60" />
-					<p class="text-2xl text-balance"><strong>Spending hours</strong> recreating components in Figma?</p>
-				</div>
-				<!-- 2 -->
-				<div class="card preset-outlined-surface-200-800 bg-surface-50-950 p-10 space-y-10">
-					<IconShapes size="32" className="opacity-60" />
-					<p class="text-2xl text-balance">Finding it <strong>hard to align</strong> with developers or clients?</p>
-				</div>
-				<!-- 3 -->
-				<div class="card preset-outlined-surface-200-800 bg-surface-50-950 p-10 space-y-10">
-					<IconSwatches size="32" className="opacity-60" />
-					<p class="text-2xl text-balance">Unsure how your design will look with <strong>a custom theme</strong>?</p>
-				</div>
-			</div>
-		</section>
-
-		<!-- Features -->
-		<section class="flex flex-col gap-24 w-full py-12">
-			<!-- 1 -->
-			<div class="grid grid-cols-1 md:grid-cols-[2fr_1fr] gap-10">
-				<div>
-					<Image src={ImgKit} class="rounded-container border border-surface-200-800 shadow-xl" alt="components" />
-				</div>
-				<header class="space-y-4">
-					<h2 class="h2">Align quickly with prebuilt Skeleton components.</h2>
-					<p class="opacity-60">
-						All components from Skeleton have been recreated in Figma, saving you time and helping establish consistency.
-					</p>
-				</header>
-			</div>
-			<!-- 2 -->
-			<div class="grid grid-cols-1 md:grid-cols-[1fr_2fr] gap-10">
-				<header class="space-y-4">
-					<h2 class="h2">Ensure consistency with theme imports.</h2>
-					<p class="opacity-60">
-						Import your custom Skeleton themes directly into Figma using our dedicated plugin. Switch between dark and light modes and
-						preview your design and theme instantly.
-					</p>
-				</header>
-				<div>
-					<Image src={ImgPlugin} class="rounded-container border border-surface-200-800 shadow-xl" alt="components" />
-				</div>
-			</div>
-			<!-- 3 -->
-			<div class="grid grid-cols-1 md:grid-cols-[2fr_1fr] gap-10">
-				<div>
-					<Image src={ImgTutorial} class="rounded-container border border-surface-200-800 shadow-xl" alt="components" />
-				</div>
-				<header class="space-y-4">
-					<h2 class="h2">Iterate faster with tutorials designed for every step of the design process.</h2>
-					<p class="opacity-60">Learn how to:</p>
-					<ul class="list-inside list-disc space-y-2 opacity-60">
-						<li>Customize themes for your brand.</li>
-						<li>Create wireframes for quick iteration and client feedback.</li>
-						<li>Design developer-ready assets to streamline handoffs.</li>
-					</ul>
-				</header>
-			</div>
-		</section>
-
-		<!-- Figma Kit Preview Section -->
-		<section class="flex flex-col gap-6 py-12">
-			<h2 class="h2">Experience the Skeleton Figma Kit</h2>
-			<p class="text-surface-800-200 pb-6">
-				Preview our comprehensive Figma UI Kit below. Explore the components, styles, and design patterns that will accelerate your
-				workflow.
-			</p>
-			<iframe
-				class="rounded-container border-surface-200-800 aspect-[16/9] w-full border shadow-lg"
-				title="Figma"
-				src="https://embed.figma.com/design/uuwNSrfjdMfkIFvtIKhCbw/Skeleton-v3.1.0?node-id=10015-47324&embed-host=share&footer=false&theme=system"
-				allowfullscreen></iframe>
-		</section>
-
-		<!-- Quote -->
-		<section class="max-w-6xl mx-auto space-y-10">
-			<blockquote class="blockquote text-3xl not-italic">
-				"...the Figma is very well put together and the most robust that I could find out of all the UI kits so our company chose to go with
-				Skeleton 🙂"
-			</blockquote>
-			<p class="text-xs opacity-60">Rob, Skeleton community member</p>
-		</section>
-
-		<!-- Get Access -->
-		<section class="max-w-4xl mx-auto space-y-10">
-			<FigmaBuyNow />
-			<!-- Attribution -->
-			<p class="md:text-xl text-center">
-				Created with &#x2665; by <a class="anchor" href="https://www.linkedin.com/in/micha-mail%C3%A4nder-548aba16a/" target="_blank"
-					>Micha</a
-				>,
-				<a class="anchor" href="https://www.linkedin.com/in/bohdan-karpliak-659a41162/" target="_blank">Bohdan</a>, and <a
-					class="anchor"
-					href="https://www.skeletonlabs.co/"
-					target="_blank">Skeleton Labs</a
-				>.
-			</p>
-		</section>
-
-		<!-- Guides -->
-		<section class="space-y-10 w-full max-w-6xl mx-auto">
-			<h2 class="h2">Guides</h2>
-			<NavGrid collection="docs" path="figma/" classes="md:grid-cols-1" />
-		</section>
 	</main>
 	<!-- Footer -->
 	<Footer />


### PR DESCRIPTION
## Description

The `v3.skeleton.dev/figma` page still pointed to the old Polar checkout, while the new `etesie.dev/figma` page uses our updated Creem setup. Some users still land on the v3 page via Google, and today someone ended up buying the kit twice because of that.
To avoid this confusion, I’ve updated the v3 page to redirect directly to the new one — this should prevent unnecessary trouble both for users and for support/refunds.

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [ ] Your branch should be prefixed with: `docs/`, `feature/`, `task/`, `bugfix/`
- [ ] Contributions should target the `main` branch
- [ ] Documentation should be updated to describe all relevant changes
- [ ] Run `pnpm check` in the root of the monorepo
- [ ] Run `pnpm format` in the root of the monorepo
- [ ] Run `pnpm lint` in the root of the monorepo
- [ ] Run `pnpm test` in the root of the monorepo
- [ ] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR ready for review.
