### PR TITLE
fix(floating-panel): fix body height overflow issue

### DIFF
--- a/packages/skeleton-common/src/components/floating-panel.css
+++ b/packages/skeleton-common/src/components/floating-panel.css
@@ -2,6 +2,8 @@
 	&[data-part='content'] {
 		overflow: hidden;
 		border: 1px solid var(--color-surface-300-700);
+		display: flex;
+		flex-direction: column;
 
 		@apply card shadow-lg;
 	}
@@ -46,7 +48,8 @@
 	}
 
 	&[data-part='body'] {
-		height: 100%;
+		flex: 1;
+		min-height: 0;
 		background: var(--color-surface-100-900);
 		padding: --spacing(4);
 		overflow-y: auto;


### PR DESCRIPTION
## Description

Fixed FloatingPanel.Body overflowing the panel bounds when content exceeds the default height.

### Problem
The FloatingPanel.Body had "height: 100%" which caused it to take up 100% of the content area height without accounting for the space occupied by FloatingPanel.Header, resulting in vertical overflow.

### Solution
- Changed content wrapper to use flex column layout (`display: flex; flex-direction: column`)
- Changed body from `height: 100%` to `flex: 1; min-height: 0`
- This ensures the body fills only the remaining vertical space after the header

### Changes
- Modified: `packages/skeleton-common/src/components/floating-panel.css`

Fixes #4298