### PR TITLE
task: update svelte peer dep to use `createContext`

### DIFF
--- a/.changeset/afraid-paths-fry.md
+++ b/.changeset/afraid-paths-fry.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton-svelte": major
+---
+
+deps: update peerDep to 5.40.0
+  

--- a/packages/skeleton-svelte/package.json
+++ b/packages/skeleton-svelte/package.json
@@ -58,7 +58,7 @@
 		"@zag-js/tree-view": "catalog:"
 	},
 	"peerDependencies": {
-		"svelte": "^5.29.0"
+		"svelte": "^5.40.0"
 	},
 	"devDependencies": {
 		"@skeletonlabs/skeleton": "workspace:*",

--- a/packages/skeleton-svelte/src/internal/create-context.ts
+++ b/packages/skeleton-svelte/src/internal/create-context.ts
@@ -4,7 +4,11 @@ export function createContext<T>(defaultValue?: T) {
 	const [consume, provide] = createContextSvelte<T>();
 	return {
 		consume() {
-			return consume() || (defaultValue as T);
+			try {
+				return consume();
+			} catch {
+				return defaultValue as T;
+			}
 		},
 		provide,
 	};

--- a/packages/skeleton-svelte/src/internal/create-context.ts
+++ b/packages/skeleton-svelte/src/internal/create-context.ts
@@ -1,14 +1,11 @@
-import { getContext, setContext } from 'svelte';
+import { createContext as createContextSvelte } from 'svelte';
 
 export function createContext<T>(defaultValue?: T) {
-	const key = Symbol();
+	const [consume, provide] = createContextSvelte<T>();
 	return {
-		key,
 		consume() {
-			return getContext<T>(key) || (defaultValue as T);
+			return consume() || (defaultValue as T);
 		},
-		provide(value: T) {
-			return setContext(key, value);
-		},
+		provide,
 	};
 }


### PR DESCRIPTION
## Linked Issue

Closes #3942

## Description

Updates the peerDep to 5.40.0 to we can utilize `createContext` instead of rolling our own.

## AI Disclosure

Use of [LLM technology](https://en.wikipedia.org/wiki/Large_language_model) is allowed. We ask for your voluntary disclosure to help inform future Skeleton contribution guidelines.

- [x] I used AI to generate this pull request

## Checklist

Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).

- [x] Your branch should be prefixed with: `docs/`, `feature/`, `task/`, `bugfix/`
- [x] Contributions should target the `main` branch
- [x] Documentation should be updated to describe all relevant changes
- [x] Run `pnpm check` in the root of the monorepo
- [x] Run `pnpm format` in the root of the monorepo
- [x] Run `pnpm lint` in the root of the monorepo
- [x] Run `pnpm test` in the root of the monorepo
- [x] If you modify `/package` projects, please supply a Changeset

## Changesets

[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR ready for review.
