### PR TITLE
Docs: fix typo in Get Started Vite+Svelte installation step 3

### DIFF
--- a/sites/skeleton.dev/src/content/docs/get-started/installation/vite-svelte.mdx
+++ b/sites/skeleton.dev/src/content/docs/get-started/installation/vite-svelte.mdx
@@ -49,7 +49,7 @@ import Process from '@/components/ui/process.astro';
 
         ### Install Tailwind
 
-        Install Tailwind and and the Tailwind Vite plugin.
+        Install Tailwind and the Tailwind Vite plugin.
 
         ```bash
         npm install tailwindcss @tailwindcss/vite


### PR DESCRIPTION
## Linked Issue

Closes #4308

## Description
Typo on the Vite + Svelte installation page: /docs/svelte/get-started/installation/vite-svelte

At Step 3 - Install Tailwind the text read: "Install Tailwind and and the Tailwind Vite plugin." Removed the duplicate “and”.
