### PR TITLE
task(plus.skeleton.dev): dev server warning when docker isn't running

### DIFF
--- a/sites/plus.skeleton.dev/compose.yml
+++ b/sites/plus.skeleton.dev/compose.yml
@@ -1,3 +1,5 @@
+name: plus-skeleton-dev
+
 services:
   postgres:
     image: postgres:17

--- a/sites/plus.skeleton.dev/vite.config.ts
+++ b/sites/plus.skeleton.dev/vite.config.ts
@@ -1,8 +1,37 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwind from '@tailwindcss/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import icons from 'unplugin-icons/vite';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+
+function ensureDockerContainersAreRunning(containers: string[]) {
+	return {
+		name: 'ensure-docker-containers-are-running',
+		apply: 'serve',
+		async configureServer() {
+			for (const container of containers) {
+				try {
+					const dockerInspect = await execAsync(`docker inspect -f "{{.State.Running}}" ${container}`);
+
+					if (dockerInspect.stdout.trim() === 'true') {
+						continue;
+					}
+				} catch {}
+
+				this.warn(`Docker container "${container}" is not running. Start it with "pnpm env:start".`);
+			}
+		},
+	} satisfies Plugin;
+}
 
 export default defineConfig({
-	plugins: [sveltekit(), tailwind(), icons({ compiler: 'svelte' })],
+	plugins: [
+		sveltekit(),
+		tailwind(),
+		icons({ compiler: 'svelte' }),
+		ensureDockerContainersAreRunning(['plus-skeleton-dev-postgres-1', 'plus-skeleton-dev-oauth2-server-1']),
+	],
 });


### PR DESCRIPTION
## Linked Issue(s)

<!-- Closes #0000 -->

## Description

This PR adds a handy warning when you forgot to `pnpm env:start`, which will likely prevent you to work on the website.

## Checklist

Please read our [contribution requirements](https://skeleton.dev/docs/svelte/resources/contribute/) and make sure you have:

- [x] Prefixed your branch name with: `docs/`, `feature/`, `task/`, `bugfix/`
- [x] Targeted the `main` branch
- [x] Documented any changes made
- [x] Supplied a [changeset](#changesets) (if changes were made to any project within `/packages`)

## Changesets

[View our documentation](https://skeleton.dev/docs/svelte/resources/contribute/get-started#changesets) to learn more about [changesets](https://github.com/changesets/changesets). To create a changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR ready for review.
