### PR TITLE
docs: fix overflow

### DIFF
--- a/sites/skeleton.dev/src/components/typography/code.astro
+++ b/sites/skeleton.dev/src/components/typography/code.astro
@@ -4,9 +4,9 @@ import Code from '@/components/ui/code.svelte';
 ---
 
 {
-	Astro.props.className ? (
+	Astro.props.class ? (
 		<div class="mb-2">
-			<Code code={unescape(await Astro.slots.render('default'))} lang={Astro.props.className.split('-').pop()} client:visible />
+			<Code code={unescape(await Astro.slots.render('default'))} lang={Astro.props.class.split('-').pop()} client:visible />
 		</div>
 	) : (
 		<code class="code">

--- a/sites/skeleton.dev/src/content/docs/get-started/fundamentals.mdx
+++ b/sites/skeleton.dev/src/content/docs/get-started/fundamentals.mdx
@@ -289,6 +289,7 @@ Using the extensible markup pattern, you may implement custom animations. We sho
 Skeleton components maintain a uniform pattern for handling data flow in and out. We lean into the Zag convention for this, which handles this explicitly with a prop for data in and event handler for data out. As opposed to two-way binding (such as `bind:` in Svelte). You can see this in practice below for the Switch component.
 
 <Framework id="react">
+
 ```tsx
 import { Switch } from '@skeletonlabs/skeleton-react';
 import { useState } from 'react';
@@ -296,29 +297,30 @@ import { useState } from 'react';
 export default function Default() {
 	const [checked, setChecked] = useState(false);
 
-    return (
-    	<Switch checked={checked} onCheckedChange={(e) => setChecked(e.checked)}>
-    		<Switch.Control>
-    			<Switch.Thumb />
-    		</Switch.Control>
-    		<Switch.Label>Label</Switch.Label>
-    		<Switch.HiddenInput />
-    	</Switch>
-    );
-
+	return (
+		<Switch checked={checked} onCheckedChange={(e) => setChecked(e.checked)}>
+			<Switch.Control>
+				<Switch.Thumb />
+			</Switch.Control>
+			<Switch.Label>Label</Switch.Label>
+			<Switch.HiddenInput />
+		</Switch>
+	);
 }
+```
 
-````
 </Framework>
+
 <Framework id="svelte">
-{/* prettier-ignore */}
+
 ```svelte
 <script lang="ts">
 	import { Switch } from '@skeletonlabs/skeleton-svelte';
+
 	let checked = $state(false);
 </script>
 
-<Switch checked={checked} onCheckedChange={(e) => (checked = e.checked)}>
+<Switch {checked} onCheckedChange={(e) => (checked = e.checked)}>
 	<Switch.Control>
 		<Switch.Thumb />
 	</Switch.Control>
@@ -399,5 +401,3 @@ export default function TooltipExample() {
 ### Learn More
 
 For a comprehensive guide to how Skeleton implements components, refer to our [contribution guidelines](/docs/[framework]/resources/contribute/components).
-
-````


### PR DESCRIPTION
## Linked Issue(s)

Closes #4553 

## Description

Astro shipped a breaking change that renamed the `className` prop to `class` inside markdown components. Since we rely on that property being present or not the multineline codeblocks were treated as single line codeblocks.

## Checklist

Please read our [contribution requirements](https://skeleton.dev/docs/svelte/resources/contribute/) and make sure you have:

- [x] Prefixed your branch name with: `docs/`, `feature/`, `task/`, `bugfix/`
- [x] Targeted the `main` branch
- [x] Documented any changes made
- [x] Supplied a [changeset](#changesets) (if changes were made to any project within `/packages`)

## Changesets

[View our documentation](https://skeleton.dev/docs/svelte/resources/contribute/get-started#changesets) to learn more about [changesets](https://github.com/changesets/changesets). To create a changeset:

1. Navigate to the root of the monorepo in your terminal
2. Run `pnpm changeset` and follow the prompts
3. Commit and push the changeset before flagging your PR ready for review.
