### PR TITLE
docs: satisfy never

### DIFF
--- a/sites/plus.skeleton.dev/src/lib/auth/user-schema.ts
+++ b/sites/plus.skeleton.dev/src/lib/auth/user-schema.ts
@@ -21,5 +21,6 @@ export const User = v.pipe(
 					username: data.user_metadata.preferred_username,
 				};
 		}
+		data.app_metadata.provider satisfies never;
 	}),
 );


### PR DESCRIPTION
satisfy never added to prevent adding providers that are missing an implementation for the user schema