### PR TITLE
feat: add canned CSS animation utilities

### DIFF
--- a/.changeset/tidy-canned-animations.md
+++ b/.changeset/tidy-canned-animations.md
@@ -1,0 +1,5 @@
+---
+'@skeletonlabs/skeleton': minor
+---
+
+Add a curated set of canned CSS animations exposed as Tailwind `animate-*` utilities (entry and attention effects such as `animate-pop-in`, `animate-slide-in-up`, `animate-shake`, and `animate-wiggle`).

--- a/packages/skeleton/src/base/theme.css
+++ b/packages/skeleton/src/base/theme.css
@@ -98,6 +98,19 @@
 	--animate-progress-linear-indeterminate-vertical: progress-linear-indeterminate-vertical 1.5s ease-in-out infinite;
 	--animate-progress-circular-indeterminate: progress-circular-indeterminate 1.5s linear infinite;
 
+	/* Canned Animations */
+	/* Curated micro-animations for common UI interactions. */
+	--animate-pop-in: skeleton-pop-in 0.4s ease-out both;
+	--animate-fade-in: skeleton-fade-in 0.4s ease-out both;
+	--animate-slide-in-up: skeleton-slide-in-up 0.4s ease-out both;
+	--animate-slide-in-down: skeleton-slide-in-down 0.4s ease-out both;
+	--animate-slide-in-left: skeleton-slide-in-left 0.4s ease-out both;
+	--animate-slide-in-right: skeleton-slide-in-right 0.4s ease-out both;
+	--animate-zoom-in: skeleton-zoom-in 0.4s ease-out both;
+	--animate-shake: skeleton-shake 0.5s ease-in-out;
+	--animate-wiggle: skeleton-wiggle 0.6s ease-in-out infinite;
+	--animate-pulse-soft: skeleton-pulse-soft 2s ease-in-out infinite;
+
 	/* Primary */
 	--color-primary-50: oklch(0.985 0 0);
 	--color-primary-100: oklch(0.97 0 0);

--- a/packages/skeleton/src/index.css
+++ b/packages/skeleton/src/index.css
@@ -29,3 +29,4 @@
 
 @import './keyframes/progress-circular.css';
 @import './keyframes/progress-linear.css';
+@import './keyframes/animations.css';

