### PR TITLE
docs: hide banner

### DIFF
--- a/sites/skeleton.dev/src/components/ui/header/header.astro
+++ b/sites/skeleton.dev/src/components/ui/header/header.astro
@@ -111,7 +111,8 @@ const socialLinks = [
 	</div>
 </header>
 
-<div class="preset-tonal text-center p-4">You are viewing the archived Skeleton v4.0 documentation.</div>
+<!-- TODO: Add back the archived banner when v5 is released -->
+<!-- <div class="preset-tonal text-center p-4">You are viewing the archived Skeleton v4.0 documentation.</div> -->
 
 <style is:global>
 	@reference '../../../app.css';


### PR DESCRIPTION
This hides the archive banner for now, we should undo this once V5 goes out the door.