### PR TITLE
task: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ## Checklist
 
-Please read our [contribution requirements](https://skeleton.dev/docs/resources/contribute/) and make sure you have:
+Please read our [contribution requirements](https://skeleton.dev/docs/svelte/resources/contribute/) and make sure you have:
 
 - [ ] Prefixed your branch name with: `docs/`, `feature/`, `task/`, `bugfix/`
 - [ ] Targeted the `main` branch
@@ -17,7 +17,7 @@ Please read our [contribution requirements](https://skeleton.dev/docs/resources/
 
 ## Changesets
 
-[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [changesets](https://github.com/changesets/changesets). To create a changeset:
+[View our documentation](https://skeleton.dev/docs/svelte/resources/contribute/get-started#changesets) to learn more about [changesets](https://github.com/changesets/changesets). To create a changeset:
 
 1. Navigate to the root of the monorepo in your terminal
 2. Run `pnpm changeset` and follow the prompts

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ## Checklist
 
-Please read our [contribution requirements](https://skeleton.dev/docs/resources/contribute/) and make sure you:
+Please read our [contribution requirements](https://skeleton.dev/docs/resources/contribute/) and make sure you have:
 
 - [ ] Prefixed your branch name with: `docs/`, `feature/`, `task/`, `bugfix/`
 - [ ] Targeted the `main` branch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,23 @@
-## Linked Issue
+## Linked Issue(s)
 
-Closes #{issueNumber}
+<!-- Closes #0000 -->
 
 ## Description
 
-{description}
-
-## AI Disclosure
-
-Use of [LLM technology](https://en.wikipedia.org/wiki/Large_language_model) is allowed. We ask for your voluntary disclosure to help inform future Skeleton contribution guidelines.
-
-- [ ] I used AI to generate this pull request
+<!-- Description -->
 
 ## Checklist
 
-Please read and apply all [contribution requirements](https://skeleton.dev/docs/resources/contribute/).
+Please read our [contribution requirements](https://skeleton.dev/docs/resources/contribute/) and make sure you:
 
-- [ ] Your branch should be prefixed with: `docs/`, `feature/`, `task/`, `bugfix/`
-- [ ] Contributions should target the `main` branch
-- [ ] Documentation should be updated to describe all relevant changes
-- [ ] Run `pnpm check` in the root of the monorepo
-- [ ] Run `pnpm format` in the root of the monorepo
-- [ ] Run `pnpm lint` in the root of the monorepo
-- [ ] Run `pnpm test` in the root of the monorepo
-- [ ] If you modify `/package` projects, please supply a Changeset
+- [ ] Prefixed your branch name with: `docs/`, `feature/`, `task/`, `bugfix/`
+- [ ] Targeted the `main` branch
+- [ ] Documented any changes made
+- [ ] Suppplied a [changeset](#changesets) (if changes were made to any project within `/packages`)
 
 ## Changesets
 
-[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [Changesets](https://github.com/changesets/changesets). To create a Changeset:
+[View our documentation](https://skeleton.dev/docs/resources/contribute/get-started#changesets) to learn more about [changesets](https://github.com/changesets/changesets). To create a changeset:
 
 1. Navigate to the root of the monorepo in your terminal
 2. Run `pnpm changeset` and follow the prompts


### PR DESCRIPTION
closes #4406

This PR:
- Removes the AI disclosure checkbox
- Removes the `pnpm run x` commands, the PR will already be marked by Github actions wether you ran those or not.
- Uses Markdown comments for placeholders instead of text.

Preview:
<img width="607" height="503" alt="image" src="https://github.com/user-attachments/assets/9576f244-3ba5-4aad-912c-bf3b13c3ca67" />


Note about the redirect stuff:
Astro (`astro@>6`) seems to have had a regression that causes the redirects to stop working in production, the code is present and it works in development, just not in production. I suggest we handle this in a seperate PR because it looks like a bit of a rabbithole, I've updated the links to default to `svelte` for now, which would be the same behaviour that the redirect would do.