### PR TITLE
Fix for input-group not showing ring outlines

### DIFF
--- a/sites/skeleton.dev/src/app.css
+++ b/sites/skeleton.dev/src/app.css
@@ -124,8 +124,7 @@ html {
 .select,
 .input,
 .textarea,
-.ig-input,
-.ig-select {
+.input-group {
 	background-color: var(--color-surface-50-950);
 	color: var(--color-surface-950-50);
 }

--- a/sites/skeleton.dev/src/content/docs/tailwind-components/forms.mdx
+++ b/sites/skeleton.dev/src/content/docs/tailwind-components/forms.mdx
@@ -61,8 +61,7 @@ To avoid a [breaking style issue in Windows-based browsers](https://github.com/s
 .select,
 .input,
 .textarea,
-.ig-input,
-.ig-select {
+.input-group {
 	background-color: var(--color-surface-50-950);
 	color: var(--color-surface-950-50);
 }


### PR DESCRIPTION
## Linked Issue

Closes #4274

## Description

Minor adjustment to the input-group styles preventing the ring outline from showing in normal usage.

## AI Disclosure

Use of [LLM technology](https://en.wikipedia.org/wiki/Large_language_model) is allowed. We ask for your voluntary disclosure to help inform future Skeleton contribution guidelines.

- [ ] I used AI to generate this pull request

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `task/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [ ] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR ready for review.
