### PR TITLE
Resolve Comobox anatomy docs example issue

### DIFF
--- a/sites/skeleton.dev/src/content/docs/framework-components/combobox.mdx
+++ b/sites/skeleton.dev/src/content/docs/framework-components/combobox.mdx
@@ -172,8 +172,8 @@ export default function Anatomy() {
 			<Combobox.Control>
 				<Combobox.Input />
 				<Combobox.Trigger />
-				<Combobox.ClearTrigger />
 			</Combobox.Control>
+			<Combobox.ClearTrigger />
 			<Portal>
 				<Combobox.Positioner>
 					<Combobox.Content>


### PR DESCRIPTION
## Linked Issue

Closes #4242

## Description

Resolves a small discrepancy in the positioning of the clear button element in the Combobox anatomy diagram.

## AI Disclosure

Use of [LLM technology](https://en.wikipedia.org/wiki/Large_language_model) is allowed. We ask for your voluntary disclosure to help inform future Skeleton contribution guidelines.

- [ ] I used AI to generate this pull request

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `task/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR ready for review.
