### PR TITLE
docs: remove style chip from unstyled components

### DIFF
--- a/sites/skeleton.dev/src/content/docs/framework-components/dialog.mdx
+++ b/sites/skeleton.dev/src/content/docs/framework-components/dialog.mdx
@@ -1,6 +1,8 @@
 ---
 title: Dialog
 description: A modal dialog for displaying content and actions.
+references:
+  styles: false
 ---
 
 import Alert from '@/components/ui/alert.astro';

--- a/sites/skeleton.dev/src/content/docs/framework-components/popover.mdx
+++ b/sites/skeleton.dev/src/content/docs/framework-components/popover.mdx
@@ -1,6 +1,8 @@
 ---
 title: Popover
 description: Small overlay panels positioned relative to a trigger.
+references:
+  styles: false
 ---
 
 import ApiReference from '@/components/ui/api-reference.astro';

--- a/sites/skeleton.dev/src/content/docs/framework-components/tooltip.mdx
+++ b/sites/skeleton.dev/src/content/docs/framework-components/tooltip.mdx
@@ -1,6 +1,8 @@
 ---
 title: Tooltip
 description: A floating label that appears on hover or focus, providing additional context.
+references:
+  styles: false
 ---
 
 import ApiReference from '@/components/ui/api-reference.astro';


### PR DESCRIPTION
## Linked Issue(s)

Closes #4512

## Description

Sets `styles` to false in the frontmatter to disable those references in relevant docs

## Checklist

Please read our [contribution requirements](https://skeleton.dev/docs/svelte/resources/contribute/) and make sure you have:

- [x] Prefixed your branch name with: `docs/`, `feature/`, `task/`, `bugfix/`
- [x] Targeted the `main` branch
- [x] Documented any changes made
- [x] Supplied a [changeset](#changesets) (if changes were made to any project within `/packages`)

## Changesets

[View our documentation](https://skeleton.dev/docs/svelte/resources/contribute/get-started#changesets) to learn more about [changesets](https://github.com/changesets/changesets). To create a changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR ready for review.