--- a/packages/skeleton/src/keyframes/animations.css
+++ b/packages/skeleton/src/keyframes/animations.css
@@ -1,0 +1,131 @@
+/* Components: Keyframe - Canned Animations */
+/* A curated set of reusable micro-animations for common UI interactions. */
+/* NOTE: keyframes are prefixed with `skeleton-` to avoid naming collisions. */
+
+/* Entry: Pop In */
+@keyframes skeleton-pop-in {
+	0% {
+		opacity: 0;
+		scale: 0.8;
+	}
+	60% {
+		opacity: 1;
+		scale: 1.05;
+	}
+	100% {
+		opacity: 1;
+		scale: 1;
+	}
+}
+
+/* Entry: Fade In */
+@keyframes skeleton-fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+/* Entry: Slide In Up */
+@keyframes skeleton-slide-in-up {
+	from {
+		opacity: 0;
+		transform: translateY(12px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+/* Entry: Slide In Down */
+@keyframes skeleton-slide-in-down {
+	from {
+		opacity: 0;
+		transform: translateY(-12px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+/* Entry: Slide In Left */
+@keyframes skeleton-slide-in-left {
+	from {
+		opacity: 0;
+		transform: translateX(-12px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}
+
+/* Entry: Slide In Right */
+@keyframes skeleton-slide-in-right {
+	from {
+		opacity: 0;
+		transform: translateX(12px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}
+
+/* Entry: Zoom In */
+@keyframes skeleton-zoom-in {
+	from {
+		opacity: 0;
+		scale: 0.8;
+	}
+	to {
+		opacity: 1;
+		scale: 1;
+	}
+}
+
+/* Attention: Shake */
+@keyframes skeleton-shake {
+	0%,
+	100% {
+		transform: translateX(0);
+	}
+	20% {
+		transform: translateX(-6px);
+	}
+	40% {
+		transform: translateX(6px);
+	}
+	60% {
+		transform: translateX(-4px);
+	}
+	80% {
+		transform: translateX(4px);
+	}
+}
+
+/* Attention: Wiggle */
+@keyframes skeleton-wiggle {
+	0%,
+	100% {
+		transform: rotate(-3deg);
+	}
+	50% {
+		transform: rotate(3deg);
+	}
+}
+
+/* Attention: Soft Pulse */
+@keyframes skeleton-pulse-soft {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.6;
+	}
+}

--- a/sites/skeleton.dev/src/components/examples/tailwind-utilities/animations/default.astro
+++ b/sites/skeleton.dev/src/components/examples/tailwind-utilities/animations/default.astro
@@ -1,0 +1,21 @@
+---
+const commonClasses = 'size-20 rounded-xl text-xs font-medium grid place-items-center';
+---
+
+<p class="text-sm mb-2 opacity-75">Entry animations</p>
+<div class="grid grid-cols-3 gap-4">
+	<div class={`${commonClasses} animate-pop-in`}>pop-in</div>
+	<div class={`${commonClasses} animate-fade-in`}>fade-in</div>
+	<div class={`${commonClasses} animate-zoom-in`}>zoom-in</div>
+	<div class={`${commonClasses} animate-slide-in-up`}>slide-up</div>
+	<div class={`${commonClasses} animate-slide-in-down`}>slide-down</div>
+	<div class={`${commonClasses} animate-slide-in-left`}>slide-left</div>
+	<div class={`${commonClasses} animate-slide-in-right`}>slide-right</div>
+</div>
+
+<p class="text-sm mt-6 opacity-75">Attention animations</p>
+<div class="grid grid-cols-3 gap-4">
+	<div class={`${commonClasses} animate-shake`}>shake</div>
+	<div class={`${commonClasses} animate-wiggle`}>wiggle</div>
+	<div class={`${commonClasses} animate-pulse-soft`}>pulse-soft</div>
+</div>

--- a/sites/skeleton.dev/src/content/docs/tailwind-utilities/animations.mdx
+++ b/sites/skeleton.dev/src/content/docs/tailwind-utilities/animations.mdx
@@ -1,0 +1,72 @@
+---
+title: Animations
+description: A curated set of canned micro-animations for common UI interactions, including entry and attention effects.
+references:
+  source: 'https://github.com/skeletonlabs/skeleton/blob/main/packages/skeleton/src/keyframes/animations.css'
+stability: alpha
+---
+
+import Preview from '@/components/ui/preview.svelte';
+
+import Default from '@/components/examples/tailwind-utilities/animations/default.astro';
+import DefaultRaw from '@/components/examples/tailwind-utilities/animations/default.astro?raw';
+
+Skeleton provides a set of canned CSS animations, exposed as Tailwind `animate-*` utilities. Apply them with a single class — no custom keyframes required.
+
+<Preview files={{ 'app.astro': DefaultRaw }} client:visible>
+	<Default />
+</Preview>
+
+## Entry Animations
+
+Animate an element into view. Use these to reveal content when it mounts, or pair with a conditional render for list transitions.
+
+| Class                    | Description                                |
+| ------------------------ | ------------------------------------------ |
+| `animate-pop-in`         | Scales up from 80% with a subtle overshoot |
+| `animate-fade-in`        | Fades in from fully transparent            |
+| `animate-zoom-in`        | Scales up from 80% while fading in         |
+| `animate-slide-in-up`    | Slides up 12px while fading in             |
+| `animate-slide-in-down`  | Slides down 12px while fading in           |
+| `animate-slide-in-left`  | Slides left 12px while fading in           |
+| `animate-slide-in-right` | Slides right 12px while fading in          |
+
+## Attention Animations
+
+Draw attention to an element, or signal interaction feedback such as a validation error.
+
+| Class                | Description                                |
+| -------------------- | ------------------------------------------ |
+| `animate-shake`      | Shakes horizontally. Great for form errors |
+| `animate-wiggle`     | Gently rotates back and forth, looping     |
+| `animate-pulse-soft` | Softly fades opacity in and out, looping   |
+
+## Usage
+
+Entry animations use a `both` fill mode, so elements start at their initial keyframe state (hidden) before animating. Attention animations that loop run indefinitely.
+
+```html
+<div class="animate-pop-in">
+	<!-- content -->
+</div>
+```
+
+Entry animations run once on mount. To replay them, re-mount the element or re-trigger the animation:
+
+```html
+<div class="animate-shake motion-reduce:animate-none">
+	<!-- content -->
+</div>
+```
+
+Use the `motion-reduce` variant to disable animations for users who prefer reduced motion.
+
+## Customizing
+
+Canned animations are defined as theme variables, so you can override the duration, easing, or iteration count per project, or use them as a base for your own keyframes.
+
+```css
+@theme {
+	--animate-pop-in: skeleton-pop-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+```


### PR DESCRIPTION
## Summary

Adds a curated set of **canned CSS animations** to Skeleton, exposed as Tailwind `animate-*` utilities — no custom keyframes required. This addresses the feature request in #3214.

Covers the most common UI animation needs:

**Entry** — `animate-pop-in`, `animate-fade-in`, `animate-zoom-in`, `animate-slide-in-up/down/left/right`
**Attention** — `animate-shake` (form errors), `animate-wiggle`, `animate-pulse-soft`

## Implementation

- **`packages/skeleton/src/keyframes/animations.css`** — 10 original keyframes, prefixed `skeleton-` to avoid naming collisions with user keyframes.
- **`packages/skeleton/src/base/theme.css`** — new `--animate-*` theme tokens (Tailwind v4 `@theme`), so durations/easing can be overridden per project.
- **`packages/skeleton/src/index.css`** — imports the new keyframes.
- **Docs** — new "Animations" page under Tailwind Utilities with live examples.
- **Changeset** — minor bump for `@skeletonlabs/skeleton`.

## Verification

- Compiled `packages/skeleton/src/index.css` with Tailwind CSS v4.3.3: all 10 `animate-*` utilities generated, all 10 keyframes emitted.
- Verified in a real browser: each element's computed `animation-name`/`duration`/`iteration-count` resolves correctly (e.g. `skeleton-shake` 0.5s × 1, `skeleton-wiggle` 0.6s infinite); animations visibly run (pop/zoom overshoot, wiggle rotation, pulse fade).
- `prettier --check` passes on all changed files.

Entry animations use `both` fill mode (elements start hidden); docs show the `motion-reduce:animate-none` pattern for reduced-motion users.