### PR TITLE
task: remove card

### DIFF
--- a/.changeset/large-peas-jog.md
+++ b/.changeset/large-peas-jog.md
@@ -1,0 +1,6 @@
+---
+"@skeletonlabs/skeleton": major
+---
+
+task: remove `card-hover` utility
+  

--- a/packages/skeleton/src/utilities/cards.css
+++ b/packages/skeleton/src/utilities/cards.css
@@ -18,17 +18,3 @@
 		}
 	}
 }
-
-@utility card-hover {
-	/* Transitions (all) */
-	transition-property: var(--default-transition-property);
-	transition-timing-function: var(--default-transition-timing-function);
-	transition-duration: var(--default-transition-duration);
-
-	@variant hover {
-		filter: brightness(95%);
-		@variant dark {
-			filter: brightness(110%);
-		}
-	}
-}

--- a/sites/skeleton.dev/src/content/docs/tailwind-components/cards.mdx
+++ b/sites/skeleton.dev/src/content/docs/tailwind-components/cards.mdx
@@ -16,7 +16,7 @@ import PresetsRaw from '@/components/examples/tailwind-components/cards/presets.
 
 ## Hover
 
-Hover styles are applied when the card is an `anchor` or `button` element. Otherwise use class `card-hover`.
+Hover styles are applied when the card is an `anchor` or `button` element.
 
 <Preview files={{ 'app.astro': DetailedRaw }} client:visible>
 	<Detailed />


### PR DESCRIPTION
## Linked Issue

Closes #4412 

## Description

Removes the `card-hover` utility, it does more harm than good and `card` already makes the element look interactive when it's a button or anchor.

